### PR TITLE
chore: some cleanup inpsired by refurb

### DIFF
--- a/src/uproot/_awkward_forth.py
+++ b/src/uproot/_awkward_forth.py
@@ -53,7 +53,6 @@ class ForthGenerator:
         self.form_keys = []
         self.var_set = var_set
         self.count_obj = count_obj
-        return
 
     def traverse_aform(self):
         self.aform = self.aform.content
@@ -316,21 +315,17 @@ class ForthGenerator:
             self.forth_code[ref] = {}
         self.forth_code[ref][str(ref) + "pre"] = forth_exec_pre
         self.forth_code[ref][str(ref) + "post"] = forth_exec_post
-        return
 
     def add_to_final(self, code):
         if not isinstance(code, list):
             raise TypeError
         self.final_code.extend(code)
-        return
 
     def add_to_header(self, code):
         self.final_header.append(code)
-        return
 
     def add_to_init(self, code):
         self.final_init.append(code)
-        return
 
 
 class GenHelper:

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -106,7 +106,7 @@ def dask(
     if library.name == "pd":
         raise NotImplementedError()
 
-    real_options = dict(options)
+    real_options = options.copy()
     if "num_workers" not in real_options:
         real_options["num_workers"] = 1
     if "num_fallback_workers" not in real_options:

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -376,7 +376,7 @@ def file_path_to_source_class(file_path, options):
             )
         return out, file_path
 
-    elif parsed_url.scheme.upper() == "HTTP" or parsed_url.scheme.upper() == "HTTPS":
+    elif parsed_url.scheme.upper() in {"HTTP", "HTTPS"}:
         out = options["http_handler"]
         if not (isinstance(out, type) and issubclass(out, uproot.source.chunk.Source)):
             raise TypeError(

--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -154,7 +154,7 @@ def _str_with_ellipsis(tostring, length, lbracket, rbracket, limit):
         return lbracket + rbracket
     elif done:
         return lbracket + "".join(left) + "".join(right) + rbracket
-    elif len(left) == 0 and len(right) == 0:
+    elif len(left) == len(right) == 0:
         return lbracket + f"{tostring(0)}, ..." + rbracket
     elif len(right) == 0:
         return lbracket + "".join(left) + "..." + rbracket

--- a/src/uproot/deserialization.py
+++ b/src/uproot/deserialization.py
@@ -53,7 +53,7 @@ def compile_class(file, classes, class_code, class_name):
 
     Compile a new class from Python code and insert it in the dict of classes.
     """
-    new_scope = dict(scope)
+    new_scope = scope.copy()
     for cls in classes.values():
         new_scope[cls.__name__] = cls
 

--- a/src/uproot/exceptions.py
+++ b/src/uproot/exceptions.py
@@ -78,14 +78,7 @@ class KeyInFileError(KeyError):
             in_object = f"\nin object {self.object_path}"
 
         if self.cycle == "any":
-            return """not found: {} (with any cycle number){}{}{}{}""".format(
-                repr(self.key), because, with_keys, in_file, in_object
-            )
-        elif self.cycle is None:
-            return """not found: {}{}{}{}{}""".format(
-                repr(self.key), because, with_keys, in_file, in_object
-            )
-        else:
-            return """not found: {} with cycle {}{}{}{}{}""".format(
-                repr(self.key), self.cycle, because, with_keys, in_file, in_object
-            )
+            return f"not found: {self.key!r} (with any cycle number){because}{with_keys}{in_file}{in_object}"
+        if self.cycle is None:
+            return f"not found: {self.key!r}{because}{with_keys}{in_file}{in_object}"
+        return f"not found: {self.key!r} with cycle {self.cycle}{because}{with_keys}{in_file}{in_object}"

--- a/src/uproot/exceptions.py
+++ b/src/uproot/exceptions.py
@@ -79,6 +79,7 @@ class KeyInFileError(KeyError):
 
         if self.cycle == "any":
             return f"not found: {self.key!r} (with any cycle number){because}{with_keys}{in_file}{in_object}"
-        if self.cycle is None:
+        elif self.cycle is None:
             return f"not found: {self.key!r}{because}{with_keys}{in_file}{in_object}"
-        return f"not found: {self.key!r} with cycle {self.cycle}{because}{with_keys}{in_file}{in_object}"
+        else:
+            return f"not found: {self.key!r} with cycle {self.cycle}{because}{with_keys}{in_file}{in_object}"

--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -732,13 +732,12 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
             ),
         )
 
-    elif has2 and tokens[i].group(0) == "long" and tokens[i + 1].group(0) == "long":
+    elif has2 and tokens[i].group(0) == tokens[i + 1].group(0) == "long":
         return i + 2, _parse_maybe_quote('numpy.dtype(">i8")', quote)
     elif (
         i + 2 < len(tokens)
         and tokens[i].group(0) == "unsigned"
-        and tokens[i + 1].group(0) == "long"
-        and tokens[i + 2].group(0) == "long"
+        and tokens[i + 1].group(0) == tokens[i + 2].group(0) == "long"
     ):
         return i + 3, _parse_maybe_quote('numpy.dtype(">u8")', quote)
 

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -182,11 +182,9 @@ class AsDtype(Numerical):
 
     def __repr__(self):
         if self._to_dtype == self._from_dtype.newbyteorder("="):
-            return f"AsDtype({repr(str(self._from_dtype))})"
+            return f"AsDtype({str(self._from_dtype)!r})"
         else:
-            return "AsDtype({}, {})".format(
-                repr(str(self._from_dtype)), repr(str(self._to_dtype))
-            )
+            return f"AsDtype({str(self._from_dtype)!r}, {str(self._to_dtype)!r})"
 
     def __eq__(self, other):
         return (
@@ -500,7 +498,7 @@ class TruncatedNumerical(Numerical):
         and :ref:`uproot.interpretation.numerical.TruncatedNumerical.high` are
         both ``0``), the data are truly truncated.
         """
-        return self._low == 0.0 and self._high == 0.0
+        return self._low == self._high == 0.0
 
     def __repr__(self):
         args = [repr(self._low), repr(self._high), repr(self._num_bits)]

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -19,6 +19,7 @@ while an array is being built from ``TBaskets``. Its final form is determined
 by the :doc:`uproot.interpretation.library.Library`.
 """
 
+import contextlib
 import threading
 
 import numpy
@@ -376,7 +377,7 @@ loop
         ``self``.
         """
         if self._branch is not None:
-            try:
+            with contextlib.suppress(CannotBeStrided):
                 return self._model.strided_interpretation(
                     self._branch.file,
                     header=False,
@@ -384,8 +385,6 @@ loop
                     breadcrumbs=(),
                     original=self._model,
                 )
-            except CannotBeStrided:
-                pass
 
         if isinstance(self._model, uproot.containers.AsString):
             header_bytes = 0
@@ -427,7 +426,7 @@ loop
                 )
 
             if self._branch is not None:
-                try:
+                with contextlib.suppress(CannotBeStrided):
                     content = self._model.values.strided_interpretation(
                         self._branch.file,
                         header=False,
@@ -450,8 +449,6 @@ loop
                         self._model.typename,
                         original=self._model,
                     )
-                except CannotBeStrided:
-                    pass
 
         return self
 

--- a/src/uproot/source/cursor.py
+++ b/src/uproot/source/cursor.py
@@ -565,7 +565,7 @@ of file path {}""".format(
             stream.write(
                 prefix
                 + " ".join(
-                    f"{chr(x):>3s}" if chr(x) in _printable_characters else "---"
+                    f"{x:>3c}" if chr(x) in _printable_characters else "---"
                     for x in line_data
                 )
                 + "\n"

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -559,7 +559,7 @@ class HTTPSource(uproot.source.chunk.Source):
         self._num_bytes = None
 
         self._fallback = None
-        self._fallback_options = dict(options)
+        self._fallback_options = options.copy()
         self._fallback_options["num_workers"] = self._num_fallback_workers
         self._open()
 

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -111,7 +111,7 @@ class XRootDResource(uproot.source.chunk.Resource):
 
         # https://github.com/xrootd/xrootd/blob/8e91462e76ab969720b40fc324714b84e0b4bd42/src/XrdCl/XrdClStatus.hh#L47-L103
         # https://github.com/xrootd/xrootd/blob/250eced4d3787c2ac5be2c8c922134153bbf7f08/src/XrdCl/XrdClStatus.cc#L34-L74
-        if status.code == 101 or status.code == 304 or status.code == 400:
+        if status.code in {101, 304, 400}:
             raise uproot._util._file_not_found(self._file_path, status.message)
 
         else:

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -111,7 +111,7 @@ class XRootDResource(uproot.source.chunk.Resource):
 
         # https://github.com/xrootd/xrootd/blob/8e91462e76ab969720b40fc324714b84e0b4bd42/src/XrdCl/XrdClStatus.hh#L47-L103
         # https://github.com/xrootd/xrootd/blob/250eced4d3787c2ac5be2c8c922134153bbf7f08/src/XrdCl/XrdClStatus.cc#L34-L74
-        if status.code in {101, 304, 400}:
+        if status.code in (101, 304, 400):
             raise uproot._util._file_not_found(self._file_path, status.message)
 
         else:

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -109,7 +109,7 @@ def recreate(file_path, **options):
         "initial_streamers_bytes", create.defaults["initial_streamers_bytes"]
     )
     uuid_function = options.pop("uuid_function", create.defaults["uuid_function"])
-    if len(options) != 0:
+    if options:
         raise TypeError(
             "unrecognized options for uproot.create or uproot.recreate: "
             + ", ".join(repr(x) for x in options)
@@ -157,7 +157,7 @@ def update(file_path, **options):
         "initial_directory_bytes", create.defaults["initial_directory_bytes"]
     )
     uuid_function = options.pop("uuid_function", create.defaults["uuid_function"])
-    if len(options) != 0:
+    if options:
         raise TypeError(
             "unrecognized options for uproot.update: "
             + ", ".join(repr(x) for x in options)


### PR DESCRIPTION
I've added a few cleanups based on `pipx run refurb src`. I didn't work on else after return (there's a lot of them), or on ones that were not clearly an improvement, but I liked these.

- chore: remove extra returns
- chore: using copy for dicts (better readability)
- chore: nicer strings and comparisons
- chore: use contextlib.suppress
