### PR TITLE
ci: autocancel repeated runs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,10 +1,14 @@
 name: "Test build"
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
Saves some time for repeated pushes (including pre-commit fixes). Also allows Actions to run on a branch-to-branch PR, or manually.
