### PR TITLE
fix: use ctx manager to ensure resources are freed

### DIFF
--- a/src/uproot/models/TTree.py
+++ b/src/uproot/models/TTree.py
@@ -968,6 +968,7 @@ def num_entries(paths):
         paths = [uproot._util.file_object_path_split(paths)]
 
     for i, (file_path, object_path) in enumerate(paths2):
-        yield paths[i][0], paths[i][1], uproot.open(
+        with uproot.open(
             {file_path: object_path}, custom_classes={"TTree": Model_TTree_NumEntries}
-        ).all_members["fEntries"][0]
+        ) as f:
+            yield paths[i][0], paths[i][1], f.all_members["fEntries"][0]


### PR DESCRIPTION
Long term I think we should be dealing with a per-process pool rather than a per-source pool, but that's a bigger task.

Fixes #712 

@alexander-held would you be able to check that this works in your context w/o any changes to `HTTPSource.__del__`?