### PR TITLE
fix: avoid empty TBasket issue in embedded TBasket

### DIFF
--- a/src/uproot/models/TBasket.py
+++ b/src/uproot/models/TBasket.py
@@ -272,7 +272,10 @@ class Model_TBasket(uproot.model.Model):
             cursor.skip(self._members["fKeylen"])
 
             self._raw_data = None
-            self._data = cursor.bytes(chunk, self.border, context)
+            if self.border == 0:
+                self._data = numpy.empty(0, dtype=numpy.uint8)
+            else:
+                self._data = cursor.bytes(chunk, self.border, context)
 
         else:
             compressed_bytes = self._members["fNbytes"] - self._members["fKeylen"]

--- a/tests/test_0750-avoid-empty-TBasket-issue.py
+++ b/tests/test_0750-avoid-empty-TBasket-issue.py
@@ -1,0 +1,17 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import json
+import sys
+
+import numpy
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+def test():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-750.root"))[
+        "tout/Electron_eta"
+    ] as branch:
+        branch.array()


### PR DESCRIPTION
The issue is that these files apparently don't have a second TKey. See https://github.com/scikit-hep/uproot5/issues/750#issuecomment-1270469267.