### PR TITLE
Iterate over objects in TDirectory in linear time.

### DIFF
--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -19,8 +19,6 @@ import uproot
 import uproot.behaviors.TBranch
 from uproot._util import no_filter
 
-debug_counter = [0]
-
 
 def open(
     path,


### PR DESCRIPTION
This was a dumb mistake, pointed out by Andrew Wightman (Notre Dame) with a file of 61944 histograms.

Since names are not unique identifiers for objects in TDirectories, the `uproot.TDirectory.__getitem__` was iterating through the list, looking for matches. If you do that _n_ times, the time complexity is _O(n²)_.

However, names are _almost_ unique identifiers for objects in TDirectories, so I added a `uproot.TDirectory._keys_lookup`, which is a hashmap from names to lists of matching indexes in `uproot.TDirectory._keys`. For a given name, the number of items to search through is much shorter, usually 1.

This reduces the time needed to read the 61944 from 206 seconds to 54 seconds. Most importantly, it's flat: both the first and the last 1000 histograms take 0.85 seconds, whereas before it was 0.85 seconds for the first 1000 histograms and 6.2 seconds for the last 1000 histograms. The time complexity to read _n_ histograms is _O(n)_.