### PR TITLE
fix: Avoid triggering temporary dask-awkward/awkward incompatibility.

### DIFF
--- a/tests/test_0652_dask-for-awkward.py
+++ b/tests/test_0652_dask-for-awkward.py
@@ -18,7 +18,6 @@ def test_single_dask_awkward_array():
     ak_array = ttree.arrays()
     dak_array = uproot.dask(test_path, library="ak")
 
-    assert len(ak_array) == len(dak_array)
     assert_eq(dak_array, ak_array)
 
 
@@ -33,7 +32,6 @@ def test_dask_concatenation():
         [test_path1, test_path2, test_path3, test_path4], library="ak"
     )
 
-    assert len(ak_array) == len(dak_array)
     assert_eq(dak_array, ak_array, check_unconcat_form=False)
 
 
@@ -89,5 +87,4 @@ def test_delay_open():
         [test_path1, test_path2, test_path3, test_path4], open_files=False, library="ak"
     )
 
-    assert len(ak_array) == len(dak_array)
     assert_eq(dak_array, ak_array, check_unconcat_form=False)


### PR DESCRIPTION
dask-awkward assumes that `ak.Array((1, 2, 3))` makes an `ak.Array`, the same as `ak.Array([1, 2, 3])`, which is a sensible assumption.

https://github.com/scikit-hep/awkward/pull/1614 accidentally changed that, and while one accidental consequence was for the better (`ak.from_iter({"one": 1, "two": 2, "three": 3})` no longer returns `ak.Array(["one", "two", "three"])`), it's reasonable to suppose that a _top-level_ tuple is intended to become an `ak.Array`, especially if passed to the `ak.Array` constructor.

https://github.com/scikit-hep/awkward/pull/1642 fixes it (best of both worlds), but Uproot tests would fail until this comes through. Therefore, this fix removes the tests that trigger the incompatibility. It should be merged into any Uproot PRs that are failing because of it.

Removing the `len` tests doesn't decrease the power of the test: `assert_eq` would not be satisfied if the lengths were different. However, it does reduce coverage of the dask-awkward `__len__` code.