### PR TITLE
Cleanly ensure all Interpretation.awkward_form signatures have been reverted.

### DIFF
--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -147,8 +147,7 @@ class AsContainer:
             file (:doc:`uproot.reading.CommonFileMethods`): The file associated
                 with this interpretation's ``TBranch``.
             context (dict): Context for the Form-generation; defaults are
-                ``{"index_format": "i64", "header": False, "tobject_header": True, "breadcrumbs": ()}``.
-                See below for context argument descriptions.
+                the remaining arguments below.
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.

--- a/src/uproot/interpretation/__init__.py
+++ b/src/uproot/interpretation/__init__.py
@@ -67,7 +67,15 @@ class Interpretation:
 
         return context
 
-    def awkward_form(self, file, context):
+    def awkward_form(
+        self,
+        file,
+        context=None,
+        index_format="i64",
+        header=False,
+        tobject_header=True,
+        breadcrumbs=(),
+    ):
         """
         Args:
             file (:doc:`uproot.reading.ReadOnlyFile`): File to use to generate
@@ -75,8 +83,7 @@ class Interpretation:
                 :ref:`uproot.reading.ReadOnlyFile.streamers` and ``file_path``
                 for error messages.
             context (dict): Context for the Form-generation; defaults are
-                ``{"index_format": "i64", "header": False, "tobject_header": True, "breadcrumbs": ()}``.
-                See below for context argument descriptions.
+                the remaining arguments below.
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.

--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -1188,7 +1188,15 @@ in object {}""".format(
     def numpy_dtype(self):
         raise self
 
-    def awkward_form(self, file, context):
+    def awkward_form(
+        self,
+        file,
+        context=None,
+        index_format="i64",
+        header=False,
+        tobject_header=True,
+        breadcrumbs=(),
+    ):
         raise self
 
     @property

--- a/src/uproot/interpretation/jagged.py
+++ b/src/uproot/interpretation/jagged.py
@@ -104,7 +104,18 @@ class AsJagged(uproot.interpretation.Interpretation):
     def numpy_dtype(self):
         return numpy.dtype(object)
 
-    def awkward_form(self, file, context):
+    def awkward_form(
+        self,
+        file,
+        context=None,
+        index_format="i64",
+        header=False,
+        tobject_header=True,
+        breadcrumbs=(),
+    ):
+        context = self._make_context(
+            context, index_format, header, tobject_header, breadcrumbs
+        )
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
             context["index_format"],

--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -552,17 +552,11 @@ class Awkward(Library):
             return awkward.Array(layout)
 
         elif isinstance(interpretation, uproot.interpretation.objects.AsObjects):
-            context = {
-                "index_format": "i64",
-                "header": False,
-                "tobject_header": True,
-                "breadcrumbs": (),
-            }
             try:
                 form = json.loads(
-                    interpretation.awkward_form(
-                        interpretation.branch.file, context
-                    ).tojson(verbose=True)
+                    interpretation.awkward_form(interpretation.branch.file).tojson(
+                        verbose=True
+                    )
                 )
             except uproot.interpretation.objects.CannotBeAwkward as err:
                 raise ValueError(

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -137,15 +137,7 @@ class AsObjects(uproot.interpretation.Interpretation):
 
         output = None
         if isinstance(library, uproot.interpretation.library.Awkward):
-            form = self.awkward_form(
-                branch.file,
-                {
-                    "index_format": "i64",
-                    "header": False,
-                    "tobject_header": True,
-                    "breadcrumbs": (),
-                },
-            )
+            form = self.awkward_form(branch.file)
 
             if awkward_can_optimize(self, form):
                 import awkward._connect._uproot

--- a/src/uproot/model.py
+++ b/src/uproot/model.py
@@ -643,8 +643,7 @@ class Model:
                 :ref:`uproot.reading.ReadOnlyFile.streamers` and ``file_path``
                 for error messages.
             context (dict): Context for the Form-generation; defaults are
-                ``{"index_format": "i64", "header": False, "tobject_header": True, "breadcrumbs": ()}``.
-                See below for context argument descriptions.
+                the remaining arguments below.
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.

--- a/src/uproot/version.py
+++ b/src/uproot/version.py
@@ -12,7 +12,7 @@ of the latest release on PyPI.
 
 import re
 
-__version__ = "4.3.1"
+__version__ = "4.3.2"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
AsJagged was missing.

Also, I made sure that the docstrings reflect the arguments as they are.

And we never create a dict and pass it in anymore; we let the default arguments do their work.

This will have to be cherry-picked and put onto `main` as well.