### PR TITLE
feat: made 'very optional' arguments keyword-only

### DIFF
--- a/src/uproot/__init__.py
+++ b/src/uproot/__init__.py
@@ -187,3 +187,4 @@ from uproot._util import no_filter
 from uproot._dask import dask
 
 from uproot.pyroot import from_pyroot
+from uproot.pyroot import to_pyroot

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -9,6 +9,7 @@ from uproot.behaviors.TBranch import HasBranches, TBranch, _regularize_step_size
 
 def dask(
     files,
+    *,
     filter_name=no_filter,
     filter_typename=no_filter,
     filter_branch=no_filter,

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -571,6 +571,7 @@ class HasBranches(Mapping):
 
     def show(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -48,6 +48,7 @@ def iterate(
     files,
     expressions=None,
     cut=None,
+    *,
     filter_name=no_filter,
     filter_typename=no_filter,
     filter_branch=no_filter,
@@ -226,6 +227,7 @@ def concatenate(
     files,
     expressions=None,
     cut=None,
+    *,
     filter_name=no_filter,
     filter_typename=no_filter,
     filter_branch=no_filter,
@@ -672,6 +674,7 @@ class HasBranches(Mapping):
         self,
         expressions=None,
         cut=None,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -896,6 +899,7 @@ class HasBranches(Mapping):
         self,
         expressions=None,
         cut=None,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1133,6 +1137,7 @@ class HasBranches(Mapping):
 
     def keys(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1170,6 +1175,7 @@ class HasBranches(Mapping):
 
     def values(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1206,6 +1212,7 @@ class HasBranches(Mapping):
 
     def items(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1244,6 +1251,7 @@ class HasBranches(Mapping):
 
     def typenames(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1282,6 +1290,7 @@ class HasBranches(Mapping):
 
     def iterkeys(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1318,6 +1327,7 @@ class HasBranches(Mapping):
 
     def itervalues(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1354,6 +1364,7 @@ class HasBranches(Mapping):
 
     def iteritems(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1423,6 +1434,7 @@ class HasBranches(Mapping):
 
     def itertypenames(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1469,6 +1481,7 @@ class HasBranches(Mapping):
         memory_size,
         expressions=None,
         cut=None,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1553,6 +1566,7 @@ class HasBranches(Mapping):
 
     def common_entry_offsets(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,
@@ -1688,6 +1702,7 @@ class TBranch(HasBranches):
         interpretation=None,
         entry_start=None,
         entry_stop=None,
+        *,
         decompression_executor=None,
         interpretation_executor=None,
         array_cache="inherit",

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -22,6 +22,7 @@ from uproot._util import no_filter
 
 def open(
     path,
+    *,
     object_cache=100,
     array_cache="100 MB",
     custom_classes=None,
@@ -549,6 +550,7 @@ class ReadOnlyFile(CommonFileMethods):
     def __init__(
         self,
         file_path,
+        *,
         object_cache=100,
         array_cache="100 MB",
         custom_classes=None,
@@ -1598,6 +1600,7 @@ class ReadOnlyDirectory(Mapping):
 
     def keys(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -1630,6 +1633,7 @@ class ReadOnlyDirectory(Mapping):
 
     def values(
         self,
+        *,
         recursive=True,
         filter_name=no_filter,
         filter_classname=no_filter,
@@ -1660,6 +1664,7 @@ class ReadOnlyDirectory(Mapping):
 
     def items(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -1693,6 +1698,7 @@ class ReadOnlyDirectory(Mapping):
 
     def classnames(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -1725,6 +1731,7 @@ class ReadOnlyDirectory(Mapping):
 
     def iterkeys(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -1774,6 +1781,7 @@ class ReadOnlyDirectory(Mapping):
 
     def itervalues(
         self,
+        *,
         recursive=True,
         filter_name=no_filter,
         filter_classname=no_filter,
@@ -1804,6 +1812,7 @@ class ReadOnlyDirectory(Mapping):
 
     def iteritems(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -1854,6 +1863,7 @@ class ReadOnlyDirectory(Mapping):
 
     def iterclassnames(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -611,6 +611,7 @@ class WritableDirectory(MutableMapping):
 
     def keys(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -643,6 +644,7 @@ class WritableDirectory(MutableMapping):
 
     def values(
         self,
+        *,
         recursive=True,
         filter_name=no_filter,
         filter_classname=no_filter,
@@ -673,6 +675,7 @@ class WritableDirectory(MutableMapping):
 
     def items(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -706,6 +709,7 @@ class WritableDirectory(MutableMapping):
 
     def classnames(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -738,6 +742,7 @@ class WritableDirectory(MutableMapping):
 
     def iterkeys(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -784,6 +789,7 @@ class WritableDirectory(MutableMapping):
 
     def itervalues(
         self,
+        *,
         recursive=True,
         filter_name=no_filter,
         filter_classname=no_filter,
@@ -814,6 +820,7 @@ class WritableDirectory(MutableMapping):
 
     def iteritems(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -849,6 +856,7 @@ class WritableDirectory(MutableMapping):
 
     def iterclassnames(
         self,
+        *,
         recursive=True,
         cycle=True,
         filter_name=no_filter,
@@ -1152,7 +1160,7 @@ class WritableDirectory(MutableMapping):
 
         return self._subdirs[name]
 
-    def mkdir(self, name, initial_directory_bytes=None):
+    def mkdir(self, name, *, initial_directory_bytes=None):
         """
         Args:
             name (str): Name of the new subdirectory.
@@ -1221,6 +1229,7 @@ in file {} in directory {}""".format(
         name,
         branch_types,
         title="",
+        *,
         counter_name=lambda counted: "n" + counted,
         field_name=lambda outer, inner: inner if outer == "" else outer + "_" + inner,
         initial_basket_capacity=10,
@@ -1315,6 +1324,7 @@ in file {} in directory {}""".format(
     def copy_from(
         self,
         source,
+        *,
         filter_name=no_filter,
         filter_classname=no_filter,
         rename=no_rename,
@@ -1414,7 +1424,12 @@ in file {} in directory {}""".format(
             )
 
         for name, allocation in new_dirs.items():
-            self.mkdir(name, max(self._file.initial_directory_bytes, allocation))
+            self.mkdir(
+                name,
+                initial_directory_bytes=max(
+                    self._file.initial_directory_bytes, allocation
+                ),
+            )
 
         for _ in range(len(ranges)):
             chunk = notifications.get()
@@ -1463,7 +1478,10 @@ in file {} in directory {}""".format(
             path, name = fullpath[:-1], fullpath[-1]
 
             if len(path) != 0:
-                self.mkdir("/".join(path), self._file.initial_directory_bytes)
+                self.mkdir(
+                    "/".join(path),
+                    initial_directory_bytes=self._file.initial_directory_bytes,
+                )
 
             directory = self
             for item in path:
@@ -1752,6 +1770,7 @@ class WritableTree:
 
     def show(
         self,
+        *,
         filter_name=no_filter,
         filter_typename=no_filter,
         filter_branch=no_filter,

--- a/tests/test_0067-common-entry-offsets.py
+++ b/tests/test_0067-common-entry-offsets.py
@@ -27,8 +27,14 @@ def test_common_offsets():
 
     with uproot.open(skhep_testdata.data_path("uproot-small-dy-nooffsets.root")) as f:
         assert f["tree;1"].common_entry_offsets() == [0, 200, 400, 501]
-        assert f["tree;1"].common_entry_offsets(["Jet_pt"]) == [0, 200, 397, 400, 501]
-        assert f["tree;1"].common_entry_offsets(["Jet_pt", "nJet"]) == [
+        assert f["tree;1"].common_entry_offsets(filter_name=["Jet_pt"]) == [
+            0,
+            200,
+            397,
+            400,
+            501,
+        ]
+        assert f["tree;1"].common_entry_offsets(filter_name=["Jet_pt", "nJet"]) == [
             0,
             200,
             400,

--- a/tests/test_0345-bulk-copy-method.py
+++ b/tests/test_0345-bulk-copy-method.py
@@ -33,7 +33,7 @@ def test_bulk_copy(tmp_path):
 
     with uproot.open(source_filename) as source:
         with uproot.recreate(dest_filename) as dest:
-            dest.copy_from(source, "subdir/hist")
+            dest.copy_from(source, filter_name="subdir/hist")
 
     with uproot.open(dest_filename) as dest:
         assert dest.keys() == ["subdir;1", "subdir/hist;1"]

--- a/tests/test_0420-pyroot-uproot-interoperability.py
+++ b/tests/test_0420-pyroot-uproot-interoperability.py
@@ -50,7 +50,8 @@ def test_write_pyroot_TLorentzVector(tmp_path):
     with uproot.recreate(newfile, compression=None) as fout:
         fout["something"] = ROOT.TLorentzVector(1, 2, 3, 4)
 
-    with uproot.open(newfile) as fin:
+    classes = dict(uproot.classes)
+    with uproot.open(newfile, custom_classes=classes) as fin:
         uproot_vec = fin["something"]
         assert uproot_vec.member("fP").member("fX") == 1
         assert uproot_vec.member("fP").member("fY") == 2


### PR DESCRIPTION
This is similar to https://github.com/scikit-hep/awkward/pull/1905, but for Uproot.

Multi-array-fetching functions (`HasBranches.arrays`, `HasBranches.iterate`, `uproot.iterate`, `uproot.concatenate`, `uproot.dask`) can take `expressions` and `cut` as positional, but `filter_name` onward are all keyword-only. Similarly, `common_entry_offsets` takes `filter_name` onward as keyword-only (no positional arguments).

The single-array fetching function (`TBranch.array`) can take `interpretation`, `entry_start`, and `entry_stop` as positional, but `decompression_executor` onward are all keyword-only.

`uproot.open` and `ReadOnlyFile` can take `file_path` as positional, but the rest are keyword-only.

`ReadOnlyDirectory` and `HasBranches` (`TTree` and `TBranch`) have mapping-like functions (`keys`, `values`, `items`, `iterkeys`, `itervalues`, `iteritems`, and the special `classnames`, `iterclassnames`, `typenames`, `itertypenames`), which take a bunch of boolean flag arguments, all now keyword-only.

`WritableDirectory.mkdir` takes a positional `name`, but keyword-only `initial_directory_bytes`.

`WritableDirectory.mktree` takes positional `name`, `branch_types`, and `title`, but all of the advanced options are now keyword-only.

`HasBranches.show` and `WritableTTree.show` now have no positional arguments; all arguments from `filter_name` onward are keyword-only.