### PR TITLE
feat: (POC) Add column projection for reading to dask_awkward

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -527,6 +527,9 @@ class _UprootRead:
             self.branches, entry_start=start, entry_stop=stop
         )
 
+    def project_columns(self, columns):
+        return _UprootRead(self.hasbranches, columns)
+
 
 class _UprootOpenAndRead:
     def __init__(


### PR DESCRIPTION
This PR shows how to add column projection to `uproot.dask` when `library="ak"`. For this to work properly right now it would require the changes that are in ContinuumIO/dask-awkward#80 (still WIP). I've made this draft PR just to share the planned interface for making I/O column-project-able. Since `uproot.dask(..., library="ak")` already uses `dask_awkward.from_map(fn: Callable, ...)`, all `fn` needs is a `project_columns` method.