### PR TITLE
fix: ak_add_doc should add docs to both the lazy and the materialized array.

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -201,7 +201,6 @@ def dask(
                 real_options,
                 interp_options,
                 form_mapping,
-                ak_add_doc,
             )
         else:
             return _get_dak_array_delay_open(
@@ -216,7 +215,6 @@ def dask(
                 real_options,
                 interp_options,
                 form_mapping,
-                ak_add_doc,
             )
     else:
         raise NotImplementedError()
@@ -801,7 +799,6 @@ def _get_dak_array(
     real_options=None,
     interp_options=None,
     form_mapping=None,
-    ak_add_doc=None,
 ):
     dask_awkward = uproot.extras.dask_awkward()
     awkward = uproot.extras.awkward()
@@ -906,7 +903,12 @@ def _get_dak_array(
             foreach(start)
 
     meta, form = _get_meta_array(
-        awkward, dask_awkward, ttrees[0], common_keys, form_mapping, ak_add_doc
+        awkward,
+        dask_awkward,
+        ttrees[0],
+        common_keys,
+        form_mapping,
+        interp_options.get("ak_add_doc"),
     )
 
     if len(partition_args) == 0:
@@ -938,7 +940,6 @@ def _get_dak_array_delay_open(
     real_options=None,
     interp_options=None,
     form_mapping=None,
-    ak_add_doc=None,
 ):
     dask_awkward = uproot.extras.dask_awkward()
     awkward = uproot.extras.awkward()
@@ -956,7 +957,12 @@ def _get_dak_array_delay_open(
     )
 
     meta, form = _get_meta_array(
-        awkward, dask_awkward, obj, common_keys, form_mapping, ak_add_doc
+        awkward,
+        dask_awkward,
+        obj,
+        common_keys,
+        form_mapping,
+        interp_options.get("ak_add_doc"),
     )
 
     return dask_awkward.from_map(

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -406,16 +406,16 @@ class _UprootOpenAndReadNumpy:
 
 def _get_dask_array(
     files,
-    filter_name=no_filter,
-    filter_typename=no_filter,
-    filter_branch=no_filter,
-    recursive=True,
-    full_paths=False,
-    step_size="100 MB",
-    custom_classes=None,
-    allow_missing=False,
-    real_options=None,
-    interp_options=None,
+    filter_name,
+    filter_typename,
+    filter_branch,
+    recursive,
+    full_paths,
+    step_size,
+    custom_classes,
+    allow_missing,
+    real_options,
+    interp_options,
 ):
     ttrees = []
     common_keys = None
@@ -546,15 +546,15 @@ def _get_dask_array(
 
 def _get_dask_array_delay_open(
     files,
-    filter_name=no_filter,
-    filter_typename=no_filter,
-    filter_branch=no_filter,
-    recursive=True,
-    full_paths=False,
-    custom_classes=None,
-    allow_missing=False,
-    real_options=None,
-    interp_options=None,
+    filter_name,
+    filter_typename,
+    filter_branch,
+    recursive,
+    full_paths,
+    custom_classes,
+    allow_missing,
+    real_options,
+    interp_options,
 ):
     ffile_path, fobject_path = files[0]
     obj = uproot._util.regularize_object_path(
@@ -788,17 +788,17 @@ def _get_meta_array(
 
 def _get_dak_array(
     files,
-    filter_name=no_filter,
-    filter_typename=no_filter,
-    filter_branch=no_filter,
-    recursive=True,
-    full_paths=False,
-    step_size="100 MB",
-    custom_classes=None,
-    allow_missing=False,
-    real_options=None,
-    interp_options=None,
-    form_mapping=None,
+    filter_name,
+    filter_typename,
+    filter_branch,
+    recursive,
+    full_paths,
+    step_size,
+    custom_classes,
+    allow_missing,
+    real_options,
+    interp_options,
+    form_mapping,
 ):
     dask_awkward = uproot.extras.dask_awkward()
     awkward = uproot.extras.awkward()
@@ -930,16 +930,16 @@ def _get_dak_array(
 
 def _get_dak_array_delay_open(
     files,
-    filter_name=no_filter,
-    filter_typename=no_filter,
-    filter_branch=no_filter,
-    recursive=True,
-    full_paths=False,
-    custom_classes=None,
-    allow_missing=False,
-    real_options=None,
-    interp_options=None,
-    form_mapping=None,
+    filter_name,
+    filter_typename,
+    filter_branch,
+    recursive,
+    full_paths,
+    custom_classes,
+    allow_missing,
+    real_options,
+    interp_options,
+    form_mapping,
 ):
     dask_awkward = uproot.extras.dask_awkward()
     awkward = uproot.extras.awkward()

--- a/tests/test_0832-ak_add_doc-should-also-add-to-typetracer.py
+++ b/tests/test_0832-ak_add_doc-should-also-add-to-typetracer.py
@@ -1,0 +1,38 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import numpy
+import pytest
+import skhep_testdata
+
+import uproot
+
+pytest.importorskip("awkward")
+
+
+def test():
+    nMuon_doc = "slimmedMuons after basic selection (pt > 15 || (pt > 3 && (passed('CutBasedIdLoose') || passed('SoftCutBasedId') || passed('SoftMvaId') || passed('CutBasedIdGlobalHighPt') || passed('CutBasedIdTrkHighPt'))))"
+
+    with uproot.open(skhep_testdata.data_path("nanoAOD_2015_CMS_Open_Data_ttbar.root"))[
+        "Events/nMuon"
+    ] as branch:
+        assert branch.title == nMuon_doc
+
+        assert (
+            str(branch.array(ak_add_doc=True).type)
+            == f'200 * uint32[parameters={{"__doc__": "{nMuon_doc}"}}]'
+        )
+
+    lazy = uproot.dask(
+        skhep_testdata.data_path("nanoAOD_2015_CMS_Open_Data_ttbar.root") + ":Events",
+        ak_add_doc=True,
+    )
+
+    assert (
+        str(lazy["nMuon"].type)
+        == f'?? * uint32[parameters={{"__doc__": "{nMuon_doc}"}}]'
+    )
+
+    assert (
+        str(lazy["nMuon"].compute().type)
+        == f'200 * uint32[parameters={{"__doc__": "{nMuon_doc}"}}]'
+    )

--- a/tests/test_0832-ak_add_doc-should-also-add-to-typetracer.py
+++ b/tests/test_0832-ak_add_doc-should-also-add-to-typetracer.py
@@ -7,6 +7,7 @@ import skhep_testdata
 import uproot
 
 pytest.importorskip("awkward")
+pytest.importorskip("dask_awkward")
 
 
 def test():


### PR DESCRIPTION
This is essentially completing #784, which added docstrings to materialized arrays, but not the typetracers that Dask uses.