### PR TITLE
fix: AsStridedObjects.awkward_form was still including the '@' members.

### DIFF
--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -510,13 +510,25 @@ def _unravel_members(members):
 def _strided_awkward_form(awkward, classname, members, file, context):
     contents = {}
     for name, member in members:
-        if isinstance(member, AsStridedObjects):
-            cname = uproot.model.classname_decode(member._model.__name__)[0]
-            contents[name] = _strided_awkward_form(
-                awkward, cname, member._members, file, context
-            )
+        if not context["header"] and name in ("@num_bytes", "@instance_version"):
+            pass
+        elif not context["tobject_header"] and name in (
+            "@num_bytes",
+            "@instance_version",
+            "@fUniqueID",
+            "@fBits",
+            "@pidf",
+        ):
+            pass
         else:
-            contents[name] = uproot._util.awkward_form(member, file, context)
+            if isinstance(member, AsStridedObjects):
+                cname = uproot.model.classname_decode(member._model.__name__)[0]
+                contents[name] = _strided_awkward_form(
+                    awkward, cname, member._members, file, context
+                )
+            else:
+                contents[name] = uproot._util.awkward_form(member, file, context)
+
     return awkward.forms.RecordForm(
         list(contents.values()),
         list(contents.keys()),

--- a/tests/test_0808-fix_awkward_form_for_AsStridedObjects.py
+++ b/tests/test_0808-fix_awkward_form_for_AsStridedObjects.py
@@ -1,0 +1,63 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import numpy
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+def test():
+    path = skhep_testdata.data_path("uproot-HZZ-objects.root")
+    with uproot.open(path)["events"] as tree:
+        form = tree["jetp4"].interpretation.awkward_form(None)
+        assert form.to_dict() == {
+            "class": "ListOffsetArray",
+            "offsets": "i64",
+            "content": {
+                "class": "RecordArray",
+                "fields": ["fP", "fE"],
+                "contents": [
+                    {
+                        "class": "RecordArray",
+                        "fields": ["fX", "fY", "fZ"],
+                        "contents": [
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "float64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": None,
+                            },
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "float64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": None,
+                            },
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "float64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": None,
+                            },
+                        ],
+                        "parameters": {"__record__": "TVector3"},
+                        "form_key": None,
+                    },
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "float64",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": None,
+                    },
+                ],
+                "parameters": {"__record__": "TLorentzVector"},
+                "form_key": None,
+            },
+            "parameters": {},
+            "form_key": None,
+        }


### PR DESCRIPTION
AwkwardForth doesn't read class members like `@instance_version`, `@fBits`, ... because they're not data; they're internal ROOT metadata. `AsObjects.awkward_form` was made to agree with the Forms of the as-built Awkward Arrays (in #790), but `AsStridedObjects.awkward_form` was still sneaking this information in.

It wasn't that the `header` and `tobject_header` flags were somehow being unset from their default values (the default value of `False` means to exclude these "`@`" members). The issue was that the list of member names was being taken from `Model._members`, which includes everything.

Now the accumulation of `_strided_awkward_form` excludes the "`@`' members if the `header` and `tobject_header` flags say we should.