### PR TITLE
feat: allow `uproot.dask` to re-map forms at the data source

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -64,7 +64,7 @@ def dask(
             the dask collections. If False, the opening of the files and reading the
             metadata is also delayed till the compute call. In this case, branch-names
             are inferred by opening only the first file.
-        form_mapping (Callable[awkward.forms.form] -> awkward.forms.form | None): If not none
+        form_mapping (Callable[awkward.forms.Form] -> awkward.forms.Form | None): If not none
             and library="ak" then apply this remapping function to the awkward form of the input
             data. The form keys of the desired form should be available data in the input form.
         options: See below.


### PR DESCRIPTION
This PR implements the interface (to be merged) defined in https://github.com/douglasdavis/dask-awkward/pull/3 to implement form remapping in `uproot.dask`.

I have confirmed this so far with local testing, ideas for a minimal test would be appreciated!

@jpivarski 