### PR TITLE
test: make tests parallelizable (custom_classes in uproot.open).

### DIFF
--- a/tests/test_0420-pyroot-uproot-interoperability.py
+++ b/tests/test_0420-pyroot-uproot-interoperability.py
@@ -50,7 +50,8 @@ def test_write_pyroot_TLorentzVector(tmp_path):
     with uproot.recreate(newfile, compression=None) as fout:
         fout["something"] = ROOT.TLorentzVector(1, 2, 3, 4)
 
-    with uproot.open(newfile) as fin:
+    classes = dict(uproot.classes)
+    with uproot.open(newfile, custom_classes=classes) as fin:
         uproot_vec = fin["something"]
         assert uproot_vec.member("fP").member("fX") == 1
         assert uproot_vec.member("fP").member("fY") == 2


### PR DESCRIPTION
I'm going to fast-track this, adding

```diff
@@ -50,7 +50,8 @@ def test_write_pyroot_TLorentzVector(tmp_path):
     with uproot.recreate(newfile, compression=None) as fout:
         fout["something"] = ROOT.TLorentzVector(1, 2, 3, 4)
 
-    with uproot.open(newfile) as fin:
+    classes = dict(uproot.classes)
+    with uproot.open(newfile, custom_classes=classes) as fin:
         uproot_vec = fin["something"]
         assert uproot_vec.member("fP").member("fX") == 1
         assert uproot_vec.member("fP").member("fY") == 2
```

It's always legal to add `custom_classes` to [uproot.open](https://uproot.readthedocs.io/en/latest/uproot.reading.open.html). Doing so in this case prevents a test from modifying a global variable, `uproot.classes`, which makes the test fail offline. Maybe all `uproot.open` calls in the test suite should have their own `custom_classes` so that it's 100% thread-safe (instead of 99% ± 1% thread-safe), but that can be a PR for another day.

Or more ambitiously, maybe we can find the right place to put a lock on the updating of `uproot.classes` so that it can always be modified in parallel threads.

By "fast-track," I mean that I'm going to enable auto-merge without a review, and my next PR (addressing #778, a much bigger PR) can assume that this will be ready in `main`. We may need to formalize when "fast-tracking" is allowed and by whom, but however we formalize that, a case like this one would be allowed.