### PR TITLE
feat: pass tree title as a docstr when remapping

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -770,7 +770,7 @@ def _get_meta_array(
         common_keys,
     )
     if form_mapping is not None:
-        form = form_mapping(form)
+        form = form_mapping(form, docstr=ttree.title)
     empty_arr = awkward.from_buffers(
         form, 0, {"": b"\x00\x00\x00\x00\x00\x00\x00\x00"}, buffer_key=""
     )


### PR DESCRIPTION
Define top-level docstring for tree by kwarg.