### PR TITLE
Gets the number of overflow bins for hist.axis.IntCategory, at least.

### DIFF
--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -264,11 +264,10 @@ def to_writable(obj):
             fSumw2 = obj.variances(flow=True)
 
             # and flow=True is different from flow=False (obj actually has flow bins)
-            if (
-                data.shape == obj.values(flow=False).shape
-                and fSumw2.shape == obj.variances(flow=True).shape
-            ):
-                raise TypeError
+            data_noflow = obj.values(flow=False)
+            for flow, noflow in zip(data.shape, data_noflow.shape):
+                if flow != noflow + 2:
+                    raise TypeError
 
         except TypeError:
             # flow=True is not supported, fallback to allocate-and-fill


### PR DESCRIPTION
Doesn't fully support categorical axis round-trip from hist through TH*, but at least it gets the number of overflow bins right (fixing #659).