### PR TITLE
ci: use concurrency group for `semantic-pr-title`

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: semantic-pr-title-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -8,6 +8,10 @@ on:
       - synchronize
   workflow_dispatch:
 
+concurrency:
+  group: semantic-pr-title-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
The semantic-pr-title workflow does not currently run in a concurrency group. This means that subsequent pushes do not cancel in-progress actions. The following PR fixes this.