### PR TITLE
fix: ReadOnlyDirectory should provide the largest abs(cycle) when cycle is unspecified, not the largest cycle (v4).

### DIFF
--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -2047,7 +2047,7 @@ class ReadOnlyDirectory(Mapping):
                 return key
             elif cycle is None and last is None:
                 last = key
-            elif cycle is None and last.fCycle < key.fCycle:
+            elif cycle is None and abs(last.fCycle) < abs(key.fCycle):
                 last = key
 
         if last is not None:

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -2047,6 +2047,7 @@ class ReadOnlyDirectory(Mapping):
                 return key
             elif cycle is None and last is None:
                 last = key
+            # Follow ROOT's behaviour in comparing negative fCycle values
             elif cycle is None and abs(last.fCycle) < abs(key.fCycle):
                 last = key
 


### PR DESCRIPTION
This is the "v4" version of #715.

Like the other in-flight PRs, it will follow this procedure:

  1. #720 gets approved and merged into `main-v4`.
  2. This PR updates to `main-v4`.
  3. The tests re-run and pass (again).
  4. This PR gets approved and merged into `main-v4`.