### PR TITLE
ci: update to Python 3.11 final

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.11-dev"]
+        python-version: ["3.11"]
 
     runs-on: "${{ matrix.platform }}"
     timeout-minutes: 30


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos