### PR TITLE
AsDynamic has no self._header.

### DIFF
--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -290,7 +290,7 @@ class AsDynamic(AsContainer):
             return awkward._v2.forms.ListOffsetForm(
                 context["index_format"],
                 uproot._util.awkward_form(self._model, file, context),
-                parameters={"uproot": {"as": "array", "header": self._header}},
+                parameters={"uproot": {"as": "dynamic"}},
             )
 
     def read(self, chunk, cursor, context, file, selffile, parent, header=True):


### PR DESCRIPTION
This fixes the direct error that #607 saw, though this data type is likely too complex to solve all of its issues. I see an infinite loop:

```
uproot.deserialization.DeserializationError: while reading

    MGTEvent version 9 as uproot.dynamic.Model_MGTEvent_v9 (6286 bytes)
        (base): <MGTDataObject (version 2) at 0x7f8c73766fa0>
        (base): <MGVMemoryCheckable (version 1) at 0x7f8c73766b50>
        fEventType: 16469
        fETotal: -1.82467463945584e-05
        fTime: 3.6780645929512914e+267
        fWaveforms: None
        fDigitizerData: None
        MGTEvent version 9 as uproot.dynamic.Model_MGTEvent_v9 (24441 bytes)
            (base): <MGTDataObject (version 2) at 0x7f8c7371a160>
            (base): <MGVMemoryCheckable (version 1) at 0x7f8c7371a1c0>
            fEventType: 16608
            fETotal: 1.0222966365301011e-196
            fTime: 3.7243961167525673e+267
            MGTEvent version 9 as uproot.dynamic.Model_MGTEvent_v9 (6868 bytes)
                (base): <MGTDataObject (version 2) at 0x7f8c7371ae50>
                (base): <MGVMemoryCheckable (version 1) at 0x7f8c7371adc0>
                fEventType: 16611
                fETotal: 1.1499381031852565e+253
                fTime: 3.7309778849244594e+267
                fWaveforms: None
                fDigitizerData: None
                MGTEvent version 9 as uproot.dynamic.Model_MGTEvent_v9 (6117 bytes)
                    (base): <MGTDataObject (version 2) at 0x7f8c7371a910>
                    (base): <MGVMemoryCheckable (version 1) at 0x7f8c7371a8b0>
                    fEventType: 16555
                    fETotal: -8.034678566710207e+212
                    fTime: 3.7882262938416495e+267
                    fWaveforms: None
                    fDigitizerData: None
                    MGTEvent version 9 as uproot.dynamic.Model_MGTEvent_v9 (6286 bytes)
                        (base): <MGTDataObject (version 2) at 0x7f8c73713ca0>
                        (base): <MGVMemoryCheckable (version 1) at 0x7f8c737139d0>
                        fEventType: 16469
                        fETotal: -1.82467463945584e-05
                        fTime: 3.6780645929512914e+267
                        fWaveforms: None
                        fDigitizerData: None
                        MGTEvent version 9 as uproot.dynamic.Model_MGTEvent_v9 (24441 bytes)
                            (base): <MGTDataObject (version 2) at 0x7f8c73712ca0>
                            (base): <MGVMemoryCheckable (version 1) at 0x7f8c73712c40>
                            fEventType: 16608
                            fETotal: 1.0222966365301011e-196
                            fTime: 3.7243961167525673e+267
                            MGTEvent version 9 as uproot.dynamic.Model_MGTEvent_v9 (6868 bytes)
                                (base): <MGTDataObject (version 2) at 0x7f8c73712550>
                                (base): <MGVMemoryCheckable (version 1) at 0x7f8c737125b0>
                                fEventType: 16611
                                fETotal: 1.1499381031852565e+253
                                fTime: 3.7309778849244594e+267
                                fWaveforms: None
                                fDigitizerData: None
                                MGTEvent version 9 as uproot.dynamic.Model_MGTEvent_v9 (6117 bytes)
                                    (base): <MGTDataObject (version 2) at 0x7f8c737122b0>
                                    (base): <MGVMemoryCheckable (version 1) at 0x7f8c73712250>
                                    fEventType: 16555
                                    fETotal: -8.034678566710207e+212
                                    fTime: 3.7882262938416495e+267
                                    fWaveforms: None
                                    fDigitizerData: None
Base classes for MGTEvent: (MGTDataObject), (MGVMemoryCheckable)
Members for MGTEvent: (fEventType), (fETotal), (fTime), (fWaveforms), (fDigitizerData), fActiveID, fUseAuxWaveformArray, fAuxWaveforms, fEventNumber

attempting to get bytes 3221179793:3221179799
outside expected range 0:6296 for this Chunk
in file gerda-run0050-20150826T170402Z-cal-ged-tier1.root
in object /MGTree;1
```

The `cursor` is not advancing forward, so it's trying to read the same class instance over and over again. Something evidently goes wrong before the first `fEventType` (that number is not a small `enum` value).