### PR TITLE
feat: add 'interp_options' mechanism and ak_add_doc.

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -57,6 +57,7 @@ def iterate(
     decompression_executor=None,
     interpretation_executor=None,
     library="ak",
+    ak_add_doc=False,
     how=None,
     report=False,
     custom_classes=None,
@@ -104,6 +105,8 @@ def iterate(
         library (str or :doc:`uproot.interpretation.library.Library`): The library
             that is used to represent arrays. Options are ``"np"`` for NumPy,
             ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
+        ak_add_doc (bool): If True and ``library="ak"``, add the TBranch ``title``
+            to the Awkward ``__doc__`` parameter of the array.
         how (None, str, or container type): Library-dependent instructions
             for grouping. The only recognized container types are ``tuple``,
             ``list``, and ``dict``. Note that the container *type itself*
@@ -199,6 +202,7 @@ def iterate(
                         decompression_executor=decompression_executor,
                         interpretation_executor=interpretation_executor,
                         library=library,
+                        ak_add_doc=ak_add_doc,
                         how=how,
                         report=report,
                     ):
@@ -231,6 +235,7 @@ def concatenate(
     decompression_executor=None,
     interpretation_executor=None,
     library="ak",
+    ak_add_doc=False,
     how=None,
     custom_classes=None,
     allow_missing=False,
@@ -273,6 +278,8 @@ def concatenate(
         library (str or :doc:`uproot.interpretation.library.Library`): The library
             that is used to represent arrays. Options are ``"np"`` for NumPy,
             ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
+        ak_add_doc (bool): If True and ``library="ak"``, add the TBranch ``title``
+            to the Awkward ``__doc__`` parameter of the array.
         how (None, str, or container type): Library-dependent instructions
             for grouping. The only recognized container types are ``tuple``,
             ``list``, and ``dict``. Note that the container *type itself*
@@ -363,6 +370,7 @@ def concatenate(
                         interpretation_executor=interpretation_executor,
                         array_cache=None,
                         library=library,
+                        ak_add_doc=ak_add_doc,
                         how=how,
                     )
                     arrays = library.global_index(arrays, global_start)
@@ -801,6 +809,7 @@ class HasBranches(Mapping):
         interpretation_executor=None,
         array_cache="inherit",
         library="ak",
+        ak_add_doc=False,
         how=None,
     ):
         """
@@ -849,6 +858,8 @@ class HasBranches(Mapping):
             library (str or :doc:`uproot.interpretation.library.Library`): The library
                 that is used to represent arrays. Options are ``"np"`` for NumPy,
                 ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
+            ak_add_doc (bool): If True and ``library="ak"``, add the TBranch ``title``
+                to the Awkward ``__doc__`` parameter of the array.
             how (None, str, or container type): Library-dependent instructions
                 for grouping. The only recognized container types are ``tuple``,
                 ``list``, and ``dict``. Note that the container *type itself*
@@ -941,6 +952,7 @@ class HasBranches(Mapping):
                     ) in branch.entries_to_ranges_or_baskets(entry_start, entry_stop):
                         ranges_or_baskets.append((branch, basket_num, range_or_basket))
 
+        interp_options = {"ak_add_doc": ak_add_doc}
         _ranges_or_baskets_to_arrays(
             self,
             ranges_or_baskets,
@@ -952,6 +964,7 @@ class HasBranches(Mapping):
             library,
             arrays,
             False,
+            interp_options,
         )
 
         # no longer needed; save memory
@@ -1013,6 +1026,7 @@ class HasBranches(Mapping):
         decompression_executor=None,
         interpretation_executor=None,
         library="ak",
+        ak_add_doc=False,
         how=None,
         report=False,
     ):
@@ -1063,6 +1077,8 @@ class HasBranches(Mapping):
             library (str or :doc:`uproot.interpretation.library.Library`): The library
                 that is used to represent arrays. Options are ``"np"`` for NumPy,
                 ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
+            ak_add_doc (bool): If True and ``library="ak"``, add the TBranch ``title``
+                to the Awkward ``__doc__`` parameter of the array.
             how (None, str, or container type): Library-dependent instructions
                 for grouping. The only recognized container types are ``tuple``,
                 ``list``, and ``dict``. Note that the container *type itself*
@@ -1172,6 +1188,7 @@ class HasBranches(Mapping):
                                     )
 
                 arrays = {}
+                interp_options = {"ak_add_doc": ak_add_doc}
                 _ranges_or_baskets_to_arrays(
                     self,
                     ranges_or_baskets,
@@ -1183,6 +1200,7 @@ class HasBranches(Mapping):
                     library,
                     arrays,
                     True,
+                    interp_options,
                 )
 
                 _fix_asgrouped(
@@ -1784,6 +1802,7 @@ class TBranch(HasBranches):
         interpretation_executor=None,
         array_cache="inherit",
         library="ak",
+        ak_add_doc=False,
     ):
         """
         Args:
@@ -1812,6 +1831,8 @@ class TBranch(HasBranches):
             library (str or :doc:`uproot.interpretation.library.Library`): The library
                 that is used to represent arrays. Options are ``"np"`` for NumPy,
                 ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
+            ak_add_doc (bool): If True and ``library="ak"``, add the TBranch ``title``
+                to the Awkward ``__doc__`` parameter of the array.
 
         Returns the ``TBranch`` data as an array.
 
@@ -1887,6 +1908,7 @@ class TBranch(HasBranches):
                     ) in branch.entries_to_ranges_or_baskets(entry_start, entry_stop):
                         ranges_or_baskets.append((branch, basket_num, range_or_basket))
 
+        interp_options = {"ak_add_doc": ak_add_doc}
         _ranges_or_baskets_to_arrays(
             self,
             ranges_or_baskets,
@@ -1898,6 +1920,7 @@ class TBranch(HasBranches):
             library,
             arrays,
             False,
+            interp_options,
         )
 
         _fix_asgrouped(
@@ -3054,6 +3077,7 @@ def _ranges_or_baskets_to_arrays(
     library,
     arrays,
     update_ranges_or_baskets,
+    interp_options,
 ):
     notifications = queue.Queue()
 
@@ -3087,7 +3111,7 @@ def _ranges_or_baskets_to_arrays(
         if branchid_num_baskets[cache_key] == 0:
             if cache_key not in arrays:
                 arrays[cache_key] = interpretation.final_array(
-                    {}, 0, 0, [0], library, None
+                    {}, 0, 0, [0], library, None, interp_options
                 )
 
     hasbranches._file.source.chunks(ranges, notifications=notifications)
@@ -3136,6 +3160,7 @@ def _ranges_or_baskets_to_arrays(
                 context,
                 basket.member("fKeylen"),
                 library,
+                interp_options,
             )
             if basket.num_entries != len(basket_arrays[basket.basket_num]):
                 raise ValueError(
@@ -3161,6 +3186,7 @@ def _ranges_or_baskets_to_arrays(
                     branch.entry_offsets,
                     library,
                     branch,
+                    interp_options,
                 )
                 # no longer needed, save memory
                 basket_arrays.clear()

--- a/src/uproot/interpretation/__init__.py
+++ b/src/uproot/interpretation/__init__.py
@@ -101,7 +101,15 @@ class Interpretation:
         raise AssertionError
 
     def basket_array(
-        self, data, byte_offsets, basket, branch, context, cursor_offset, library
+        self,
+        data,
+        byte_offsets,
+        basket,
+        branch,
+        context,
+        cursor_offset,
+        library,
+        options,
     ):
         """
         Args:
@@ -120,6 +128,8 @@ class Interpretation:
                 (:doc:`uproot.deserialization.read_object_any`).
             library (:doc:`uproot.interpretation.library.Library`): The
                 requested library for output.
+            options (dict): Flags and other options passed through the
+                interpretation process.
 
         Performs the first step of interpretation, from uncompressed ``TBasket``
         data to a temporary array.
@@ -127,7 +137,14 @@ class Interpretation:
         raise AssertionError
 
     def final_array(
-        self, basket_arrays, entry_start, entry_stop, entry_offsets, library, branch
+        self,
+        basket_arrays,
+        entry_start,
+        entry_stop,
+        entry_offsets,
+        library,
+        branch,
+        options,
     ):
         """
         Args:
@@ -146,6 +163,8 @@ class Interpretation:
                 requested library for output.
             branch (:doc:`uproot.behaviors.TBranch.TBranch`): The ``TBranch``
                 that is being interpreted.
+            options (dict): Flags and other options passed through the
+                interpretation process.
 
         Performs the last steps of interpretation, from a collection of
         temporary arrays, one for each ``TBasket``, to a trimmed, finalized,

--- a/src/uproot/interpretation/__init__.py
+++ b/src/uproot/interpretation/__init__.py
@@ -109,7 +109,7 @@ class Interpretation:
         context,
         cursor_offset,
         library,
-        options,
+        interp_options,
     ):
         """
         Args:
@@ -128,7 +128,7 @@ class Interpretation:
                 (:doc:`uproot.deserialization.read_object_any`).
             library (:doc:`uproot.interpretation.library.Library`): The
                 requested library for output.
-            options (dict): Flags and other options passed through the
+            interp_options (dict): Flags and other options passed through the
                 interpretation process.
 
         Performs the first step of interpretation, from uncompressed ``TBasket``
@@ -144,7 +144,7 @@ class Interpretation:
         entry_offsets,
         library,
         branch,
-        options,
+        interp_options,
     ):
         """
         Args:
@@ -163,7 +163,7 @@ class Interpretation:
                 requested library for output.
             branch (:doc:`uproot.behaviors.TBranch.TBranch`): The ``TBranch``
                 that is being interpreted.
-            options (dict): Flags and other options passed through the
+            interp_options (dict): Flags and other options passed through the
                 interpretation process.
 
         Performs the last steps of interpretation, from a collection of

--- a/src/uproot/interpretation/grouped.py
+++ b/src/uproot/interpretation/grouped.py
@@ -106,7 +106,15 @@ class AsGrouped(uproot.interpretation.Interpretation):
         return awkward.forms.RecordForm(fields, names)
 
     def basket_array(
-        self, data, byte_offsets, basket, branch, context, cursor_offset, library
+        self,
+        data,
+        byte_offsets,
+        basket,
+        branch,
+        context,
+        cursor_offset,
+        library,
+        options,
     ):
         raise ValueError(
             """grouping branches like {} should not be read directly; instead read the subbranches:
@@ -123,7 +131,14 @@ in object {}""".format(
         )
 
     def final_array(
-        self, basket_arrays, entry_start, entry_stop, entry_offsets, library, branch
+        self,
+        basket_arrays,
+        entry_start,
+        entry_stop,
+        entry_offsets,
+        library,
+        branch,
+        options,
     ):
         raise ValueError(
             """grouping branches like {} should not be read directly; instead read the subbranches:

--- a/src/uproot/interpretation/jagged.py
+++ b/src/uproot/interpretation/jagged.py
@@ -141,7 +141,15 @@ class AsJagged(uproot.interpretation.Interpretation):
             return self._typename
 
     def basket_array(
-        self, data, byte_offsets, basket, branch, context, cursor_offset, library
+        self,
+        data,
+        byte_offsets,
+        basket,
+        branch,
+        context,
+        cursor_offset,
+        library,
+        options,
     ):
         self.hook_before_basket_array(
             data=data,
@@ -151,6 +159,7 @@ class AsJagged(uproot.interpretation.Interpretation):
             context=context,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
 
         if byte_offsets is None:
@@ -173,7 +182,7 @@ class AsJagged(uproot.interpretation.Interpretation):
         if self._header_bytes == 0:
             offsets = fast_divide(byte_offsets, self._content.itemsize)
             content = self._content.basket_array(
-                data, None, basket, branch, context, cursor_offset, library
+                data, None, basket, branch, context, cursor_offset, library, options
             )
             output = JaggedArray(offsets, content)
 
@@ -189,7 +198,7 @@ class AsJagged(uproot.interpretation.Interpretation):
             data = data[mask]
 
             content = self._content.basket_array(
-                data, None, basket, branch, context, cursor_offset, library
+                data, None, basket, branch, context, cursor_offset, library, options
             )
 
             byte_counts = byte_stops - byte_starts
@@ -209,12 +218,20 @@ class AsJagged(uproot.interpretation.Interpretation):
             output=output,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
 
         return output
 
     def final_array(
-        self, basket_arrays, entry_start, entry_stop, entry_offsets, library, branch
+        self,
+        basket_arrays,
+        entry_start,
+        entry_stop,
+        entry_offsets,
+        library,
+        branch,
+        options,
     ):
         self.hook_before_final_array(
             basket_arrays=basket_arrays,
@@ -223,6 +240,7 @@ class AsJagged(uproot.interpretation.Interpretation):
             entry_offsets=entry_offsets,
             library=library,
             branch=branch,
+            options=options,
         )
 
         basket_offsets = {}
@@ -316,7 +334,9 @@ class AsJagged(uproot.interpretation.Interpretation):
                 output=output,
             )
 
-        output = library.finalize(output, branch, self, entry_start, entry_stop)
+        output = library.finalize(
+            output, branch, self, entry_start, entry_stop, options
+        )
 
         self.hook_after_final_array(
             basket_arrays=basket_arrays,
@@ -326,6 +346,7 @@ class AsJagged(uproot.interpretation.Interpretation):
             library=library,
             branch=branch,
             output=output,
+            options=options,
         )
 
         return output

--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -87,7 +87,7 @@ class Library:
         """
         return numpy.zeros(shape, dtype)
 
-    def finalize(self, array, branch, interpretation, entry_start, entry_stop):
+    def finalize(self, array, branch, interpretation, entry_start, entry_stop, options):
         """
         Args:
             array (array): Internal, temporary, trimmed array. If this is a
@@ -99,6 +99,8 @@ class Library:
             entry_start (int): First entry that is included in the output.
             entry_stop (int): FIrst entry that is excluded (one greater than
                 the last entry that is included) in the output.
+            options (dict): Flags and other options passed through the
+                interpretation process.
 
         Create a library-appropriate output array for this temporary ``array``.
 
@@ -195,7 +197,7 @@ class NumPy(Library):
 
         return numpy
 
-    def finalize(self, array, branch, interpretation, entry_start, entry_stop):
+    def finalize(self, array, branch, interpretation, entry_start, entry_stop, options):
         if isinstance(array, uproot.interpretation.jagged.JaggedArray) and isinstance(
             array.content,
             uproot.interpretation.objects.StridedObjectArray,
@@ -450,6 +452,13 @@ def _awkward_json_to_array(awkward, form, array):
         raise AssertionError(form["class"])
 
 
+def _awkward_add_doc(awkward, array, branch, ak_add_doc):
+    if ak_add_doc:
+        return awkward.with_parameter(array, "__doc__", branch.title)
+    else:
+        return array
+
+
 class Awkward(Library):
     """
     A :doc:`uproot.interpretation.library.Library` that presents ``TBranch``
@@ -483,15 +492,22 @@ class Awkward(Library):
     def imported(self):
         return uproot.extras.awkward()
 
-    def finalize(self, array, branch, interpretation, entry_start, entry_stop):
+    def finalize(self, array, branch, interpretation, entry_start, entry_stop, options):
         awkward = self.imported
 
+        ak_add_doc = options.get("ak_add_doc", False)
+
         if isinstance(array, awkward.contents.Content):
-            return awkward.Array(array)
+            return _awkward_add_doc(awkward, awkward.Array(array), branch, ak_add_doc)
 
         elif isinstance(array, uproot.interpretation.objects.StridedObjectArray):
-            return awkward.Array(
-                _strided_to_awkward(awkward, "", array.interpretation, array.array)
+            return _awkward_add_doc(
+                awkward,
+                awkward.Array(
+                    _strided_to_awkward(awkward, "", array.interpretation, array.array)
+                ),
+                branch,
+                ak_add_doc,
             )
 
         elif isinstance(array, uproot.interpretation.jagged.JaggedArray) and isinstance(
@@ -506,7 +522,7 @@ class Awkward(Library):
             else:
                 offsets = awkward.index.Index64(array.offsets)
                 layout = awkward.contents.ListOffsetArray(offsets, content)
-            return awkward.Array(layout)
+            return _awkward_add_doc(awkward, awkward.Array(layout), branch, ak_add_doc)
 
         elif isinstance(array, uproot.interpretation.jagged.JaggedArray):
             content = awkward.from_numpy(
@@ -518,7 +534,7 @@ class Awkward(Library):
             else:
                 offsets = awkward.index.Index64(array.offsets)
                 layout = awkward.contents.ListOffsetArray(offsets, content)
-            return awkward.Array(layout)
+            return _awkward_add_doc(awkward, awkward.Array(layout), branch, ak_add_doc)
 
         elif isinstance(array, uproot.interpretation.strings.StringArray):
             content = awkward.contents.NumpyArray(
@@ -542,7 +558,7 @@ class Awkward(Library):
                 )
             else:
                 raise AssertionError(repr(array.offsets.dtype))
-            return awkward.Array(layout)
+            return _awkward_add_doc(awkward, awkward.Array(layout), branch, ak_add_doc)
 
         elif isinstance(interpretation, uproot.interpretation.objects.AsObjects):
             try:
@@ -569,7 +585,12 @@ in object {}""".format(
             unlabeled = awkward.from_iter(
                 (_object_to_awkward_json(form, x) for x in array), highlevel=False
             )
-            return awkward.Array(_awkward_json_to_array(awkward, form, unlabeled))
+            return _awkward_add_doc(
+                awkward,
+                awkward.Array(_awkward_json_to_array(awkward, form, unlabeled)),
+                branch,
+                ak_add_doc,
+            )
 
         elif array.dtype.names is not None:
             length, shape = array.shape[0], array.shape[1:]
@@ -586,10 +607,15 @@ in object {}""".format(
             out = awkward.contents.RecordArray(contents, array.dtype.names, length)
             for size in shape[::-1]:
                 out = awkward.contents.RegularArray(out, size)
-            return awkward.Array(out)
+            return _awkward_add_doc(awkward, awkward.Array(out), branch, ak_add_doc)
 
         else:
-            return awkward.from_numpy(array, regulararray=True)
+            return _awkward_add_doc(
+                awkward,
+                awkward.from_numpy(array, regulararray=True),
+                branch,
+                ak_add_doc,
+            )
 
     def group(self, arrays, expression_context, how):
         awkward = self.imported
@@ -828,7 +854,7 @@ class Pandas(Library):
     def imported(self):
         return uproot.extras.pandas()
 
-    def finalize(self, array, branch, interpretation, entry_start, entry_stop):
+    def finalize(self, array, branch, interpretation, entry_start, entry_stop, options):
         pandas = self.imported
 
         if isinstance(array, uproot.interpretation.objects.StridedObjectArray):

--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -87,7 +87,9 @@ class Library:
         """
         return numpy.zeros(shape, dtype)
 
-    def finalize(self, array, branch, interpretation, entry_start, entry_stop, options):
+    def finalize(
+        self, array, branch, interpretation, entry_start, entry_stop, interp_options
+    ):
         """
         Args:
             array (array): Internal, temporary, trimmed array. If this is a
@@ -99,7 +101,7 @@ class Library:
             entry_start (int): First entry that is included in the output.
             entry_stop (int): FIrst entry that is excluded (one greater than
                 the last entry that is included) in the output.
-            options (dict): Flags and other options passed through the
+            interp_options (dict): Flags and other options passed through the
                 interpretation process.
 
         Create a library-appropriate output array for this temporary ``array``.

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -43,7 +43,14 @@ class Numerical(uproot.interpretation.Interpretation):
         return array
 
     def final_array(
-        self, basket_arrays, entry_start, entry_stop, entry_offsets, library, branch
+        self,
+        basket_arrays,
+        entry_start,
+        entry_stop,
+        entry_offsets,
+        library,
+        branch,
+        options,
     ):
         self.hook_before_final_array(
             basket_arrays=basket_arrays,
@@ -111,7 +118,9 @@ class Numerical(uproot.interpretation.Interpretation):
 
         output = self._wrap_almost_finalized(output)
 
-        output = library.finalize(output, branch, self, entry_start, entry_stop)
+        output = library.finalize(
+            output, branch, self, entry_start, entry_stop, options
+        )
 
         self.hook_after_final_array(
             basket_arrays=basket_arrays,
@@ -323,7 +332,15 @@ class AsDtype(Numerical):
             )
 
     def basket_array(
-        self, data, byte_offsets, basket, branch, context, cursor_offset, library
+        self,
+        data,
+        byte_offsets,
+        basket,
+        branch,
+        context,
+        cursor_offset,
+        library,
+        options,
     ):
         self.hook_before_basket_array(
             data=data,
@@ -333,6 +350,7 @@ class AsDtype(Numerical):
             context=context,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
 
         dtype, shape = _dtype_shape(self._from_dtype)
@@ -360,6 +378,7 @@ in file {}""".format(
             output=output,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
 
         return output
@@ -526,7 +545,15 @@ class TruncatedNumerical(Numerical):
         )
 
     def basket_array(
-        self, data, byte_offsets, basket, branch, context, cursor_offset, library
+        self,
+        data,
+        byte_offsets,
+        basket,
+        branch,
+        context,
+        cursor_offset,
+        library,
+        options,
     ):
         self.hook_before_basket_array(
             data=data,
@@ -536,6 +563,7 @@ class TruncatedNumerical(Numerical):
             context=context,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
 
         try:
@@ -589,6 +617,7 @@ in file {}""".format(
             library=library,
             raw=raw,
             output=output,
+            options=options,
         )
 
         return output

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -113,7 +113,15 @@ class AsObjects(uproot.interpretation.Interpretation):
             return self._model.awkward_form(self._branch.file, context)
 
     def basket_array(
-        self, data, byte_offsets, basket, branch, context, cursor_offset, library
+        self,
+        data,
+        byte_offsets,
+        basket,
+        branch,
+        context,
+        cursor_offset,
+        library,
+        options,
     ):
         self.hook_before_basket_array(
             data=data,
@@ -123,12 +131,20 @@ class AsObjects(uproot.interpretation.Interpretation):
             context=context,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
         assert basket.byte_offsets is not None
 
         if self._forth and isinstance(library, uproot.interpretation.library.Awkward):
             output = self.basket_array_forth(
-                data, byte_offsets, basket, branch, context, cursor_offset, library
+                data,
+                byte_offsets,
+                basket,
+                branch,
+                context,
+                cursor_offset,
+                library,
+                options,
             )
         else:
             output = ObjectArray(
@@ -144,12 +160,21 @@ class AsObjects(uproot.interpretation.Interpretation):
             output=output,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
 
         return output
 
     def basket_array_forth(
-        self, data, byte_offsets, basket, branch, context, cursor_offset, library
+        self,
+        data,
+        byte_offsets,
+        basket,
+        branch,
+        context,
+        cursor_offset,
+        library,
+        options,
     ):
         awkward = uproot.extras.awkward()
         import awkward.forth
@@ -162,6 +187,7 @@ class AsObjects(uproot.interpretation.Interpretation):
             context=context,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
         assert basket.byte_offsets is not None
 
@@ -193,6 +219,7 @@ class AsObjects(uproot.interpretation.Interpretation):
                             output=output,
                             cursor_offset=cursor_offset,
                             library=library,
+                            options=options,
                         )
                         return output
 
@@ -238,6 +265,7 @@ class AsObjects(uproot.interpretation.Interpretation):
             output=output,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
 
         return output
@@ -304,7 +332,14 @@ class AsObjects(uproot.interpretation.Interpretation):
         forth_obj.add_to_final(awkward_model["post_code"])
 
     def final_array(
-        self, basket_arrays, entry_start, entry_stop, entry_offsets, library, branch
+        self,
+        basket_arrays,
+        entry_start,
+        entry_stop,
+        entry_offsets,
+        library,
+        branch,
+        options,
     ):
         self.hook_before_final_array(
             basket_arrays=basket_arrays,
@@ -313,6 +348,7 @@ class AsObjects(uproot.interpretation.Interpretation):
             entry_offsets=entry_offsets,
             library=library,
             branch=branch,
+            options=options,
         )
         trimmed = []
         start = entry_offsets[0]
@@ -358,7 +394,9 @@ class AsObjects(uproot.interpretation.Interpretation):
             output=output,
         )
 
-        output = library.finalize(output, branch, self, entry_start, entry_stop)
+        output = library.finalize(
+            output, branch, self, entry_start, entry_stop, options
+        )
 
         self.hook_after_final_array(
             basket_arrays=basket_arrays,
@@ -368,6 +406,7 @@ class AsObjects(uproot.interpretation.Interpretation):
             library=library,
             branch=branch,
             output=output,
+            options=options,
         )
 
         return output

--- a/src/uproot/interpretation/strings.py
+++ b/src/uproot/interpretation/strings.py
@@ -176,7 +176,15 @@ class AsStrings(uproot.interpretation.Interpretation):
         )
 
     def basket_array(
-        self, data, byte_offsets, basket, branch, context, cursor_offset, library
+        self,
+        data,
+        byte_offsets,
+        basket,
+        branch,
+        context,
+        cursor_offset,
+        library,
+        options,
     ):
         self.hook_before_basket_array(
             data=data,
@@ -186,6 +194,7 @@ class AsStrings(uproot.interpretation.Interpretation):
             context=context,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
         if (
             isinstance(library, uproot.interpretation.library.Awkward)
@@ -306,12 +315,20 @@ class AsStrings(uproot.interpretation.Interpretation):
             output=output,
             cursor_offset=cursor_offset,
             library=library,
+            options=options,
         )
 
         return output
 
     def final_array(
-        self, basket_arrays, entry_start, entry_stop, entry_offsets, library, branch
+        self,
+        basket_arrays,
+        entry_start,
+        entry_stop,
+        entry_offsets,
+        library,
+        branch,
+        options,
     ):
         self.hook_before_final_array(
             basket_arrays=basket_arrays,
@@ -320,6 +337,7 @@ class AsStrings(uproot.interpretation.Interpretation):
             entry_offsets=entry_offsets,
             library=library,
             branch=branch,
+            options=options,
         )
 
         if any(not isinstance(x, StringArray) for x in basket_arrays.values()):
@@ -342,7 +360,9 @@ class AsStrings(uproot.interpretation.Interpretation):
                 branch=branch,
                 output=output,
             )
-            output = library.finalize(output, branch, self, entry_start, entry_stop)
+            output = library.finalize(
+                output, branch, self, entry_start, entry_stop, options
+            )
 
         else:
             basket_offsets = {}
@@ -444,7 +464,9 @@ class AsStrings(uproot.interpretation.Interpretation):
                 output=output,
             )
 
-            output = library.finalize(output, branch, self, entry_start, entry_stop)
+            output = library.finalize(
+                output, branch, self, entry_start, entry_stop, options
+            )
 
         self.hook_after_final_array(
             basket_arrays=basket_arrays,
@@ -454,6 +476,7 @@ class AsStrings(uproot.interpretation.Interpretation):
             library=library,
             branch=branch,
             output=output,
+            options=options,
         )
 
         return output

--- a/src/uproot/models/TBasket.py
+++ b/src/uproot/models/TBasket.py
@@ -69,7 +69,7 @@ class Model_TBasket(uproot.model.Model):
         """
         return self._byte_offsets
 
-    def array(self, interpretation=None, library="ak"):
+    def array(self, interpretation=None, library="ak", ak_add_doc=False):
         """
         The ``TBasket`` data and entry offsets as an array, given an
         :doc:`uproot.interpretation.Interpretation` (or the ``TBranch`` parent's
@@ -80,6 +80,8 @@ class Model_TBasket(uproot.model.Model):
             interpretation = self._parent.interpretation
         library = uproot.interpretation.library._regularize_library(library)
 
+        interp_options = {"ak_add_doc": ak_add_doc}
+
         basket_array = interpretation.basket_array(
             self.data,
             self.byte_offsets,
@@ -88,6 +90,7 @@ class Model_TBasket(uproot.model.Model):
             self._parent.context,
             self._members["fKeylen"],
             library,
+            interp_options,
         )
 
         return interpretation.final_array(
@@ -97,6 +100,7 @@ class Model_TBasket(uproot.model.Model):
             [0, self.num_entries],
             library,
             self._parent,
+            interp_options,
         )
 
     @property

--- a/tests/test_0017-multi-basket-multi-branch-fetch.py
+++ b/tests/test_0017-multi-basket-multi-branch-fetch.py
@@ -70,7 +70,7 @@ def test_stitching_arrays():
     for start in range(16):
         for stop in range(15, -1, -1):
             actual = interpretation.final_array(
-                basket_arrays, start, stop, entry_offsets, library, None
+                basket_arrays, start, stop, entry_offsets, library, None, {}
             )
             assert expectation[start:stop] == actual.tolist()
 
@@ -128,6 +128,7 @@ def test_ranges_or_baskets_to_arrays():
             library,
             arrays,
             False,
+            {},
         )
         assert arrays[branch.cache_key].tolist() == [
             -15,


### PR DESCRIPTION
This is taking over a function from Coffea—adding `TBranch.title` to the `__doc__` parameter of Awkward Arrays—in a centralized way. The only file that is affected to add that feature is library.py (the `Awkward` singleton). Let me know, @lgray, if it works as needed.

All the rest of the changes are to propagate the option down. We don't want to _always_ do this; Coffea just needs a hook to be able to enable it. The `interp_options` mechanism enables us to pass more of these options in in the future.