### PR TITLE
test: adjust for boost-histogram 1.3.2's _storage_type deprecation.

### DIFF
--- a/tests/test_0350-read-RooCurve-RooHist.py
+++ b/tests/test_0350-read-RooCurve-RooHist.py
@@ -107,10 +107,17 @@ def test_to_boost(roohist, roocurve, roocurve_err):
 
     rc_boost = roocurve.to_boost(rh_boost.axes[0].edges)
     assert (rc_boost.axes[0].edges == rh_boost.axes[0].edges).all()
-    assert rc_boost.storage_type == boost_histogram.storage.Double
+    if hasattr(rc_boost, "storage_type"):
+        assert rc_boost.storage_type == boost_histogram.storage.Double
+    else:
+        assert rc_boost._storage_type == boost_histogram.storage.Double
+
     rc_boost = roocurve.to_boost(rh_boost.axes[0].edges, error_curve=roocurve_err)
     assert (rc_boost.axes[0].edges == rh_boost.axes[0].edges).all()
-    assert rc_boost.storage_type == boost_histogram.storage.Weight
+    if hasattr(rc_boost, "storage_type"):
+        assert rc_boost.storage_type == boost_histogram.storage.Weight
+    else:
+        assert rc_boost._storage_type == boost_histogram.storage.Weight
 
 
 def test_interpolate(roocurve, roocurve_err):

--- a/tests/test_0350-read-RooCurve-RooHist.py
+++ b/tests/test_0350-read-RooCurve-RooHist.py
@@ -107,10 +107,10 @@ def test_to_boost(roohist, roocurve, roocurve_err):
 
     rc_boost = roocurve.to_boost(rh_boost.axes[0].edges)
     assert (rc_boost.axes[0].edges == rh_boost.axes[0].edges).all()
-    assert rc_boost._storage_type == boost_histogram.storage.Double
+    assert rc_boost.storage_type == boost_histogram.storage.Double
     rc_boost = roocurve.to_boost(rh_boost.axes[0].edges, error_curve=roocurve_err)
     assert (rc_boost.axes[0].edges == rh_boost.axes[0].edges).all()
-    assert rc_boost._storage_type == boost_histogram.storage.Weight
+    assert rc_boost.storage_type == boost_histogram.storage.Weight
 
 
 def test_interpolate(roocurve, roocurve_err):


### PR DESCRIPTION
This is needed for all PRs targeting `main`.

It should be fast-tracked into `main` so that it can be used in all those PRs.