### PR TITLE
feat: [WIP] RNTuple Basic Writing

### DIFF
--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -130,6 +130,7 @@ def _serialize_rntuple_page_innerlist(items):
     raw_bytes = b"".join([size_bytes, n_items.to_bytes(4, "little"), payload_bytes])
     return raw_bytes
 
+
 def _serialize_rntuple_list_frame(items, wrap=True):
     # when items is [], b'\xf8\xff\xff\xff\x00\x00\x00\x00'
     n_items = len(items)

--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -548,7 +548,7 @@ class NTuple_Anchor(CascadeLeaf):
         crc32 = zlib.crc32(out)
         self.fCheckSum = crc32
         out = _rntuple_format1.pack(*self._fields)
-        return b"@\x00\x006\x00\x00" + out
+        return b"@\x00\x006\x00\x03" + out
 
 
 class Ntuple_PageLink:

--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -762,25 +762,26 @@ class NTuple(CascadeNode):
         5. update anchor's foot metadata values in-place
         """
 
+        # DUMMY, replace with real `data` later
+        data = numpy.array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0], dtype="int32")
+        #######################################
+
         cluster_summary = NTuple_ClusterSummary(self._num_entries, len(data))
         self._num_entries += len(data)
         self._footer.cluster_summary_record_frames.append(cluster_summary)
-
-        # page (actual column content)
-        dummy_data = numpy.array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0], dtype="int32")
-        dummy_data_bytes = dummy_data.view("uint8")
+        data_bytes = data.view("uint8")
         page_key = self.add_rblob(
-            sink, dummy_data_bytes, len(dummy_data_bytes), big=False
+            sink, data_bytes, len(data_bytes), big=False
         )
         page_locator = NTuple_Locator(
-            len(dummy_data_bytes), page_key.location + page_key.allocation
+            len(data_bytes), page_key.location + page_key.allocation
         )
         # FIXME use this
         # self.array_to_type(data.layout, data.type)
 
         # we always add one more `list of list` into the `footer.cluster_group_records`, because we always make a new
         # cluster
-        page_desc = NTuple_PageDescription(len(dummy_data), page_locator)
+        page_desc = NTuple_PageDescription(len(data), page_locator)
         inner_page_list = NTuple_InnerListLocator([page_desc])
         inner_page_list_bytes = _serialize_rntuple_list_frame([inner_page_list], False)
         inner_size_bytes = struct.Struct("<i").pack(
@@ -805,7 +806,7 @@ class NTuple(CascadeNode):
         new_page_list_envlink = NTuple_EnvLink(len(pagelist_bytes), pagelist_locator)
 
         new_cluster_group_record = NTuple_ClusterGroupRecord(1, new_page_list_envlink)
-        self._footer.cluster_group_record_frames.append(new_cluster_group_record)
+        self._footer.cluster_group_record_frames[0] = new_cluster_group_record
 
         #### relocate Footer ##############################
         old_footer_key = self._footer_key

--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -770,9 +770,7 @@ class NTuple(CascadeNode):
         self._num_entries += len(data)
         self._footer.cluster_summary_record_frames.append(cluster_summary)
         data_bytes = data.view("uint8")
-        page_key = self.add_rblob(
-            sink, data_bytes, len(data_bytes), big=False
-        )
+        page_key = self.add_rblob(sink, data_bytes, len(data_bytes), big=False)
         page_locator = NTuple_Locator(
             len(data_bytes), page_key.location + page_key.allocation
         )


### PR DESCRIPTION
testing on something real simple:
```python
import uproot
import awkward as ak

def test_writable():
    filepath = "/tmp/test.root"

    with uproot.recreate(filepath) as file:
        akform = ak.forms.RecordForm(
            [
                ak.forms.NumpyForm("int32"),
            ],
            ["one"],
        )
        file.mkrntuple("ntuple", akform)
        array = array = ak.from_iter([{"one_integers":1}])
        a = file["ntuple"]
        a.extend(array)
        assert type(file["ntuple"]).__name__ == "WritableNTuple"

test_writable()
```

and can be read back from Julia
```julia
julia> f = ROOTFile("/tmp/test.root")
ROOTFile with 1 entry and 0 streamers.
/tmp/test.root
└─ ntuple (ROOT::Experimental::RNTuple)


julia> LazyTree(f, "ntuple")
 Row │ one
     │ Int32
─────┼───────
 1   │ 9
 2   │ 8
 3   │ 7
 4   │ 6
 5   │ 5
 6   │ 4
 7   │ 3
 8   │ 2
 9   │ 1
 10  │ 0
```

But ROOT doesn't like it:
```python
>>> import ROOT
>>> ROOT.Experimental.RNTupleReader.Open("ntuple", "./test.root")
...<long error>
basic_string_view<char,char_traits<char> > storage, const ROOT::Experimental::RNTupleReadOptions& options = ROOT::Experimental::RNTupleReadOptions()) =>
    RException: page list frame too short
```

which points to:
https://github.com/root-project/root/blob/36bf93c68cbe581b22e6f7d31046860b7fddefc3/tree/ntuple/v7/src/RNTupleSerialize.cxx#L1426

upon further re-reading of the specification:
>The inner list is followed by a 64bit unsigned integer element offset and the 32bit compression settings (see Section "Basic Types"). 

was something I missed before.