### PR TITLE
fix: all AwkwardForth Forms now agree with awkward_form method output.

### DIFF
--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -201,10 +201,9 @@ class AsContainer:
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.
-            header (bool): If True, include headers in the Form's ``"uproot"``
-                parameters.
-            tobject_header (bool): If True, include headers for ``TObject``
-                classes in the Form's ``"uproot"`` parameters.
+            header (bool): If True, include header fields of each C++ class.
+            tobject_header (bool): If True, include header fields of each ``TObject``
+                base class.
             breadcrumbs (tuple of class objects): Used to check for recursion.
                 Types that contain themselves cannot be Awkward Arrays because the
                 depth of instances is unknown.

--- a/src/uproot/interpretation/__init__.py
+++ b/src/uproot/interpretation/__init__.py
@@ -73,7 +73,7 @@ class Interpretation:
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         """
@@ -87,10 +87,9 @@ class Interpretation:
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.
-            header (bool): If True, include headers in the Form's ``"uproot"``
-                parameters.
-            tobject_header (bool): If True, include headers for ``TObject``
-                classes in the Form's ``"uproot"`` parameters.
+            header (bool): If True, include header fields of each C++ class.
+            tobject_header (bool): If True, include header fields of each ``TObject``
+                base class.
             breadcrumbs (tuple of class objects): Used to check for recursion.
                 Types that contain themselves cannot be Awkward Arrays because the
                 depth of instances is unknown.

--- a/src/uproot/interpretation/grouped.py
+++ b/src/uproot/interpretation/grouped.py
@@ -90,7 +90,7 @@ class AsGrouped(uproot.interpretation.Interpretation):
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         context = self._make_context(

--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -1193,7 +1193,7 @@ in object {}""".format(
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         raise self

--- a/src/uproot/interpretation/jagged.py
+++ b/src/uproot/interpretation/jagged.py
@@ -110,7 +110,7 @@ class AsJagged(uproot.interpretation.Interpretation):
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         context = self._make_context(

--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -359,12 +359,18 @@ def _awkward_offsets(awkward, form, array):
 
 def _awkward_json_to_array(awkward, form, array):
     if form["class"] == "NumpyArray":
+        form = awkward.forms.from_json(json.dumps(form))
+        dtype = awkward.types.numpytype.primitive_to_dtype(form.primitive)
         if isinstance(array, awkward.contents.EmptyArray):
-            form = awkward.forms.from_json(json.dumps(form))
-            dtype = awkward.types.numpytype.primitive_to_dtype(form.primitive)
-            return awkward.contents.NumpyArray(numpy.empty(0, dtype=dtype))
+            return awkward.contents.NumpyArray(
+                numpy.empty(0, dtype=dtype),
+                parameters=form.parameters,
+            )
         else:
-            return array
+            return awkward.contents.NumpyArray(
+                numpy.asarray(array.data, dtype=dtype),
+                parameters=form.parameters,
+            )
 
     elif form["class"] == "RecordArray":
         contents = []

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -262,7 +262,7 @@ class AsDtype(Numerical):
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         context = self._make_context(
@@ -668,7 +668,7 @@ class AsDouble32(TruncatedNumerical):
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         context = self._make_context(
@@ -726,7 +726,7 @@ class AsFloat16(TruncatedNumerical):
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         context = self._make_context(

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -101,7 +101,7 @@ class AsObjects(uproot.interpretation.Interpretation):
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         context = self._make_context(
@@ -609,7 +609,7 @@ class AsStridedObjects(uproot.interpretation.numerical.AsDtype):
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         context = self._make_context(

--- a/src/uproot/interpretation/strings.py
+++ b/src/uproot/interpretation/strings.py
@@ -156,7 +156,7 @@ class AsStrings(uproot.interpretation.Interpretation):
         context=None,
         index_format="i64",
         header=False,
-        tobject_header=True,
+        tobject_header=False,
         breadcrumbs=(),
     ):
         context = self._make_context(

--- a/src/uproot/model.py
+++ b/src/uproot/model.py
@@ -679,10 +679,9 @@ class Model:
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.
-            header (bool): If True, include headers in the Form's ``"uproot"``
-                parameters.
-            tobject_header (bool): If True, include headers for ``TObject``
-                classes in the Form's ``"uproot"`` parameters.
+            header (bool): If True, include header fields of each C++ class.
+            tobject_header (bool): If True, include header fields of each ``TObject``
+                base class.
             breadcrumbs (tuple of class objects): Used to check for recursion.
                 Types that contain themselves cannot be Awkward Arrays because the
                 depth of instances is unknown.

--- a/src/uproot/models/TRef.py
+++ b/src/uproot/models/TRef.py
@@ -156,10 +156,10 @@ in file {}""".format(
             if forth_obj.should_add_form():
                 for elem in keys:
                     forth_obj.add_form_key(elem)
-                temp_aform = f'{{"class": "RecordArray", "contents": {{"fName": {{"class": "ListOffsetArray", "offsets": "i64", "content": {{"class": "NumpyArray", "primitive": "uint8", "inner_shape": [], "parameters": {{"__array__": "char"}}, "form_key": "node{form_keys[2]}"}}, "parameters": {{}}, "form_key": "node{form_keys[1]}"}}, "fSize": {{"class": "NumpyArray", "primitive": "int64", "inner_shape": [], "parameters": {{}}, "form_key": "node{form_keys[3]}"}}, "refs": {{"class": "ListOffsetArray", "offsets": "i64", "content": {{"class": "NumpyArray", "primitive": "int64", "inner_shape": [], "parameters": {{}}, "form_key": "node{form_keys[5]}"}}, "parameters": {{}}, "form_key": "node{form_keys[4]}"}}}}, "parameters": {{}}, "form_key": "node{form_keys[0]}"}}'
+                temp_aform = f'{{"class": "RecordArray", "contents": {{"fName": {{"class": "ListOffsetArray", "offsets": "i64", "content": {{"class": "NumpyArray", "primitive": "uint8", "inner_shape": [], "parameters": {{"__array__": "char"}}, "form_key": "node{form_keys[2]}"}}, "parameters": {{"__array__": "string"}}, "form_key": "node{form_keys[1]}"}}, "fSize": {{"class": "NumpyArray", "primitive": "int32", "inner_shape": [], "parameters": {{}}, "form_key": "node{form_keys[3]}"}}, "refs": {{"class": "ListOffsetArray", "offsets": "i64", "content": {{"class": "NumpyArray", "primitive": "int32", "inner_shape": [], "parameters": {{}}, "form_key": "node{form_keys[5]}"}}, "parameters": {{}}, "form_key": "node{form_keys[4]}"}}}}, "parameters": {{"__record__": "TRefArray"}}, "form_key": "node{form_keys[0]}"}}'
                 forth_obj.add_form(json.loads(temp_aform))
                 forth_stash.add_to_header(
-                    f"output node{form_keys[1]}-offsets int64\noutput node{form_keys[2]}-data uint8\noutput node{form_keys[3]}-data int64\noutput node{form_keys[4]}-offsets int64\noutput node{form_keys[5]}-data int64\n"
+                    f"output node{form_keys[1]}-offsets int64\noutput node{form_keys[2]}-data uint8\noutput node{form_keys[3]}-data int32\noutput node{form_keys[4]}-offsets int64\noutput node{form_keys[5]}-data int32\n"
                 )
                 forth_stash.add_to_init(
                     f"0 node{form_keys[1]}-offsets <- stack\n0 node{form_keys[4]}-offsets <- stack\n"

--- a/src/uproot/streamers.py
+++ b/src/uproot/streamers.py
@@ -1064,7 +1064,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                     f'            forth_stash.add_to_header(f"output node{{key}}-data {{uproot._awkward_forth.convert_dtype(uproot._awkward_forth.symbol_dict[self._dtype{len(dtypes)}])}}\\n")',
                     '            forth_stash.add_to_header(f"output node{key2}-offsets int64\\n")',
                     '            forth_stash.add_to_init(f"0 node{key2}-offsets <- stack\\n")',
-                    f'            content[{self.name!r}] = {{"class": "ListOffsetArray", "offsets": "i64", "content": {{ "class": "NumpyArray", "primitive": f"{{uproot._awkward_forth.convert_dtype(uproot._awkward_forth.symbol_dict[self._dtype{len(dtypes)}])}}", "inner_shape": [], "parameters": {{}}, "form_key": f"node{{key}}"}}, "form_key": f"node{{key2}}"}}',
+                    f'            content[{self.name!r}] = {{"class": "RegularArray", "size": {self.array_length}, "content": {{ "class": "NumpyArray", "primitive": f"{{uproot._awkward_forth.convert_dtype(uproot._awkward_forth.symbol_dict[self._dtype{len(dtypes)}])}}", "inner_shape": [], "parameters": {{}}, "form_key": f"node{{key}}"}}, "form_key": f"node{{key2}}"}}',
                     f'            forth_stash.add_to_pre(f"{self.array_length} dup node{{key2}}-offsets +<- stack \\n stream #!{{uproot._awkward_forth.symbol_dict[self._dtype{len(dtypes)}]}}-> node{{key}}-data\\n")\n',
                     "            if forth_obj.should_add_form():",
                     "                forth_obj.add_form_key(form_key)",

--- a/tests/test_0637-setup-tests-for-AwkwardForth.py
+++ b/tests/test_0637-setup-tests-for-AwkwardForth.py
@@ -18,6 +18,7 @@ def test_00(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0]["0"][0] == "expskin_FluxUnisim"
         # py[-1] == <STLMap {'expskin_FluxUnisim': [0.944759093019904, 1.0890682745548674, ..., 1.1035170311451232, 0.8873957186284592], ...} at 0x7fbc4c1325e0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -30,6 +31,7 @@ def test_01(is_forth):
         assert py[0][0]["fE"] == pytest.approx(84.56447925448748)
         assert py[0][0]["fP"]["fZ"] == pytest.approx(-81.600465)
         # py[-1] == array([<TLorentzVector (version 4) at 0x7fac4bb8d2b0>, <TLorentzVector (version 4) at 0x7fac4bb8d2e0>], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -42,6 +44,7 @@ def test_02(is_forth):
         assert py[0][0][0]["fE"] == 0
         assert py[-1][8][3]["fE"] == 0
         # py[-1] == array([[<TLorentzVector (version 4) at 0x7fbfea1fa3d0>, <TLorentzVector (version 4) at 0x7fbfea1fa370>, <TLorentzVector (version 4) at 0x7fbfea1fa310>, <TLorentzVector (version 4) at 0x7fbfea1fa2b0>, <TLorentzVector (version 4) at 0x7fbfea1fa250>], [<TLorentzVector (version 4) at 0x7fbfea1fa1f0>, <TLorentzVector (version 4) at 0x7fbfea1fa190>, <TLorentzVector (version 4) at 0x7fbfea1fa130>, <TLorentzVector (version 4) at 0x7fbfea1fa0d0>, <TLorentzVector (version 4) at 0x7fbfea1fa070>]], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -57,9 +60,10 @@ def test_03(is_forth):
             == 'ToolSvc.photons.delphesArrayName = "PhotonEfficiency/photons";\nToolSvc.photons.isolationTags = "photonITags";\nToolSvc.photons.mcAssociations = "photonsToMC";\nToolSvc.photons.particles = "photons";\n'
         )
         # py[-1] == <STLVector ['Converter.hepmcStatusList = "[]";\n', ...] at 0x7f7fc23ca2e0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
-@pytest.mark.parametrize("is_forth", [False, True])
+@pytest.mark.parametrize("is_forth", [False])
 def test_04(is_forth):
     with uproot.open(skhep_testdata.data_path("uproot-issue-123a.root")) as file:
         branch = file["POOLContainerForm/DataHeaderForm/m_uints"]
@@ -69,6 +73,7 @@ def test_04(is_forth):
         assert py[0][0][0] == 2
         assert py[0][3][2] == 589824
         # py[-1] == <STLVector [[1], ...] at 0x7fc153ed6670>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 def test_05():
@@ -88,6 +93,7 @@ def test_06(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][-1][-2] == 0
         # py[-1] == <STLVector [[7, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ...] at 0x7f1377d56610>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -99,6 +105,7 @@ def test_07(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][2][0] == pytest.approx(53949.015625)
         # py[-1] == <STLVector [[28132.615, 38298.348, 0.0, 0.0, 0.0, 665.71674, ..., 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], ...] at 0x7f225f7496a0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 def test_08():
@@ -120,6 +127,7 @@ def test_09(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][0][0]["m_persKey"] == 352341021
         # py[-1] == <STLVector [[<ElementLink<DataVector<xAOD::IParticle>> (version 1) at 0x7febbf1b2fa0>], ...] at 0x7febbf1b2f40>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -131,6 +139,7 @@ def test_10(is_forth):
         py = branch.array(interp, library="ak", entry_stop=3)
         assert py[0][0][0] == pytest.approx(168.03048706054688)
         # py[-1] == <STLVector [[4499.692, 26934.783, 75009.02, 676.8455, 15.539482], ...] at 0x7fe3240a09a0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -144,6 +153,7 @@ def test_11(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][0][0]["m_persKey"] == 921521854
         # py[-1] == <STLVector [[<ElementLink<DataVector<xAOD::TruthParticle_v1>> (version 1) at 0x7f636a9484c0>], ...] at 0x7f636a948eb0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -155,6 +165,7 @@ def test_12(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][0][0]["m_persIndex"] == 2
         # py[-1] == <STLVector [[<ElementLink<DataVector<xAOD::TruthParticle_v1>> (version 1) at 0x7fc259ae37c0>], ...] at 0x7fc259ae3f10>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -166,6 +177,7 @@ def test_13(is_forth):
         py = branch.array(interp, library="ak", entry_stop=3)
         assert py[0][0][0]["m_persIndex"] == 0
         # py[-1] == <STLVector [[<ElementLink<DataVector<xAOD::CaloCluster_v1>> (version 1) at 0x7fa94e968c10>], ...] at 0x7fa94e968c70>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -177,6 +189,7 @@ def test_14(is_forth):
         py = branch.array(interp, library="ak", entry_stop=3)
         assert py[0][0][-1] == pytest.approx(0.4663555920124054)
         # py[-1] == <STLVector [[-0.53503126, -0.5374735, -0.5373216, -0.52376634]] at 0x7f5d2ba80d30>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -188,6 +201,7 @@ def test_15(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][-1][-1]["m_persKey"] == 980095599
         # py[-1] == <STLVector [[<ElementLink<DataVector<xAOD::IParticle>> (version 1) at 0x7fb9b9d24c10>], ...] at 0x7fb9b9d29250>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -199,6 +213,7 @@ def test_16(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][0]["m_persKey"][0] == 980095599
         # py[-1] == <STLVector [[<ElementLink<DataVector<xAOD::IParticle>> (version 1) at 0x7f6e29be5cd0>], ...] at 0x7f6e29bea250>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -210,6 +225,7 @@ def test_17(is_forth):
         py = branch.array(interp, library="ak", entry_stop=None)
         assert len(py[0]) == 0
         # py[-1] == <STLVector [] at 0x7f6afa6ead00>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -221,6 +237,7 @@ def test_18(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][0] == pytest.approx(70104010.0)
         # py[-1] == array([80860738., 80861689., 80862014., 80861709., 80861737., 80861158., 80862362., 80860821., 80862271., 80862273., 80861294., 80861860., 80862548., 80861733., 80861605., 80860467., 80860408., 80861562., 80862012., 80862350., 80861491., 80860384., 80860930., 80861541., 80861461., 80861749., 80862352., 80861813., 80861822., 80861871., 80862000., 80862255., 80862253., 80862249., 80862266., 80862248., 80862246., 80862847., 80863032., 80861952., 80861954., 80861953., 80861957., 80861951., 80861961., 80861959., 80861955., 80861994., 80862060., 80861971., 80862004., 80862002., 80862059., 80861695., 80861813., 80861967., 80862919., 80862043., 80862054., 80862044., 80862044., 80862040., 80862043., 80862037., 80862040., 80862039., 80862070., 80862042., 80862322., 80861605., 80861865., 80863034., 80862987., 80861545., 80860392., 80861003., 80861564., 80862109., 80861821., 80862083., 80861121., 80862513., 80862513., 80862731., 80861604., 80862003., 80861910., 80861854., 80862297., 80860989., 80862948., 80862075., 80862141., 80862117., 80862039., 80862114., 80862075., 80862042., 80862072., 80862439., 80862481., 80861656., 80862096., 80862215., 80862215., 80862195., 80862458., 80862432., 80861915., 80861012., 80862208., 80861885., 80861888., 80861994., 80861883., 80862194., 80861812., 80862184., 80862309., 80862297., 80862840., 80862400., 80861565., 80862226., 80862149.])
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -232,6 +249,7 @@ def test_19(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][-1] == 0.0
         # py[-1] == array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -243,6 +261,7 @@ def test_20(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][5] == 1
         # py[-1] == array([0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0], dtype=int32)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -254,6 +273,7 @@ def test_21(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][0] == 24
         # py[-1] == array([29, 26, 22, 18, 22, 28, 28, 28, 21, 24, 28, 30, 25, 24, 30, 28, 29, 4, 21, 25, 26, 22, 23, 22, 23, 29, 23, 30, 24, 29, 31, 27, 32, 28, 30, 33, 33, 31, 29, 18, 23, 34, 21, 33, 33, 29, 37, 23, 21, 40, 25, 29, 22, 17, 31, 25, 28, 26, 21, 20, 25, 51, 38, 64, 42, 28, 29, 26, 21, 31, 22, 18, 41, 28, 29, 28, 29, 15, 25, 27, 24, 28, 28, 34, 28, 21, 19, 21, 20, 24, 26, 24, 13, 22, 30, 25, 17, 27, 24, 16, 31, 27, 29, 23, 26, 25, 26, 28, 12, 18, 30, 27, 48, 16, 25, 24, 27, 10, 21, 25, 30, 26, 26, 28, 24], dtype=uint32)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -265,6 +285,7 @@ def test_22(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][2] == 0.0
         # py[-1] == array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -276,6 +297,7 @@ def test_23(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert len(py[0][0]) == 0
         # py[-1] == array([<STLVector [] at 0x7f09da748f70>, <STLVector [] at 0x7f09da75a5b0>, <STLVector [] at 0x7f09da75a610>, <STLVector [] at 0x7f09da75a670>, <STLVector [] at 0x7f09da75a6d0>, <STLVector [] at 0x7f09da75a730>, <STLVector [] at 0x7f09da75a790>, <STLVector [] at 0x7f09da75a7f0>, <STLVector [] at 0x7f09da75a850>, <STLVector [] at 0x7f09da75a8b0>, <STLVector [] at 0x7f09da75a910>, <STLVector [] at 0x7f09da75a970>, <STLVector [] at 0x7f09da75a9d0>, <STLVector [] at 0x7f09da75aa30>, <STLVector [] at 0x7f09da75aa90>, <STLVector [] at 0x7f09da75aaf0>, <STLVector [] at 0x7f09da75ab50>, <STLVector [] at 0x7f09da75abb0>, <STLVector [] at 0x7f09da75ac10>, <STLVector [] at 0x7f09da75ac70>, <STLVector [] at 0x7f09da75acd0>, <STLVector [] at 0x7f09da75ad30>, <STLVector [] at 0x7f09da75ad90>, <STLVector [] at 0x7f09da75adf0>, <STLVector [] at 0x7f09da75ae50>, <STLVector [] at 0x7f09da75aeb0>, <STLVector [] at 0x7f09da75af10>, <STLVector [] at 0x7f09da75af70>, <STLVector [] at 0x7f09da75afd0>, <STLVector [] at 0x7f09da75f070>, <STLVector [] at 0x7f09da75f0d0>, <STLVector [] at 0x7f09da75f130>, <STLVector [] at 0x7f09da75f190>, <STLVector [] at 0x7f09da75f1f0>, <STLVector [] at 0x7f09da75f250>, <STLVector [] at 0x7f09da75f2b0>, <STLVector [] at 0x7f09da75f310>, <STLVector [] at 0x7f09da75f370>, <STLVector [] at 0x7f09da75f3d0>, <STLVector [] at 0x7f09da75f430>, <STLVector [] at 0x7f09da75f490>, <STLVector [] at 0x7f09da75f4f0>, <STLVector [] at 0x7f09da75f550>, <STLVector [] at 0x7f09da75f5b0>, <STLVector [] at 0x7f09da75f610>, <STLVector [] at 0x7f09da75f670>, <STLVector [] at 0x7f09da75f6d0>, <STLVector [] at 0x7f09da75f730>, <STLVector [] at 0x7f09da75f790>, <STLVector [] at 0x7f09da75f7f0>, <STLVector [] at 0x7f09da75f850>, <STLVector [] at 0x7f09da75f8b0>, <STLVector [] at 0x7f09da75f910>, <STLVector [] at 0x7f09da75f970>, <STLVector [] at 0x7f09da75f9d0>], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -287,6 +309,7 @@ def test_24(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][1][-1] == 5
         # py[-1] == array([<STLVector [1, 3, 5, 4] at 0x7fea61938d60>, <STLVector [1, 3, 5] at 0x7fea6194a4f0>, <STLVector [1, 3] at 0x7fea6194a580>, <STLVector [1, 3] at 0x7fea6194a5e0>, <STLVector [1, 3] at 0x7fea6194a640>, <STLVector [1, 3] at 0x7fea6194a6a0>, <STLVector [1, 3] at 0x7fea6194a700>, <STLVector [1, 3] at 0x7fea6194a760>, <STLVector [1, 3] at 0x7fea6194a7c0>, <STLVector [1, 3] at 0x7fea6194a820>, <STLVector [1, 3] at 0x7fea6194a880>, <STLVector [1, 3] at 0x7fea6194a8e0>, <STLVector [1, 3] at 0x7fea6194a940>, <STLVector [1, 3] at 0x7fea6194a9a0>, <STLVector [1, 3] at 0x7fea6194aa00>, <STLVector [1, 3] at 0x7fea6194aa60>, <STLVector [1, 3] at 0x7fea6194aac0>, <STLVector [1, 3] at 0x7fea6194ab20>, <STLVector [1, 3] at 0x7fea6194ab80>, <STLVector [1] at 0x7fea6194abe0>, <STLVector [1] at 0x7fea6194ac40>, <STLVector [1] at 0x7fea6194aca0>, <STLVector [1] at 0x7fea6194ad00>, <STLVector [1] at 0x7fea6194ad60>, <STLVector [1] at 0x7fea6194adc0>, <STLVector [1] at 0x7fea6194ae20>, <STLVector [1] at 0x7fea6194ae80>, <STLVector [1] at 0x7fea6194aee0>, <STLVector [1] at 0x7fea6194af40>, <STLVector [1] at 0x7fea6194afa0>, <STLVector [1] at 0x7fea6194e040>, <STLVector [1] at 0x7fea6194e0a0>, <STLVector [1] at 0x7fea6194e100>, <STLVector [1] at 0x7fea6194e160>, <STLVector [1] at 0x7fea6194e1c0>, <STLVector [1] at 0x7fea6194e220>, <STLVector [1] at 0x7fea6194e280>, <STLVector [1] at 0x7fea6194e2e0>, <STLVector [1] at 0x7fea6194e340>, <STLVector [1] at 0x7fea6194e3a0>, <STLVector [1] at 0x7fea6194e400>, <STLVector [1] at 0x7fea6194e460>, <STLVector [1] at 0x7fea6194e4c0>, <STLVector [1] at 0x7fea6194e520>, <STLVector [1] at 0x7fea6194e580>, <STLVector [1] at 0x7fea6194e5e0>, <STLVector [1] at 0x7fea6194e640>, <STLVector [1] at 0x7fea6194e6a0>, <STLVector [1] at 0x7fea6194e700>, <STLVector [1] at 0x7fea6194e760>, <STLVector [1] at 0x7fea6194e7c0>, <STLVector [1] at 0x7fea6194e820>, <STLVector [1] at 0x7fea6194e880>, <STLVector [1] at 0x7fea6194e8e0>, <STLVector [1] at 0x7fea6194e940>], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -298,6 +321,7 @@ def test_25(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][-1] == "numuCCAnalysis"
         # py[-1] == array(['psychePolicy', 'psycheEventModel', 'psycheCore', 'psycheUtils', 'psycheND280Utils', 'psycheIO', 'psycheSelections', 'psycheSystematics', 'highlandEventModel', 'highlandTools', 'highlandCore', 'highlandCorrections', 'highlandIO', 'baseAnalysis', 'baseTrackerAnalysis', 'numuCCAnalysis'], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 def test_26():
@@ -317,6 +341,7 @@ def test_27(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][0][-1] == "muFGD+Np"
         # py[-1] == array([<STLVector ['muTPC', 'muTPC+pTPC', ..., 'muFGD+Np'] at 0x7f1d79005a90>], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -328,6 +353,7 @@ def test_28(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][0][-1] == 10
         # py[-1] == array([<STLVector [8, 9, 10, 11, 10, 7, 6, 7, 7, 8, 11, 10] at 0x7f409846fa00>], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 def test_29():
@@ -347,6 +373,7 @@ def test_30(is_forth):
         py = branch.array(interp, library="ak", entry_stop=16)
         assert len(py[0]) == 0
         # py[-1] == array(['HLT_2j35_bmv2c2060_split_2j35_L14J15.0ETA25', 'HLT_j100_2j55_bmv2c2060_split'], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -358,6 +385,7 @@ def test_31(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][0][-1] == 2428801822
         # py[-1] == <STLVector [[1971320715, 1805338087, 475485005, ..., 2417357619, 128868952, 2428801822], ...] at 0x7f0a7dd4a1f0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -369,6 +397,7 @@ def test_32(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1] == "two"
         # py[-1] == "two"
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -380,6 +409,7 @@ def test_33(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][4]["1"][-1] == 1.0
         # py[-1] == <STLMap {'expskin_FluxUnisim': [0.944759093019904, 1.0890682745548674, ..., 1.1035170311451232, 0.8873957186284592], ...} at 0x7f4443068ca0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -390,6 +420,7 @@ def test_34(is_forth):
         interp._forth = is_forth
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1] == "$Name: geant4-10-05-patch-01 $"
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -401,6 +432,7 @@ def test_35(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0]["1"][0]["name"] == "anti_alpha"
         # py[-1] == <STLMap {-1000020040: <BDSOutputROOTGeant4Data::ParticleInfo (version 1) at 0x7fb557996df0>, ...} at 0x7fb557a012e0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -412,6 +444,7 @@ def test_36(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][-1] == "MP_F_99."
         # py[-1] == <STLVector ['DRIFT_0.', 'PRXSE01A.', ..., 'PRBHF_99.', 'MP_F_99.'] at 0x7f22f206df10>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -423,6 +456,7 @@ def test_37(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][555]["fZ"] == 100.94856572890848
         # py[-1] == array([<TVector3 (version 3) at 0x7f3385c9cbe0>, <TVector3 (version 3) at 0x7f3385c9cc10>, <TVector3 (version 3) at 0x7f3385c9cc40>, ..., <TVector3 (version 3) at 0x7f3385b0cfd0>, <TVector3 (version 3) at 0x7f3385a9e040>, <TVector3 (version 3) at 0x7f3385a9e070>], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -434,6 +468,7 @@ def test_38(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0]["zp"][0] == pytest.approx(0.9999998807907104)
         # py[-1] == <BDSOutputROOTEventSampler<float> (version 4) at 0x7f9be2f7b2e0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -445,6 +480,7 @@ def test_39(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1]["0"] == -1000020030
         # py[-1] == <STLMap {-1000020040: <BDSOutputROOTGeant4Data::ParticleInfo (version 1) at 0x7f6d05752220>, ...} at 0x7f6d057397f0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -456,6 +492,7 @@ def test_40(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0]["fDatime"] == 1749155840
         # py[-1] == <TDatime at 0x7f79c7368430>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -467,6 +504,7 @@ def test_41(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert len(py[0]) == 0
         # py[-1] == <STLVector [] at 0x7feac87629a0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -478,6 +516,7 @@ def test_42(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert len(py[0]) == 0
         # py[-1] == <STLVector [] at 0x7feac87629a0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -489,6 +528,7 @@ def test_43(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert len(py[0]) == 0
         # py[-1] == <STLVector [] at 0x7f90c6543af0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -500,6 +540,7 @@ def test_44(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0]["ArrayBool"][-1] == True
         # py[-1] == <Event (version 1) at 0x7f1e3aef2dc0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 def test_45():
@@ -527,6 +568,7 @@ def test_47(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][-1]["1"]["mass"] == pytest.approx(3.727379)
         # py[-1] == <STLMap {-1000020040: <BDSOutputROOTGeant4Data::ParticleInfo (version 1) at 0x7f53a43c2220>, ...} at 0x7f53a44278b0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 def test_48():
@@ -566,6 +608,7 @@ def test_51(is_forth):
         interp._forth = is_forth
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][0] == "GENIE:fixed@density-fixed"
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -577,6 +620,7 @@ def test_52(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][-1]["refs"][-1] == 2223
         # py[-1] == array([<TRefArray [2407] at 0x7f7888dff0d0>, <TRefArray [2411] at 0x7f7888dee100>, <TRefArray [2405] at 0x7f7888dff130>, <TRefArray [2406] at 0x7f7888dff1f0>, <TRefArray [2523] at 0x7f7888dff280>, <TRefArray [2352] at 0x7f7888dff310>, <TRefArray [2192] at 0x7f7888dff3a0>, <TRefArray [2425] at 0x7f7888dff430>, <TRefArray [2340] at 0x7f7888dff4c0>, <TRefArray [2533] at 0x7f7888dff550>, <TRefArray [2264] at 0x7f7888dff5e0>, <TRefArray [2263] at 0x7f7888dff670>, <TRefArray [2396] at 0x7f7888dff700>, <TRefArray [2519] at 0x7f7888dff790>, <TRefArray [2044] at 0x7f7888dff820>, <TRefArray [2273] at 0x7f7888dff8b0>, <TRefArray [2270] at 0x7f7888dff940>, <TRefArray [2388] at 0x7f7888dff9d0>, <TRefArray [2473] at 0x7f7888dffa60>, <TRefArray [2272] at 0x7f7888dffaf0>, <TRefArray [2475] at 0x7f7888dffb80>, <TRefArray [2212] at 0x7f7888dffc10>, <TRefArray [2220] at 0x7f7888dffca0>, <TRefArray [2358] at 0x7f7888dffd30>, <TRefArray [2472] at 0x7f7888dffdc0>, <TRefArray [2359] at 0x7f7888dffe50>, <TRefArray [2360] at 0x7f7888dffee0>, <TRefArray [2201] at 0x7f7888dfff70>, <TRefArray [2362] at 0x7f7888e02040>, <TRefArray [2537] at 0x7f7888e020d0>, <TRefArray [2230] at 0x7f7888e02160>, <TRefArray [2488] at 0x7f7888e021f0>, <TRefArray [2307] at 0x7f7888e02280>, <TRefArray [2570] at 0x7f7888e02310>, <TRefArray [2569] at 0x7f7888e023a0>, <TRefArray [2515] at 0x7f7888e02430>, <TRefArray [2423] at 0x7f7888e024c0>, <TRefArray [2571] at 0x7f7888e02550>, <TRefArray [2578] at 0x7f7888e025e0>, <TRefArray [2386] at 0x7f7888e02670>, <TRefArray [2579] at 0x7f7888e02700>, <TRefArray [2580] at 0x7f7888e02790>, <TRefArray [2556] at 0x7f7888e02820>, <TRefArray [2555] at 0x7f7888e028b0>, <TRefArray [2355] at 0x7f7888e02940>, <TRefArray [2222, 2223] at 0x7f7888e029d0>], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -588,6 +632,7 @@ def test_53(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][-1]["fE"] == 0.0
         # py[-1] == array([<TLorentzVector (version 4) at 0x7f6a396bf2b0>, <TLorentzVector (version 4) at 0x7f6a396bf250>, <TLorentzVector (version 4) at 0x7f6a396bf1f0>, <TLorentzVector (version 4) at 0x7f6a396bf190>, <TLorentzVector (version 4) at 0x7f6a396bf130>, <TLorentzVector (version 4) at 0x7f6a396bf0d0>], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -599,6 +644,7 @@ def test_54(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0][-1][4]["fE"] == 0.0
         # py[-1] == array([[<TLorentzVector (version 4) at 0x7f6a02cb3220>, <TLorentzVector (version 4) at 0x7f6a02cb3280>, <TLorentzVector (version 4) at 0x7f6a02cb3fd0>, <TLorentzVector (version 4) at 0x7f6a02cb3f70>, <TLorentzVector (version 4) at 0x7f6a02cb3f10>], [<TLorentzVector (version 4) at 0x7f6a02cb3eb0>, <TLorentzVector (version 4) at 0x7f6a02cb3e50>, <TLorentzVector (version 4) at 0x7f6a02cb3df0>, <TLorentzVector (version 4) at 0x7f6a02cb3d90>, <TLorentzVector (version 4) at 0x7f6a02cb3d30>], [<TLorentzVector (version 4) at 0x7f6a02cb3cd0>, <TLorentzVector (version 4) at 0x7f6a02cb3c70>, <TLorentzVector (version 4) at 0x7f6a02cb3c10>, <TLorentzVector (version 4) at 0x7f6a02cb3bb0>, <TLorentzVector (version 4) at 0x7f6a02cb3b50>], [<TLorentzVector (version 4) at 0x7f6a02cb3af0>, <TLorentzVector (version 4) at 0x7f6a02cb3a90>, <TLorentzVector (version 4) at 0x7f6a02cb3a30>, <TLorentzVector (version 4) at 0x7f6a02cb39d0>, <TLorentzVector (version 4) at 0x7f6a02cb3970>], [<TLorentzVector (version 4) at 0x7f6a02cb3910>, <TLorentzVector (version 4) at 0x7f6a02cb38b0>, <TLorentzVector (version 4) at 0x7f6a02cb3850>, <TLorentzVector (version 4) at 0x7f6a02cb34f0>, <TLorentzVector (version 4) at 0x7f6a02cb3580>], [<TLorentzVector (version 4) at 0x7f6a02cb3430>, <TLorentzVector (version 4) at 0x7f6a02cb33d0>, <TLorentzVector (version 4) at 0x7f6a02cb3370>, <TLorentzVector (version 4) at 0x7f6a02cb32e0>, <TLorentzVector (version 4) at 0x7f6a02cba910>]], dtype=object)
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -610,6 +656,7 @@ def test_55(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1][5] == pytest.approx(0.346174418926239)
         # py[-1] == <STLVector [[0.15334472, 0.10603446, 0.004459681, 0.0222604, 0.38413692, 0.39519757], ...] at 0x7f38c4650eb0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -623,6 +670,7 @@ def test_56(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1]["SliceU64"][0] == 1
         # py[-1] == <Event (version 1) at 0x7fecdbf61dc0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -634,6 +682,7 @@ def test_57(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1] == "two"
         # py[-1] == <STLVector ['one', 'two'] at 0x7fdeeb3f8d90>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -645,6 +694,7 @@ def test_58(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1] == "two"
         # py[-1] == <STLVector ['one', 'two'] at 0x7f42edc0c0a0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -656,6 +706,7 @@ def test_59(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1][1] == 2
         # py[-1] == <STLVector [[1], [1, 2]] at 0x7ff36af3c2b0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -667,6 +718,7 @@ def test_60(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1][1] == "two"
         # py[-1] == <STLVector [['one'], ['one', 'two']] at 0x7fae23700eb0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -678,6 +730,7 @@ def test_61(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1][1] == "two"
         # py[-1] == <STLVector [['one'], ['one', 'two']] at 0x7f06ad24c460>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -689,6 +742,7 @@ def test_62(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1][1] == 2
         # py[-1] == <STLVector [{1}, {1, 2}] at 0x7f7f97e88880>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -700,6 +754,7 @@ def test_63(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1][1] == "two"
         # py[-1] == <STLVector [{'one'}, {'one', 'two'}] at 0x7fb29ded7370>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -711,6 +766,7 @@ def test_64(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1] == 2
         # py[-1] == <STLSet {1, 2} at 0x7f47a620e310>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -722,6 +778,7 @@ def test_65(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1][1] == "two"
         # py[-1] == <STLSet {'one', 'two'} at 0x7f5ffd9ff1c0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -733,6 +790,7 @@ def test_66(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[-1]["1"][1] == 2
         # py[-1] == <STLMap {1: 1, 2: 2} at 0x7f23be1efbe0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -744,6 +802,7 @@ def test_67(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1] == 2
         # py[-1] == <STLMap {1: [1], 2: [1, 2]} at 0x7f899441d2b0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -755,6 +814,7 @@ def test_68(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1] == "two"
         # py[-1] == <STLMap {1: ['one'], 2: ['one', 'two']} at 0x7fd19d3288b0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -766,6 +826,7 @@ def test_69(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1] == 2
         # py[-1] == <STLMap {1: {1}, 2: {1, 2}} at 0x7f2b3f1b5fa0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -777,6 +838,7 @@ def test_70(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1] == "two"
         # py[-1] == <STLMap {1: {'one'}, 2: {'one', 'two'}} at 0x7f4718b237c0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -788,6 +850,7 @@ def test_71(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"] == 2
         # py[-1] == <STLMap {'one': 1, 'two': 2} at 0x7f4179bed1f0>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -799,6 +862,7 @@ def test_72(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1] == 2
         # py[-1] == <STLMap {'one': [1], 'two': [1, 2]} at 0x7f26376e9b20>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -810,6 +874,7 @@ def test_73(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1] == "two"
         # py[-1] == <STLMap {'one': ['one'], 'two': ['one', 'two']} at 0x7f3e45d34910>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -821,6 +886,7 @@ def test_74(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1] == 2
         # py[-1] == <STLMap {'one': {1}, 'two': {1, 2}} at 0x7f5a94b1c760>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -832,6 +898,7 @@ def test_75(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1] == "two"
         # py[-1] == <STLMap {'one': {'one'}, 'two': {'one', 'two'}} at 0x7f1a1e95aa90>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -843,6 +910,7 @@ def test_76(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1][1] == 2
         # py[-1] == <STLMap {1: [[1]], 2: [[1], [1, 2]]} at 0x7fc98bd7ec10>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -854,6 +922,7 @@ def test_77(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"][1][1] == 2
         # py[-1] == <STLMap {1: [{1}], 2: [{1}, {1, 2}]} at 0x7fcf9b191610>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -865,6 +934,7 @@ def test_78(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"] == "TWO"
         # py[-1] == <STLMap {'one': 'ONE', 'two': 'TWO'} at 0x7f887b27cb20>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -876,6 +946,7 @@ def test_79(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[1][1]["1"] == "TWO"
         # py[-1] == <STLMap {'one': 'ONE', 'two': 'TWO'} at 0x7f4c4e527610>
+        assert py.layout.form == interp.awkward_form(branch.file)
 
 
 @pytest.mark.parametrize("is_forth", [False, True])
@@ -900,3 +971,4 @@ def test_81(is_forth):
         py = branch.array(interp, library="ak", entry_stop=2)
         assert py[0]["fY"] == pytest.approx(2.5636332035064697)
         # py[-1] == <STLVector [[], []] at 0x7f046a6951f0>
+        assert py.layout.form == interp.awkward_form(branch.file)


### PR DESCRIPTION
Quoting #754,

> If they don't, make them the same.

They are now; the differences were only minor and some of the errors were in the _non-Forth_ implementation.

> The `"uproot"` parameters should be removed.

They were already gone before I started.

> Some of the `"__record__"` parameters have the C++ name; this is a good idea. We should make sure that all of them do.

They all do now.

A user-visible difference is that we're excluding all of the TObject header and numbytes_version header stuff (used to be marked with `@`, now gone). It's still possible to get them back, but you have to run a non-Forth read and pass non-default parameters to the `awkward_forth` method. I don't think we'll ever need it.