### PR TITLE
ci: remove GHA workaround for macOS Python 3.11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["windows-latest", "ubuntu-latest"]
+        platform: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.11-dev"]
 
     runs-on: "${{ matrix.platform }}"

--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -11,8 +11,6 @@ import pytest
 
 import uproot
 
-macos_py311 = platform.system() == "Darwin" and sys.version_info >= (3, 11)
-
 
 def tobytes(x):
     if hasattr(x, "tobytes"):
@@ -158,7 +156,6 @@ def test_http_port():
         assert [tobytes(x.raw_data) for x in chunks] == [one, two, three]
 
 
-@pytest.mark.skipif(macos_py311, reason="Python 3.11 MacOS SSL bug")
 @pytest.mark.network
 def test_http_size():
     with uproot.source.http.HTTPSource(
@@ -176,7 +173,6 @@ def test_http_size():
     assert size1 == size2
 
 
-@pytest.mark.skipif(macos_py311, reason="Python 3.11 MacOS SSL bug")
 @pytest.mark.network
 def test_http_size_port():
     with uproot.source.http.HTTPSource(
@@ -207,7 +203,6 @@ def test_http_fail():
         chunks[0].raw_data
 
 
-@pytest.mark.skipif(macos_py311, reason="Python 3.11 MacOS SSL bug")
 @pytest.mark.network
 def test_no_multipart():
     for num_workers in [1, 2]:
@@ -237,7 +232,6 @@ def test_no_multipart_fail():
             chunks[0].raw_data
 
 
-@pytest.mark.skipif(macos_py311, reason="Python 3.11 MacOS SSL bug")
 @pytest.mark.network
 def test_fallback():
     for num_workers in [1, 2]:


### PR DESCRIPTION
Added in #742, was tracking https://github.com/actions/python-versions/pull/189, and fixed in https://github.com/actions/setup-python/issues/512.