### PR TITLE
Prevent std::pair from being AsStridedObjects.

### DIFF
--- a/src/uproot/streamers.py
+++ b/src/uproot/streamers.py
@@ -312,6 +312,13 @@ class Model_TStreamerInfo(uproot.model.Model):
             f"    class_flags = {{{', '.join(repr(k) + ': ' + repr(v) for k, v in class_flags.items())}}}"
         )
 
+        # std::pair cannot be strided
+        if self.name.startswith("pair<"):
+            strided_interpretation = strided_interpretation[:2]
+            strided_interpretation.append(
+                "        raise uproot.interpretation.objects.CannotBeStrided('std::pair')"
+            )
+
         classname = uproot.model.classname_encode(self.name, self.class_version)
         return "\n".join(
             [f"class {classname}(uproot.model.VersionedModel):"]

--- a/tests/test_0643-reading-vector-pair-TLorentzVector-int.py
+++ b/tests/test_0643-reading-vector-pair-TLorentzVector-int.py
@@ -1,0 +1,27 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+def test_numpy():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-643.root"))[
+        "ntuple0/objects"
+    ] as t:
+        array = t["pf"].array(entry_stop=2, library="np")
+        assert array[1][1].member("first").member("fE") == 326.0029230449897
+        assert array[1][1].member("second") == 22
+
+
+awkward = pytest.importorskip("awkward")
+
+
+def test_awkward():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-643.root"))[
+        "ntuple0/objects"
+    ] as t:
+        array = t["pf"].array(entry_stop=2, library="ak")
+        assert array[1, 1, "first", "fE"] == 326.0029230449897
+        assert array[1, 1, "second"] == 22


### PR DESCRIPTION
@aryan26roy, does this one get read properly through AwkwardForth, when this commit is ported to your branch?