### PR TITLE
Multiple clusters support for RNTuple

### DIFF
--- a/src/uproot/const.py
+++ b/src/uproot/const.py
@@ -122,7 +122,7 @@ rntuple_col_num_to_dtype_dict = {
     3: "uint64",  # Switch
     4: "uint8",
     5: "uint8",  # char
-    6: "bool",
+    6: "bit",
     7: "float64",
     8: "float32",
     9: "float16",

--- a/src/uproot/const.py
+++ b/src/uproot/const.py
@@ -122,7 +122,7 @@ rntuple_col_num_to_dtype_dict = {
     3: "uint64",  # Switch
     4: "uint8",
     5: "uint8",  # char
-    6: "bit",
+    6: "bool",
     7: "float64",
     8: "float32",
     9: "float16",

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -304,7 +304,9 @@ in file {}""".format(
         )
 
     def read_col_pages(self, ncol, cluster_range):
-        return numpy.concatenate([self.read_col_page(ncol, i) for i in cluster_range], axis=0)
+        return numpy.concatenate(
+            [self.read_col_page(ncol, i) for i in cluster_range], axis=0
+        )
 
     def read_col_page(self, ncol, cluster_i):
         linklist = self.page_list_envelopes.pagelinklist[cluster_i]
@@ -349,11 +351,17 @@ in file {}""".format(
 
         clusters = self.cluster_summaries
         cluster_starts = numpy.array([c.num_first_entry for c in clusters])
-        cluster_stops = cluster_starts + numpy.array([c.num_entries for c in clusters]) - 1
+        cluster_stops = (
+            cluster_starts + numpy.array([c.num_entries for c in clusters]) - 1
+        )
 
-        start_cluster_idx = numpy.searchsorted(cluster_starts, entry_start, side="right") - 1
+        start_cluster_idx = (
+            numpy.searchsorted(cluster_starts, entry_start, side="right") - 1
+        )
         stop_cluster_idx = numpy.searchsorted(cluster_starts, entry_stop, side="right")
-        L = numpy.sum([c.num_entries for c in clusters[start_cluster_idx:stop_cluster_idx]])
+        L = numpy.sum(
+            [c.num_entries for c in clusters[start_cluster_idx:stop_cluster_idx]]
+        )
 
         form = self.to_akform().select_columns(filter_names)
         # only read columns mentioned in the awkward form
@@ -364,7 +372,9 @@ in file {}""".format(
             key = f"column-{i}"
             dtype_byte = cr.type
             if key in target_cols:
-                content = self.read_col_pages(i, range(start_cluster_idx, stop_cluster_idx))
+                content = self.read_col_pages(
+                    i, range(start_cluster_idx, stop_cluster_idx)
+                )
                 if dtype_byte == uproot.const.rntuple_col_type_to_num_dict["switch"]:
                     kindex, tags = _split_switch_bits(content)
                     D[f"{key}-index"] = kindex

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -361,9 +361,6 @@ in file {}""".format(
 
         clusters = self.cluster_summaries
         cluster_starts = numpy.array([c.num_first_entry for c in clusters])
-        cluster_stops = (
-            cluster_starts + numpy.array([c.num_entries for c in clusters]) - 1
-        )
 
         start_cluster_idx = (
             numpy.searchsorted(cluster_starts, entry_start, side="right") - 1

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -305,7 +305,9 @@ in file {}""".format(
             decomp_chunk, num_elements_toread, dtype, context, move=False
         )
         if len_divider != 1:
-            content = numpy.unpackbits(content.view(dtype=numpy.uint8), bitorder="little")
+            content = numpy.unpackbits(
+                content.view(dtype=numpy.uint8), bitorder="little"
+            )
         assert len(destination) == num_elements
         destination[:] = content[:num_elements]
 
@@ -337,7 +339,9 @@ in file {}""".format(
         for page_desc in pagelist:
             n_elements = page_desc.num_elements
             tracker_end = tracker + n_elements
-            self.read_pagedesc(res[tracker:tracker_end], page_desc, n_elements, T, len_divider)
+            self.read_pagedesc(
+                res[tracker:tracker_end], page_desc, n_elements, T, len_divider
+            )
             tracker = tracker_end
 
         if dtype_byte <= uproot.const.rntuple_col_type_to_num_dict["index32"]:

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -308,9 +308,11 @@ in file {}""".format(
             decomp_chunk, num_elements_toread, dtype, context, move=False
         )
         if isbit:
-            content = numpy.unpackbits(
-                    content.view(dtype=numpy.uint8)
-                    ).reshape(-1, 8)[:, ::-1].reshape(-1)
+            content = (
+                numpy.unpackbits(content.view(dtype=numpy.uint8))
+                .reshape(-1, 8)[:, ::-1]
+                .reshape(-1)
+            )
 
         # needed to chop off extra bits incase we used `unpackbits`
         destination[:] = content[:num_elements]
@@ -393,7 +395,9 @@ in file {}""".format(
         cluster_offset = cluster_starts[start_cluster_idx]
         entry_start -= cluster_offset
         entry_stop -= cluster_offset
-        return ak._v2.from_buffers(form, cluster_num_entries, container_dict)[entry_start:entry_stop]
+        return ak._v2.from_buffers(form, cluster_num_entries, container_dict)[
+            entry_start:entry_stop
+        ]
 
 
 # Supporting function and classes
@@ -412,6 +416,7 @@ def _recursive_find(form, res):
     if hasattr(form, "content"):
         if issubclass(type(form.content), ak._v2.forms.Form):
             _recursive_find(form.content, res)
+
 
 # https://github.com/jblomer/root/blob/ntuple-binary-format-v1/tree/ntuple/v7/doc/specifications.md#page-list-envelope
 class PageDescription:

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -340,8 +340,7 @@ in file {}""".format(
         for page_desc in pagelist:
             n_elements = page_desc.num_elements
             tracker_end = tracker + n_elements
-            self.read_pagedesc(
-                res[tracker:tracker_end], page_desc, n_elements, T)
+            self.read_pagedesc(res[tracker:tracker_end], page_desc, n_elements, T)
             tracker = tracker_end
 
         if dtype_byte <= uproot.const.rntuple_col_type_to_num_dict["index32"]:

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -362,8 +362,9 @@ in file {}""".format(
                     # don't distinguish data and offsets
                     D[f"{key}-data"] = content
                     D[f"{key}-offsets"] = content
-        entry_start -= cluster_starts[start_cluster_idx]
-        entry_stop -= cluster_stops[stop_cluster_idx]
+        cluster_offset = cluster_starts[start_cluster_idx]
+        entry_start -= cluster_offset
+        entry_stop -= cluster_offset - 1
         return ak._v2.from_buffers(form, L, Container(D))[entry_start:entry_stop]
 
 


### PR DESCRIPTION
```python
akako@archlinux ~/D/g/uproot4 (RNTuple)> python -c 'from pprint import pprint; import uproot as up; import 
skhep_testdata; filename = skhep_testdata.data_path("test_ntuple_large_bit_int64.root"); r = up.open(filena
me)["ntuple"]; pprint(r.arrays(entry_start=1, entry_stop=2).to_list())'
[{'one_bit': True, 'two_int64': 1}]

akako@archlinux ~/D/g/uproot4 (RNTuple)> python -c 'from pprint import pprint; import uproot as up; import 
skhep_testdata; filename = skhep_testdata.data_path("test_ntuple_large_bit_int64.root"); r = up.open(filena
me)["ntuple"]; pprint(r.arrays(entry_start=11111112, entry_stop=11111113).to_list())'
[{'one_bit': True, 'two_int64': 11111112},
 {'one_bit': True, 'two_int64': 11111113}]
```

the `one_bit` field is not being read out correctly because it's actually bit not byte encoded in the serialization