### PR TITLE
fix: Use `from_map` optimization for delayed numpy arrays and add tests with empty branches for the same

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -327,6 +327,25 @@ class _UprootReadNumpy:
         )
 
 
+class _UprootOpenAndReadNumpy:
+    def __init__(self, custom_classes, allow_missing, real_options, key):
+        self.custom_classes = custom_classes
+        self.allow_missing = allow_missing
+        self.real_options = real_options
+        self.key = key
+
+    def __call__(self, file_path_object_path):
+        file_path, object_path = file_path_object_path
+        ttree = uproot._util.regularize_object_path(
+            file_path,
+            object_path,
+            self.custom_classes,
+            self.allow_missing,
+            self.real_options,
+        )
+        return ttree[self.key].array(library="np")
+
+
 def _get_dask_array(
     files,
     filter_name=no_filter,
@@ -466,8 +485,6 @@ def _get_dask_array_delay_open(
     allow_missing=False,
     real_options=None,
 ):
-    dask = uproot.extras.dask()
-    da = uproot.extras.dask_array()
     ffile_path, fobject_path = files[0]
     obj = uproot._util.regularize_object_path(
         ffile_path, fobject_path, custom_classes, allow_missing, real_options
@@ -481,27 +498,21 @@ def _get_dask_array_delay_open(
     )
 
     dask_dict = {}
-    delayed_open_fn = dask.delayed(uproot._util.regularize_object_path)
-
-    @dask.delayed
-    def delayed_get_array(ttree, key):
-        return ttree[key].array(library="np")
 
     for key in common_keys:
-        dask_arrays = []
-        for file_path, object_path in files:
-            delayed_tree = delayed_open_fn(
-                file_path, object_path, custom_classes, allow_missing, real_options
-            )
-            delayed_array = delayed_get_array(delayed_tree, key)
-            dt = obj[key].interpretation.numpy_dtype
-            if dt.subdtype is not None:
-                dt, inner_shape = dt.subdtype
+        dt = obj[key].interpretation.numpy_dtype
+        if dt.subdtype is None:
+            inner_shape = ()
+        else:
+            dt, inner_shape = dt.subdtype
 
-            dask_arrays.append(
-                da.from_delayed(delayed_array, shape=(numpy.nan,), dtype=dt)
-            )
-        dask_dict[key] = da.concatenate(dask_arrays, allow_unknown_chunksizes=True)
+        dask_dict[key] = _dask_array_from_map(
+            _UprootOpenAndReadNumpy(custom_classes, allow_missing, real_options, key),
+            files,
+            chunks=((numpy.nan,) * len(files),),
+            dtype=dt,
+            label=f"{key}-from-uproot",
+        )
     return dask_dict
 
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -690,13 +690,8 @@ def _get_dak_array_delay_open(
         full_paths=full_paths,
     )
 
-    first_basket_start, first_basket_stop = obj[common_keys[0]].basket_entry_start_stop(
-        0
-    )
-    first_basket = obj.arrays(
-        common_keys, entry_start=first_basket_start, entry_stop=first_basket_stop
-    )
-    meta = dask_awkward.core.typetracer_array(first_basket)
+    empty_arr = obj.arrays(common_keys, entry_start=0, entry_stop=0)
+    meta = dask_awkward.core.typetracer_array(empty_arr)
 
     return dask_awkward.from_map(
         _UprootOpenAndRead(custom_classes, allow_missing, real_options, common_keys),

--- a/tests/test_0700-dask-empty-arrays.py
+++ b/tests/test_0700-dask-empty-arrays.py
@@ -27,12 +27,38 @@ def test_dask_numpy_empty_arrays():
         assert comp.all(), f"Incorrect array at key {key}"
 
 
+def test_dask_delayed_open_numpy():
+    test_path = skhep_testdata.data_path("uproot-issue-697.root") + ":tree"
+    ttree = uproot.open(test_path)
+
+    np_arrays = ttree.arrays(library="np")
+    dask_arrays = uproot.dask(test_path, library="np", open_files=False)
+
+    assert list(dask_arrays.keys()) == list(
+        np_arrays.keys()
+    ), "Different keys detected in dictionary of dask arrays and dictionary of numpy arrays"
+
+    for key in np_arrays.keys():
+        comp = dask_arrays[key].compute() == np_arrays[key]
+        assert comp.all(), f"Incorrect array at key {key}"
+
+
 def test_dask_awkward_empty_arrays():
     test_path = skhep_testdata.data_path("uproot-issue-697.root") + ":tree"
     ttree = uproot.open(test_path)
 
     ak_array = ttree.arrays()
     dak_array = uproot.dask(test_path, library="ak")
+
+    assert_eq(dak_array, ak_array)
+
+
+def test_dask_delayed_open_awkward():
+    test_path = skhep_testdata.data_path("uproot-issue-697.root") + ":tree"
+    ttree = uproot.open(test_path)
+
+    ak_array = ttree.arrays()
+    dak_array = uproot.dask(test_path, library="ak", open_files=False)
 
     assert_eq(dak_array, ak_array)
 


### PR DESCRIPTION
This PR tackles 2 very similar things together:
1. `from_map` optimisation for dask-numpy arrays with `open_files=False`.
2. Tests for empty arrays with delayed open for dask-numpy and dask-awkward. I added this because the chunking mechanism for delayed-file-open calls is handled differently and might not match the behaviour discussed in #697. These tests increase coverage and assure us the chunks are as expected.

This is PR is ready for review @jpivarski 