### PR TITLE
fix: histogram weights not handled correctly in hist / boost conversion

### DIFF
--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -110,7 +110,11 @@ class Histogram:
         True if the histogram has weights (``fSumw2``); False otherwise.
         """
         sumw2 = self.member("fSumw2")
-        return sumw2 is not None and len(sumw2) == self.member("fNcells")
+        return (
+            sumw2 is not None
+            and len(sumw2) > 0
+            and len(sumw2) == self.member("fNcells")
+        )
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -293,8 +293,8 @@ class TH1(Histogram):
 
     @property
     def weighted(self):
-        sumw2 = self.member("fSumw2", none_if_missing=True)
-        return sumw2 is not None and len(sumw2) == self.member("fNcells")
+        sumw2 = self.member("fSumw2")
+        return len(sumw2) > 0 and len(sumw2) == self.member("fNcells")
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -201,7 +201,7 @@ class Histogram:
         values = self.values(flow=True)
 
         sumw2 = None
-        if self.weighted:   # ensures self.member("fSumw2") exists
+        if self.weighted:  # ensures self.member("fSumw2") exists
             sumw2 = self.member("fSumw2")
             sumw2 = numpy.asarray(sumw2, dtype=sumw2.dtype.newbyteorder("="))
             sumw2 = numpy.reshape(sumw2, values.shape)
@@ -231,7 +231,7 @@ class Histogram:
             ):
                 continue
             # TODO: simplify this code (save multidim slice into a variable?)
-            ix = (numpy.s_[:],)*i + (numpy.s_[1:],)
+            ix = (numpy.s_[:],) * i + (numpy.s_[1:],)
             values = values[ix]
             if sumw2 is not None:
                 sumw2 = sumw2[ix]

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -110,7 +110,7 @@ class Histogram:
         True if the histogram has weights (``fSumw2``); False otherwise.
         """
         sumw2 = self.member("fSumw2")
-        return len(sumw2) > 0 and len(sumw2) == self.member("fNcells")
+        return sumw2 is not None and len(sumw2) == self.member("fNcells")
 
     @property
     def kind(self):
@@ -200,9 +200,8 @@ class Histogram:
 
         values = self.values(flow=True)
 
-        # 'fSumw2' will never be missing, if weights are not defined it is an array of length 0
         sumw2 = None
-        if self.weighted:
+        if self.weighted:   # ensures self.member("fSumw2") exists
             sumw2 = self.member("fSumw2")
             sumw2 = numpy.asarray(sumw2, dtype=sumw2.dtype.newbyteorder("="))
             sumw2 = numpy.reshape(sumw2, values.shape)
@@ -232,18 +231,10 @@ class Histogram:
             ):
                 continue
             # TODO: simplify this code (save multidim slice into a variable?)
-            if i == 0:
-                values = values[1:]
-                if sumw2 is not None:
-                    sumw2 = sumw2[1:]
-            elif i == 1:
-                values = values[:, 1:]
-                if sumw2 is not None:
-                    sumw2 = sumw2[:, 1:]
-            elif i == 2:
-                values = values[:, :, 1:]
-                if sumw2 is not None:
-                    sumw2 = sumw2[:, :, 1:]
+            ix = (numpy.s_[:],)*i + (numpy.s_[1:],)
+            values = values[ix]
+            if sumw2 is not None:
+                sumw2 = sumw2[ix]
 
         view = out.view(flow=True)
         if sumw2 is not None:

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -109,7 +109,8 @@ class Histogram:
         """
         True if the histogram has weights (``fSumw2``); False otherwise.
         """
-        raise NotImplementedError(repr(self))
+        sumw2 = self.member("fSumw2")
+        return len(sumw2) > 0 and len(sumw2) == self.member("fNcells")
 
     @property
     def kind(self):
@@ -293,8 +294,7 @@ class TH1(Histogram):
 
     @property
     def weighted(self):
-        sumw2 = self.member("fSumw2")
-        return len(sumw2) > 0 and len(sumw2) == self.member("fNcells")
+        return super().weighted()
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -201,13 +201,13 @@ class Histogram:
         values = self.values(flow=True)
 
         # 'fSumw2' will never be missing, if weights are not defined it is an array of length 0
-        sumw2 = self.member("fSumw2")
-        if len(sumw2) > 0 and len(sumw2) == self.member("fNcells"):
+        sumw2 = None
+        if self.weighted:
+            sumw2 = self.member("fSumw2")
             sumw2 = numpy.asarray(sumw2, dtype=sumw2.dtype.newbyteorder("="))
             sumw2 = numpy.reshape(sumw2, values.shape)
             storage = boost_histogram.storage.Weight()
         else:
-            sumw2 = None
             if issubclass(values.dtype.type, numpy.integer):
                 storage = boost_histogram.storage.Int64()
             else:

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -294,7 +294,7 @@ class TH1(Histogram):
 
     @property
     def weighted(self):
-        return super().weighted()
+        return super().weighted
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -287,10 +287,6 @@ class TH1(Histogram):
             raise ValueError("axis must be 0 (-1) or 'x' for a TH1")
 
     @property
-    def weighted(self):
-        return super().weighted
-
-    @property
     def kind(self):
         return "COUNT"
 
@@ -349,6 +345,3 @@ class TH1(Histogram):
             return values, (xedges,)
         else:
             return values, xedges
-
-    def to_boost(self, metadata=None, axis_metadata=None):
-        return super().to_boost(metadata=metadata, axis_metadata=axis_metadata)

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -230,11 +230,10 @@ class Histogram:
                 (boost_histogram.axis.IntCategory, boost_histogram.axis.StrCategory),
             ):
                 continue
-            # TODO: simplify this code (save multidim slice into a variable?)
-            ix = (numpy.s_[:],) * i + (numpy.s_[1:],)
-            values = values[ix]
+            slicer = (slice(None),) * i + (slice(1, None),)
+            values = values[slicer]
             if sumw2 is not None:
-                sumw2 = sumw2[ix]
+                sumw2 = sumw2[slicer]
 
         view = out.view(flow=True)
         if sumw2 is not None:

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -257,7 +257,7 @@ class Histogram:
 
         return out
 
-    def to_hist(self, metadata=boost_metadata, axis_metadata=boost_axis_metadata):
+    def to_hist(self, metadata=None, axis_metadata=None):
         """
         Args:
             metadata (dict of str \u2192 str): Metadata to collect (keys) and
@@ -268,7 +268,7 @@ class Histogram:
         Converts the histogram into a ``hist`` object.
         """
         return uproot.extras.hist().Hist(
-            self.to_boost(metadata=boost_metadata, axis_metadata=boost_axis_metadata)
+            self.to_boost(metadata=metadata, axis_metadata=axis_metadata)
         )
 
     # Support direct conversion to histograms, such as bh.Histogram(self) or hist.Hist(self)

--- a/src/uproot/behaviors/TH2.py
+++ b/src/uproot/behaviors/TH2.py
@@ -33,8 +33,8 @@ class TH2(uproot.behaviors.TH1.Histogram):
 
     @property
     def weighted(self):
-        sumw2 = self.member("fSumw2", none_if_missing=True)
-        return sumw2 is not None and len(sumw2) == self.member("fNcells")
+        sumw2 = self.member("fSumw2")
+        return len(sumw2) > 0 and len(sumw2) == self.member("fNcells")
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH2.py
+++ b/src/uproot/behaviors/TH2.py
@@ -9,7 +9,6 @@ This module defines the behaviors of ``TH2`` and its subclasses (not including
 import numpy
 
 import uproot
-from uproot.behaviors.TH1 import boost_axis_metadata, boost_metadata
 
 
 class TH2(uproot.behaviors.TH1.Histogram):
@@ -101,39 +100,5 @@ class TH2(uproot.behaviors.TH1.Histogram):
         else:
             return values, xedges, yedges
 
-    def to_boost(self, metadata=boost_metadata, axis_metadata=boost_axis_metadata):
-        boost_histogram = uproot.extras.boost_histogram()
-
-        values = self.values(flow=True)
-
-        sumw2 = self.member("fSumw2", none_if_missing=True)
-
-        if sumw2 is not None and len(sumw2) == self.member("fNcells"):
-            sumw2 = numpy.asarray(sumw2, dtype=sumw2.dtype.newbyteorder("="))
-            sumw2 = numpy.transpose(numpy.reshape(sumw2, values.shape[::-1]))
-            storage = boost_histogram.storage.Weight()
-        else:
-            if issubclass(values.dtype.type, numpy.integer):
-                storage = boost_histogram.storage.Int64()
-            else:
-                storage = boost_histogram.storage.Double()
-
-        xaxis = uproot.behaviors.TH1._boost_axis(self.member("fXaxis"), axis_metadata)
-        yaxis = uproot.behaviors.TH1._boost_axis(self.member("fYaxis"), axis_metadata)
-        out = boost_histogram.Histogram(xaxis, yaxis, storage=storage)
-        for k, v in metadata.items():
-            setattr(out, k, self.member(v))
-
-        if isinstance(xaxis, boost_histogram.axis.StrCategory):
-            values = values[1:, :]
-        if isinstance(yaxis, boost_histogram.axis.StrCategory):
-            values = values[:, 1:]
-
-        view = out.view(flow=True)
-        if sumw2 is not None and len(sumw2) == len(values):
-            view.value = values
-            view.variance = sumw2
-        else:
-            view[...] = values
-
-        return out
+    def to_boost(self, metadata=None, axis_metadata=None):
+        return super().to_boost(metadata=metadata, axis_metadata=axis_metadata)

--- a/src/uproot/behaviors/TH2.py
+++ b/src/uproot/behaviors/TH2.py
@@ -33,8 +33,7 @@ class TH2(uproot.behaviors.TH1.Histogram):
 
     @property
     def weighted(self):
-        sumw2 = self.member("fSumw2")
-        return len(sumw2) > 0 and len(sumw2) == self.member("fNcells")
+        return super().weighted()
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH2.py
+++ b/src/uproot/behaviors/TH2.py
@@ -32,10 +32,6 @@ class TH2(uproot.behaviors.TH1.Histogram):
             raise ValueError("axis must be 0 (-2), 1 (-1) or 'x', 'y' for a TH2")
 
     @property
-    def weighted(self):
-        return super().weighted
-
-    @property
     def kind(self):
         return "COUNT"
 
@@ -98,6 +94,3 @@ class TH2(uproot.behaviors.TH1.Histogram):
             return values, (xedges, yedges)
         else:
             return values, xedges, yedges
-
-    def to_boost(self, metadata=None, axis_metadata=None):
-        return super().to_boost(metadata=metadata, axis_metadata=axis_metadata)

--- a/src/uproot/behaviors/TH2.py
+++ b/src/uproot/behaviors/TH2.py
@@ -33,7 +33,7 @@ class TH2(uproot.behaviors.TH1.Histogram):
 
     @property
     def weighted(self):
-        return super().weighted()
+        return super().weighted
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH3.py
+++ b/src/uproot/behaviors/TH3.py
@@ -36,10 +36,6 @@ class TH3(uproot.behaviors.TH1.Histogram):
             )
 
     @property
-    def weighted(self):
-        return super().weighted
-
-    @property
     def kind(self):
         return "COUNT"
 
@@ -107,6 +103,3 @@ class TH3(uproot.behaviors.TH1.Histogram):
             return values, (xedges, yedges, zedges)
         else:
             return values, xedges, yedges, zedges
-
-    def to_boost(self, metadata=None, axis_metadata=None):
-        return super().to_boost(metadata=metadata, axis_metadata=axis_metadata)

--- a/src/uproot/behaviors/TH3.py
+++ b/src/uproot/behaviors/TH3.py
@@ -37,8 +37,7 @@ class TH3(uproot.behaviors.TH1.Histogram):
 
     @property
     def weighted(self):
-        sumw2 = self.member("fSumw2")
-        return len(sumw2) > 0 and len(sumw2) == self.member("fNcells")
+        return super().weighted()
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH3.py
+++ b/src/uproot/behaviors/TH3.py
@@ -37,7 +37,7 @@ class TH3(uproot.behaviors.TH1.Histogram):
 
     @property
     def weighted(self):
-        return super().weighted()
+        return super().weighted
 
     @property
     def kind(self):

--- a/src/uproot/behaviors/TH3.py
+++ b/src/uproot/behaviors/TH3.py
@@ -37,8 +37,8 @@ class TH3(uproot.behaviors.TH1.Histogram):
 
     @property
     def weighted(self):
-        sumw2 = self.member("fSumw2", none_if_missing=True)
-        return sumw2 is not None and len(sumw2) == self.member("fNcells")
+        sumw2 = self.member("fSumw2")
+        return len(sumw2) > 0 and len(sumw2) == self.member("fNcells")
 
     @property
     def kind(self):

--- a/src/uproot/version.py
+++ b/src/uproot/version.py
@@ -12,7 +12,7 @@ of the latest release on PyPI.
 
 import re
 
-__version__ = "5.0.0rc5"
+__version__ = "5.0.0rc6"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 

--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -289,7 +289,6 @@ def to_writable(obj):
                 data = numpy.zeros((s[0] + 2, s[1] + 2, s[2] + 2), dtype=d)
                 data[1:-1, 1:-1, 1:-1] = tmp
 
-            # 'variances' appears to always be defined regardless of whether the histogram uses weights or not
             tmp = (
                 obj.variances()
                 if obj.storage_type == boost_histogram.storage.Weight

--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -261,7 +261,11 @@ def to_writable(obj):
         try:
             # using flow=True if supported
             data = obj.values(flow=True)
-            fSumw2 = obj.variances(flow=True)
+            fSumw2 = (
+                obj.variances(flow=True)
+                if isinstance(obj.storage_type, boost_histogram.storage.Weight)
+                else None
+            )
 
             # and flow=True is different from flow=False (obj actually has flow bins)
             data_noflow = obj.values(flow=False)

--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -285,19 +285,24 @@ def to_writable(obj):
                 data = numpy.zeros((s[0] + 2, s[1] + 2, s[2] + 2), dtype=d)
                 data[1:-1, 1:-1, 1:-1] = tmp
 
-            tmp = obj.variances()
-            s = tmp.shape
-            if tmp is None:
-                fSumw2 = None
-            elif ndim == 1:
-                fSumw2 = numpy.zeros(s[0] + 2, dtype=">f8")
-                fSumw2[1:-1] = tmp
-            elif ndim == 2:
-                fSumw2 = numpy.zeros((s[0] + 2, s[1] + 2), dtype=">f8")
-                fSumw2[1:-1, 1:-1] = tmp
-            elif ndim == 3:
-                fSumw2 = numpy.zeros((s[0] + 2, s[1] + 2, s[2] + 2), dtype=">f8")
-                fSumw2[1:-1, 1:-1, 1:-1] = tmp
+            # 'variances' appears to always be defined regardless of whether the histogram uses weights or not
+            tmp = (
+                obj.variances()
+                if isinstance(obj.storage_type, boost_histogram.storage.Weight)
+                else None
+            )
+            fSumw2 = None
+            if tmp is not None:
+                s = tmp.shape
+                if ndim == 1:
+                    fSumw2 = numpy.zeros(s[0] + 2, dtype=">f8")
+                    fSumw2[1:-1] = tmp
+                elif ndim == 2:
+                    fSumw2 = numpy.zeros((s[0] + 2, s[1] + 2), dtype=">f8")
+                    fSumw2[1:-1, 1:-1] = tmp
+                elif ndim == 3:
+                    fSumw2 = numpy.zeros((s[0] + 2, s[1] + 2, s[2] + 2), dtype=">f8")
+                    fSumw2[1:-1, 1:-1, 1:-1] = tmp
 
         else:
             # continuing to use flow=True, because it is supported

--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -263,7 +263,7 @@ def to_writable(obj):
             data = obj.values(flow=True)
             fSumw2 = (
                 obj.variances(flow=True)
-                if isinstance(obj.storage_type, boost_histogram.storage.Weight)
+                if obj.storage_type == boost_histogram.storage.Weight
                 else None
             )
 
@@ -292,7 +292,7 @@ def to_writable(obj):
             # 'variances' appears to always be defined regardless of whether the histogram uses weights or not
             tmp = (
                 obj.variances()
-                if isinstance(obj.storage_type, boost_histogram.storage.Weight)
+                if obj.storage_type == boost_histogram.storage.Weight
                 else None
             )
             fSumw2 = None

--- a/tests/test_0167-use-the-common-histogram-interface.py
+++ b/tests/test_0167-use-the-common-histogram-interface.py
@@ -150,6 +150,7 @@ def test_boost_2():
         # assert f["cutflow"].to_boost().axes[0].title == ""
 
 
+@pytest.mark.skip(reason="test file not yet available")
 def test_issue_0722():
     boost_histogram = pytest.importorskip("boost_histogram")
 

--- a/tests/test_0167-use-the-common-histogram-interface.py
+++ b/tests/test_0167-use-the-common-histogram-interface.py
@@ -148,3 +148,10 @@ def test_boost_2():
         # assert f["cutflow"].to_boost().title == "dijethad"
         # assert f["cutflow"].to_boost().axes[0].name == "xaxis"
         # assert f["cutflow"].to_boost().axes[0].title == ""
+
+
+def test_issue_0722():
+    boost_histogram = pytest.importorskip("boost_histogram")
+
+    with uproot.open(skhep_testdata.data_path("uproot-issue722.root")) as f:
+        f["hist"].to_boost()

--- a/tests/test_0167-use-the-common-histogram-interface.py
+++ b/tests/test_0167-use-the-common-histogram-interface.py
@@ -150,9 +150,8 @@ def test_boost_2():
         # assert f["cutflow"].to_boost().axes[0].title == ""
 
 
-@pytest.mark.skip(reason="test file not yet available")
 def test_issue_0722():
     boost_histogram = pytest.importorskip("boost_histogram")
 
-    with uproot.open(skhep_testdata.data_path("uproot-issue722.root")) as f:
+    with uproot.open(skhep_testdata.data_path("uproot-issue-722.root")) as f:
         f["hist"].to_boost()

--- a/tests/test_0167-use-the-common-histogram-interface.py
+++ b/tests/test_0167-use-the-common-histogram-interface.py
@@ -9,7 +9,12 @@ import uproot
 
 def test_axis():
     with uproot.open(skhep_testdata.data_path("uproot-hepdata-example.root")) as f:
-        f["hpx"].axes[0] == f["hpx"].axis(0) == f["hpx"].axis(-1) == f["hpx"].axis("x")
+        assert (
+            f["hpx"].axes[0]
+            == f["hpx"].axis(0)
+            == f["hpx"].axis(-1)
+            == f["hpx"].axis("x")
+        )
         axis = f["hpx"].axis()
         assert len(axis) == 100
         assert axis[0] == (-4.0, -3.92)
@@ -52,7 +57,7 @@ def test_axis():
         )
 
     with uproot.open(skhep_testdata.data_path("uproot-issue33.root")) as f:
-        f["cutflow"].axes[0] == f["cutflow"].axis(0) == f["cutflow"].axis("x")
+        assert f["cutflow"].axes[0] == f["cutflow"].axis(0) == f["cutflow"].axis("x")
         axis = f["cutflow"].axis()
         assert len(axis) == 7
         assert axis[0] == "Dijet"

--- a/tests/test_0167-use-the-common-histogram-interface.py
+++ b/tests/test_0167-use-the-common-histogram-interface.py
@@ -150,7 +150,6 @@ def test_boost_2():
         # assert f["cutflow"].to_boost().axes[0].title == ""
 
 
-@pytest.mark.skip(reason="test file not yet available")
 def test_issue_0722():
     boost_histogram = pytest.importorskip("boost_histogram")
 

--- a/tests/test_0422-hist-integration.py
+++ b/tests/test_0422-hist-integration.py
@@ -190,6 +190,6 @@ def test_issue_0659(tmp_path):
     f = ROOT.TFile(newfile)
     h_opened2 = f.Get("h")
     h2_opened2 = f.Get("h2")
-    h_opened2.GetBinContent(0) == 0.0
-    h2_opened2.GetBinContent(0) == 0.0
+    assert h_opened2.GetBinContent(0) == 0.0
+    assert h2_opened2.GetBinContent(0) == 0.0
     f.Close()

--- a/tests/test_0422-hist-integration.py
+++ b/tests/test_0422-hist-integration.py
@@ -316,3 +316,187 @@ def test_hist_weights_labels_from_root(tmp_path):
         str(h_noweights_nolabels2.storage_type)
         == "<class 'boost_histogram.storage.Double'>"
     )
+
+
+def test_hist_weights_2D(tmp_path):
+    newfile = os.path.join(tmp_path, "newfile.root")
+
+    h_2D_noweights_nolabels = ROOT.TH2D(
+        "h_2D_noweights_nolabels", "2D", 20, 0.0, 5.0, 10, -10.0, 10.0
+    )
+    h_2D_weights_nolabels = ROOT.TH2D(
+        "h_2D_weights_nolabels", "2D", 20, 0.0, 5.0, 10, -10.0, 10.0
+    )
+    h_2D_noweights_labels = ROOT.TH2D(
+        "h_2D_noweights_labels", "2D", 20, 0.0, 5.0, 10, -10.0, 10.0
+    )
+    h_2D_weights_labels = ROOT.TH2D(
+        "h_2D_weights_labels", "2D", 20, 0.0, 5.0, 10, -10.0, 10.0
+    )
+
+    for _ in range(1000):
+        # fill with random values and random weights
+        h_2D_noweights_nolabels.Fill(
+            5.0 * np.random.random(), 10.0 * np.random.random()
+        )
+        h_2D_weights_nolabels.Fill(
+            5.0 * np.random.random(), 10.0 * np.random.random(), np.random.random()
+        )
+        h_2D_noweights_labels.Fill(5.0 * np.random.random(), 10.0 * np.random.random())
+        h_2D_weights_labels.Fill(
+            5.0 * np.random.random(), 10.0 * np.random.random(), np.random.random()
+        )
+
+    assert (
+        h_2D_noweights_nolabels.GetNbinsX()
+        == h_2D_weights_nolabels.GetNbinsX()
+        == h_2D_noweights_labels.GetNbinsX()
+        == h_2D_weights_labels.GetNbinsX()
+        == 20
+    )
+    assert (
+        h_2D_noweights_nolabels.GetNbinsY()
+        == h_2D_weights_nolabels.GetNbinsY()
+        == h_2D_noweights_labels.GetNbinsY()
+        == h_2D_weights_labels.GetNbinsY()
+        == 10
+    )
+    for i in range(h_2D_weights_labels.GetNbinsX()):
+        h_2D_weights_labels.GetXaxis().SetBinLabel(i + 1, f"label_{i}")
+        h_2D_noweights_labels.GetXaxis().SetBinLabel(i + 1, f"label_{i}")
+    for i in range(h_2D_noweights_labels.GetNbinsY()):
+        # add y labels to this one
+        h_2D_noweights_labels.GetYaxis().SetBinLabel(i + 1, f"label_{i}")
+
+    assert (
+        len(h_2D_weights_nolabels.GetSumw2())
+        == len(h_2D_weights_labels.GetSumw2())
+        == 264
+    )
+    assert (
+        len(h_2D_noweights_nolabels.GetSumw2())
+        == len(h_2D_noweights_labels.GetSumw2())
+        == 0
+    )
+
+    assert (
+        h_2D_weights_labels.GetXaxis().GetLabels().GetSize()
+        == h_2D_noweights_labels.GetXaxis().GetLabels().GetSize()
+        == 20
+    )
+    assert h_2D_noweights_labels.GetYaxis().GetLabels().GetSize() == 10
+
+    fout = ROOT.TFile(newfile, "RECREATE")
+    h_2D_noweights_nolabels.Write()
+    h_2D_weights_nolabels.Write()
+    h_2D_noweights_labels.Write()
+    h_2D_weights_labels.Write()
+    fout.Close()
+
+    with uproot.open(newfile) as fin:
+        h_2D_noweights_nolabels = fin["h_2D_noweights_nolabels"]
+        h_2D_weights_nolabels = fin["h_2D_weights_nolabels"]
+        h_2D_noweights_labels = fin["h_2D_noweights_labels"]
+        h_2D_weights_labels = fin["h_2D_weights_labels"]
+
+    h_2D_noweights_nolabels.to_hist()
+    h_2D_weights_nolabels.to_hist()
+    h_2D_noweights_labels.to_hist()
+    h_2D_weights_labels.to_hist()
+
+
+def test_hist_weights_3D(tmp_path):
+    newfile = os.path.join(tmp_path, "newfile.root")
+
+    h_3D_noweights_nolabels = ROOT.TH3D(
+        "h_3D_noweights_nolabels", "3D", 20, 0.0, 5.0, 10, -10.0, 10.0, 5, -5.0, 5.0
+    )
+    h_3D_weights_nolabels = ROOT.TH3D(
+        "h_3D_weights_nolabels", "3D", 20, 0.0, 5.0, 10, -10.0, 10.0, 5, -5.0, 5.0
+    )
+    h_3D_noweights_labels = ROOT.TH3D(
+        "h_3D_noweights_labels", "3D", 20, 0.0, 5.0, 10, -10.0, 10.0, 5, -5.0, 5.0
+    )
+    h_3D_weights_labels = ROOT.TH3D(
+        "h_3D_weights_labels", "3D", 20, 0.0, 5.0, 10, -10.0, 10.0, 5, -5.0, 5.0
+    )
+
+    for _ in range(1000):
+        # fill with random values and random weights
+        h_3D_noweights_nolabels.Fill(
+            5.0 * np.random.random(), 10.0 * np.random.random(), 2 * np.random.random()
+        )
+        h_3D_weights_nolabels.Fill(
+            5.0 * np.random.random(),
+            10.0 * np.random.random(),
+            2 * np.random.random(),
+            np.random.random(),
+        )
+        h_3D_noweights_labels.Fill(
+            5.0 * np.random.random(), 10.0 * np.random.random(), 2 * np.random.random()
+        )
+        h_3D_weights_labels.Fill(
+            5.0 * np.random.random(),
+            10.0 * np.random.random(),
+            2 * np.random.random(),
+            np.random.random(),
+        )
+
+    assert (
+        h_3D_noweights_nolabels.GetNbinsX()
+        == h_3D_weights_nolabels.GetNbinsX()
+        == h_3D_noweights_labels.GetNbinsX()
+        == h_3D_weights_labels.GetNbinsX()
+        == 20
+    )
+    assert (
+        h_3D_noweights_nolabels.GetNbinsY()
+        == h_3D_weights_nolabels.GetNbinsY()
+        == h_3D_noweights_labels.GetNbinsY()
+        == h_3D_weights_labels.GetNbinsY()
+        == 10
+    )
+    assert (
+        h_3D_noweights_nolabels.GetNbinsZ()
+        == h_3D_weights_nolabels.GetNbinsZ()
+        == h_3D_noweights_labels.GetNbinsZ()
+        == h_3D_weights_labels.GetNbinsZ()
+        == 5
+    )
+    for i in range(h_3D_noweights_labels.GetNbinsX()):
+        h_3D_weights_labels.GetXaxis().SetBinLabel(i + 1, f"label_{i}")
+    for i in range(h_3D_noweights_labels.GetNbinsZ()):
+        # add z labels to this one
+        h_3D_noweights_labels.GetZaxis().SetBinLabel(i + 1, f"label_{i}")
+
+    assert (
+        len(h_3D_weights_nolabels.GetSumw2())
+        == len(h_3D_weights_labels.GetSumw2())
+        == 1848
+    )
+    assert (
+        len(h_3D_noweights_nolabels.GetSumw2())
+        == len(h_3D_noweights_labels.GetSumw2())
+        == 0
+    )
+
+    assert h_3D_weights_labels.GetXaxis().GetLabels().GetSize() == 20
+    assert h_3D_noweights_labels.GetZaxis().GetLabels().GetSize() == 5
+
+    fout = ROOT.TFile(newfile, "RECREATE")
+    h_3D_noweights_nolabels.Write()
+    h_3D_weights_nolabels.Write()
+    h_3D_noweights_labels.Write()
+    h_3D_weights_labels.Write()
+    fout.Close()
+
+    with uproot.open(newfile) as fin:
+        h_3D_noweights_nolabels = fin["h_3D_noweights_nolabels"]
+        h_3D_weights_nolabels = fin["h_3D_weights_nolabels"]
+        h_3D_noweights_labels = fin["h_3D_noweights_labels"]
+        h_3D_weights_labels = fin["h_3D_weights_labels"]
+
+    h_3D_noweights_nolabels.to_hist()
+    h_3D_weights_nolabels.to_hist()
+    h_3D_noweights_labels.to_hist()
+    h_3D_weights_labels.to_hist()

--- a/tests/test_0422-hist-integration.py
+++ b/tests/test_0422-hist-integration.py
@@ -193,3 +193,23 @@ def test_issue_0659(tmp_path):
     assert h_opened2.GetBinContent(0) == 0.0
     assert h2_opened2.GetBinContent(0) == 0.0
     f.Close()
+
+
+def test_hist_weights_from_root(tmp_path):
+    newfile = os.path.join(tmp_path, "newfile.root")
+
+    h = ROOT.TH1D("h", "h", 20, 0.0, 5.0)
+    for _ in range(1000):
+        # fill with random values and random weights
+        h.Fill(5.0 * np.random.random(), np.random.random())
+
+    assert len(h.GetSumw2()) == 22  # 20 bins + 2, should not be 0 since we have weights
+
+    fout = ROOT.TFile(newfile, "RECREATE")
+    h.Write()
+    fout.Close()
+
+    with uproot.open(newfile) as fin:
+        h1 = fin["h"]
+
+    assert len(h1.member("fSumw2")) == 22

--- a/tests/test_0422-hist-integration.py
+++ b/tests/test_0422-hist-integration.py
@@ -228,5 +228,4 @@ def test_issue_722(tmp_path):
     with uproot.open(newfile) as fin2:
         h3 = fin2["h"]
 
-    # ERROR
-    assert len(h3.member("fSumw2")) == 0, "this should be 0, but it's not!"
+    assert len(h3.member("fSumw2")) == 0

--- a/tests/test_0422-hist-integration.py
+++ b/tests/test_0422-hist-integration.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-import array
 import os
 
 import numpy as np


### PR DESCRIPTION
Currently the `fSumw2` (weights) are not being correctly read/written when performing conversion to/from `hist`/`boost` histograms.

This is causing issues in https://github.com/scikit-hep/uproot5/issues/672 and solving this will also close https://github.com/scikit-hep/uproot5/issues/722.

- We now use `hist` `storage_type` property to check wether it's a weighted histogram or not, instead of the `variances` which is always defined and was cuasing false positives.
- Add two new tests, to check the conversion with a histogram with weights and another one without weights.
- Updated slicing of values / variances for categorical axes.
- Refactored `weighted` property and `to_boost` method to use inheritance.
- Write test for 2D, 3D histograms with weights / labels.