### PR TITLE
fix: don't use Awkward in test_0751 that doesn't need it

### DIFF
--- a/tests/test_0750-avoid-empty-TBasket-issue.py
+++ b/tests/test_0750-avoid-empty-TBasket-issue.py
@@ -14,4 +14,4 @@ def test():
     with uproot.open(skhep_testdata.data_path("uproot-issue-750.root"))[
         "tout/Electron_eta"
     ] as branch:
-        branch.array()
+        branch.array(library="np")


### PR DESCRIPTION
This is a quick fix-up of #751, which shouldn't have been using Awkward in the test.

It's also interesting that it wasn't caught in `main`, only `main-v4`. In principle, there ought to be a test in our suite that doesn't install Awkward.