### PR TITLE
Iterate over objects in TDirectory in linear time.

### DIFF
--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -1444,11 +1444,18 @@ class ReadOnlyDirectory(Mapping):
             )
 
             self._keys = []
+            self._keys_lookup = {}
             for _ in range(num_keys):
                 key = ReadOnlyKey(
                     keys_chunk, keys_cursor, {}, file, self, read_strings=True
                 )
+                name = key.fName
+                if name not in self._keys_lookup:
+                    self._keys_lookup[name] = []
+                self._keys_lookup[name].append(len(self._keys))
                 self._keys.append(key)
+
+            self._len = None
 
             self.hook_after_keys(
                 chunk=chunk,
@@ -1901,11 +1908,13 @@ class ReadOnlyDirectory(Mapping):
         return self.iterkeys()  # noqa: B301 (not a dict)
 
     def __len__(self):
-        return len(self._keys) + sum(
-            len(x.get())
-            for x in self._keys
-            if x.fClassName in ("TDirectory", "TDirectoryFile")
-        )
+        if self._len is None:
+            self._len = len(self._keys) + sum(
+                len(x.get())
+                for x in self._keys
+                if x.fClassName in ("TDirectory", "TDirectoryFile")
+            )
+        return self._len
 
     def __contains__(self, where):
         try:
@@ -2031,14 +2040,14 @@ class ReadOnlyDirectory(Mapping):
             item, cycle = where, None
 
         last = None
-        for key in self._keys:
-            if key.fName == item:
-                if cycle == key.fCycle:
-                    return key
-                elif cycle is None and last is None:
-                    last = key
-                elif cycle is None and last.fCycle < key.fCycle:
-                    last = key
+        for index in self._keys_lookup.get(item, []):
+            key = self._keys[index]
+            if cycle == key.fCycle:
+                return key
+            elif cycle is None and last is None:
+                last = key
+            elif cycle is None and last.fCycle < key.fCycle:
+                last = key
 
         if last is not None:
             return last


### PR DESCRIPTION
Copying PR #638 from `main` to `main-v4`.

* Iterate over objects in TDirectory in linear time.

* Remove the debug_counter.

(cherry picked from commit 809cf8ec7923b490525fb977f7427348308ea05e)