### PR TITLE
fix: depend on packaging, not setuptools vendored packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ packages = find:
 install_requires =
     awkward>=1.9.0rc1
     numpy
-    setuptools
+    packaging
 python_requires = >=3.6
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     awkward>=1.9.0rc1
     numpy
     packaging
+    importlib-metadata;python_version<"3.8"
 python_requires = >=3.6
 package_dir =
     =src

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable
 from urllib.parse import unquote, urlparse
 
 import numpy
-import packaging
+import packaging.version
 
 win = platform.system().lower().startswith("win")
 

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable
 from urllib.parse import unquote, urlparse
 
 import numpy
-import setuptools
+import packaging
 
 win = platform.system().lower().startswith("win")
 
@@ -93,10 +93,10 @@ def parse_version(version):
     Converts a semver string into a Version object that can be compared with
     ``<``, ``>=``, etc.
 
-    Currently implemented using ``setuptools.extern.packaging.version.parse``
+    Currently implemented using ``packaging.Version``
     (exposing that library in the return type).
     """
-    return setuptools.extern.packaging.version.parse(version)
+    return packaging.version.parse(version)
 
 
 def from_module(obj, module_name):

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -11,10 +11,14 @@ error messages containing instructions on how to install the library.
 
 import atexit
 import os
-
-import pkg_resources
+import sys
 
 from uproot._util import parse_version
+
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
 
 
 def awkward():
@@ -132,14 +136,13 @@ def xrootd_version():
     Gets the XRootD version if installed, otherwise returns None.
     """
     try:
-        version = pkg_resources.get_distribution("XRootD").version
-    except pkg_resources.DistributionNotFound:
+        return importlib_metadata.version("xrootd")
+    except ModuleNotFoundError:
         try:
             # Versions before 4.11.1 used pyxrootd as the package name
-            version = pkg_resources.get_distribution("pyxrootd").version
-        except pkg_resources.DistributionNotFound:
-            version = None
-    return version
+            return importlib_metadata.version("pyxrootd")
+        except ModuleNotFoundError:
+            return None
 
 
 def lzma():


### PR DESCRIPTION
This should not be pulled from setuptools vendoring, it's a standalone package. And `importlib.metadata.version` is the correct way to get the version (or from the backport `importlib_metadata`).