### PR TITLE
fix: protect Uproot's 'project_columns' from Dask node names.

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -597,7 +597,11 @@ class _UprootRead:
         )
 
     def project_columns(self, branches):
-        return _UprootRead(self.ttrees, branches, self.interp_options)
+        return _UprootRead(
+            self.ttrees,
+            [x for x in branches if x in self.branches],
+            self.interp_options,
+        )
 
 
 class _UprootOpenAndRead:
@@ -628,7 +632,7 @@ class _UprootOpenAndRead:
             self.custom_classes,
             self.allow_missing,
             self.real_options,
-            common_keys,
+            [x for x in common_keys if x in self.common_keys],
             self.interp_options,
         )
 

--- a/tests/test_0791-protect-uproot-project_columns-from-dask-node-names.py
+++ b/tests/test_0791-protect-uproot-project_columns-from-dask-node-names.py
@@ -1,0 +1,14 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import numpy as np
+import pytest
+import skhep_testdata
+
+import uproot
+
+pytest.importorskip("dask_awkward")
+
+
+def test():
+    da = uproot.dask(skhep_testdata.data_path("uproot-issue-791.root") + ":tree")
+    assert da[da.int_branch < 0].compute().tolist() == [{"int_branch": -1}]


### PR DESCRIPTION
When computing Dask graphs with a operations inside a `__getitem__`,

```python
da = uproot.dask(skhep_testdata.data_path("uproot-issue-791.root") + ":tree")
da[da.int_branch < 0].compute()
```

Uproot is receiving names like "less-06b0b18209c65504e8506df9da02f75d" as branch names in `project_columns`. The strings we get in `project_columns` should be a strict subset of the strings in the input set of columns. This PR selects that subset, but it shouldn't be happening on the dask-awkward end.

I'm using a version of dask-awkward from git... `7fe448a1d448fa30f09693be0b14634c7968161a` from December 9, 2022.