### PR TITLE
pathlib.Path drops '//' (naturally), but it's sometimes used for URLs

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -246,21 +246,24 @@ def regularize_rename(rename):
     )
 
 
+_fix_url_path = re.compile(r"^((file|https?|root):/)([^/])", re.I)
+
+
 def regularize_path(path):
     """
     Converts pathlib Paths into plain string paths (for all versions of Python).
     """
     if isinstance(path, getattr(os, "PathLike", ())):
-        path = os.fspath(path)
+        path = _fix_url_path.sub(r"\1/\3", os.fspath(path))
 
     elif hasattr(path, "__fspath__"):
-        path = path.__fspath__()
+        path = _fix_url_path.sub(r"\1/\3", path.__fspath__())
 
     elif path.__class__.__module__ == "pathlib":
         import pathlib
 
         if isinstance(path, pathlib.Path):
-            path = str(path)
+            path = _fix_url_path.sub(r"\1/\3", str(path))
 
     return path
 


### PR DESCRIPTION
So if a path from `pathlib.Path` _starts with_ "http:/" and _no second slash_ (also for "file", "https", "root" URL schemes, case insensitive), then a second slash will be added.

`pathlib.Path` is our recommended way of saying, "This really is a path, even though it has a colon in it," but we didn't foresee this issue with _URLs_ with colons in them.

There's another way of doing it with `{filename: None}` instead of `pathlib.Path(filename)`, which doesn't suffer from this, but enough people are probably doing the `pathlib.Path` thing that we need this small correction.