### PR TITLE
fix: uproot.dask: Protect against `branches=None` in `project_columns`

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -597,9 +597,11 @@ class _UprootRead:
         )
 
     def project_columns(self, branches):
+        if branches is not None:
+            branches = [x for x in branches if x in self.branches]
         return _UprootRead(
             self.ttrees,
-            [x for x in branches if x in self.branches],
+            branches,
             self.interp_options,
         )
 
@@ -628,11 +630,14 @@ class _UprootOpenAndRead:
         )
 
     def project_columns(self, common_keys):
+        if branches is not None:
+            branches = [x for x in branches if x in self.branches]
+
         return _UprootOpenAndRead(
             self.custom_classes,
             self.allow_missing,
             self.real_options,
-            [x for x in common_keys if x in self.common_keys],
+            branches,
             self.interp_options,
         )
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -630,14 +630,14 @@ class _UprootOpenAndRead:
         )
 
     def project_columns(self, common_keys):
-        if branches is not None:
-            branches = [x for x in branches if x in self.branches]
+        if common_keys is not None:
+            common_keys = [x for x in branches if x in self.common_keys]
 
         return _UprootOpenAndRead(
             self.custom_classes,
             self.allow_missing,
             self.real_options,
-            branches,
+            common_keys,
             self.interp_options,
         )
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -631,7 +631,7 @@ class _UprootOpenAndRead:
 
     def project_columns(self, common_keys):
         if common_keys is not None:
-            common_keys = [x for x in branches if x in self.common_keys]
+            common_keys = [x for x in common_keys if x in self.common_keys]
 
         return _UprootOpenAndRead(
             self.custom_classes,


### PR DESCRIPTION
In `uproot.dask`'s `project_columns` implementations we need to make sure `branches` is not `None` before looping over the argument. (The optimization in `dask-awkward` will run project_columns with `None` branches if the the optimization determines that all original branches are necessary). more info at https://github.com/dask-contrib/dask-awkward/issues/134 and https://github.com/dask-contrib/dask-awkward/pull/131