### PR TITLE
Set ReadOnlyDirectory attributes when fSeekKeys == 0

### DIFF
--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -1406,7 +1406,7 @@ class ReadOnlyDirectory(Mapping):
             self._header_key = None
             self._keys = []
             self._keys_lookup = {}
-            self._len = None 
+            self._len = None
         else:
             keys_start = self._fSeekKeys
             keys_stop = min(keys_start + self._fNbytesKeys + 8, file.fEND)

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -1405,7 +1405,8 @@ class ReadOnlyDirectory(Mapping):
         if self._fSeekKeys == 0:
             self._header_key = None
             self._keys = []
-
+            self._keys_lookup = {}
+            self._len = None 
         else:
             keys_start = self._fSeekKeys
             keys_stop = min(keys_start + self._fNbytesKeys + 8, file.fEND)


### PR DESCRIPTION
As titled. Fixes #658. 