### PR TITLE
fix: Uproot tests now work with Awkward 2.0.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,9 @@ dynamic = [
 
 [project.optional-dependencies]
 dev = [
-    "awkward>=2.0.0r",
+    "awkward>=2.0.0",
     "boost_histogram>=0.13",
-    "dask-awkward>=2022.12a2;python_version >= \"3.8\"",
+    "dask-awkward>=2022.12a3;python_version >= \"3.8\"",
     "dask[array];python_version >= \"3.8\"",
     "hist>=1.2",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "awkward>=2.0.0rc5",
+    "awkward>=2.0.0",
     "importlib-metadata;python_version<\"3.8\"",
     "numpy",
     "packaging",
@@ -49,16 +49,16 @@ dynamic = [
 
 [project.optional-dependencies]
 dev = [
-    "awkward>=2.0.0rc2",
+    "awkward>=2.0.0r",
     "boost_histogram>=0.13",
-    "dask-awkward>=2022.10a0;python_version >= \"3.8\"",
+    "dask-awkward>=2022.12a2;python_version >= \"3.8\"",
     "dask[array];python_version >= \"3.8\"",
     "hist>=1.2",
     "pandas",
     "awkward-pandas;python_version >= \"3.8\"",
 ]
 test = [
-    "awkward>=2.0.0rc2",
+    "awkward>=2.0.0",
     "lz4",
     "pytest>=6",
     "pytest-timeout",

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -37,11 +37,11 @@ Alternatively, you can use ``library="np"`` or globally set ``uproot.default_lib
 to output as NumPy arrays, rather than Awkward arrays.
 """
         ) from err
-    if parse_version("1") < parse_version(awkward.__version__) < parse_version("2"):
+    if parse_version("2") <= parse_version(awkward.__version__):
         return awkward
     else:
         raise ModuleNotFoundError(
-            "Uproot 4.x can only be used with Awkward 1.x; you have Awkward {}".format(
+            "Uproot 5.x can only be used with Awkward 2.x; you have Awkward {}".format(
                 awkward.__version__
             )
         )

--- a/tests/test_0637-setup-tests-for-AwkwardForth.py
+++ b/tests/test_0637-setup-tests-for-AwkwardForth.py
@@ -430,7 +430,7 @@ def test_35(is_forth):
         interp = uproot.interpretation.identify.interpretation_of(branch, {}, False)
         interp._forth = is_forth
         py = branch.array(interp, library="ak", entry_stop=2)
-        assert py[0]["1"][0]["name"] == "anti_alpha"
+        assert py[0, "1", 0, "name"] == "anti_alpha"
         # py[-1] == <STLMap {-1000020040: <BDSOutputROOTGeant4Data::ParticleInfo (version 1) at 0x7fb557996df0>, ...} at 0x7fb557a012e0>
         assert py.layout.form == interp.awkward_form(branch.file)
 
@@ -932,7 +932,7 @@ def test_78(is_forth):
         interp = uproot.interpretation.identify.interpretation_of(branch, {}, False)
         interp._forth = is_forth
         py = branch.array(interp, library="ak", entry_stop=2)
-        assert py[1][1]["1"] == "TWO"
+        assert py[1, 1, "1"] == "TWO"
         # py[-1] == <STLMap {'one': 'ONE', 'two': 'TWO'} at 0x7f887b27cb20>
         assert py.layout.form == interp.awkward_form(branch.file)
 
@@ -944,7 +944,7 @@ def test_79(is_forth):
         interp = uproot.interpretation.identify.interpretation_of(branch, {}, False)
         interp._forth = is_forth
         py = branch.array(interp, library="ak", entry_stop=2)
-        assert py[1][1]["1"] == "TWO"
+        assert py[1, 1, "1"] == "TWO"
         # py[-1] == <STLMap {'one': 'ONE', 'two': 'TWO'} at 0x7f4c4e527610>
         assert py.layout.form == interp.awkward_form(branch.file)
 


### PR DESCRIPTION
It works offline with dask-awkward from its `main` branch, but the tests will still fail until a dask-awkward release is made containing dask-contrib/dask-awkward#119. We just need a dask-awkward 2022.12a3, @douglasdavis.

I'm impressed that the `parse_version("1") < parse_version(awkward.__version__) < parse_version("2")` line survived this long in Uproot v5. I simply misunderstood what "`< parse_version("2")` meant: I must have thought that it excluded all the 2.0.0rcX pre-releases, but that's not how version ordering works. Okay. The version range has been fixed, and it no longer has an upper cap. (We have no reason to believe that there will be an Awkward 3.x, or that it might be disruptive.)

The other "fix", twiddling how the tests get data out of an Awkward Array, side-steps the bug that is fixed in scikit-hep/awkward#1993 (and now there's an Awkward test for it, so we don't rely on Uproot's test).

Uproot 5.0.0 can't be released until this is merged and this can't be merged until dask-awkward 2022.12a3 exists. But we don't need scikit-hep/awkward#1993; this PR is independent of that reaching a release. That's the order of dependencies.