### PR TITLE
fix: complain about CannotBeAwkward earlier, before reading data.

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -570,6 +570,14 @@ def awkward_form(model, file, context):
                 _primitive_awkward_form[model] = awkward.forms.from_json('"float32"')
             elif model == numpy.dtype(numpy.float64):
                 _primitive_awkward_form[model] = awkward.forms.from_json('"float64"')
+            elif model.fields is not None:
+                fields = []
+                contents = []
+                for field, (dtype, _) in model.fields.items():
+                    fields.append(field)
+                    contents.append(awkward_form(dtype, file, context))
+                # directly return; don't cache RecordForms in _primitive_awkward_form
+                return awkward.forms.RecordForm(contents, fields)
             else:
                 raise AssertionError(f"{model!r}: {type(model)}")
 

--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -568,27 +568,9 @@ class Awkward(Library):
             return _awkward_add_doc(awkward, awkward.Array(layout), branch, ak_add_doc)
 
         elif isinstance(interpretation, uproot.interpretation.objects.AsObjects):
-            try:
-                form = json.loads(
-                    interpretation.awkward_form(interpretation.branch.file).to_json()
-                )
-            except uproot.interpretation.objects.CannotBeAwkward as err:
-                raise ValueError(
-                    """cannot produce Awkward Arrays for interpretation {} because
-
-    {}
-
-instead, try library="np" instead of library="ak" or globally set uproot.default_library
-
-in file {}
-in object {}""".format(
-                        repr(interpretation),
-                        err.because,
-                        interpretation.branch.file.file_path,
-                        interpretation.branch.object_path,
-                    )
-                ) from err
-
+            form = json.loads(
+                interpretation.awkward_form(interpretation.branch.file).to_json()
+            )
             unlabeled = awkward.from_iter(
                 (_object_to_awkward_json(form, x) for x in array), highlevel=False
             )


### PR DESCRIPTION
This came up in Discussion #826 (Issue #833): the AwkwardForth errors occur on an Interpretation that could never have been Awkward anyway.

An early hint was that it was going through [read_object_any](https://github.com/scikit-hep/uproot5/blob/c24159917ea5732ada3bb0b03615707823194197/src/uproot/deserialization.py#L184-L319), which means arbitrary-typed pointers, circular references, and a whole host of things that are beyond the scope of Awkward Array, but the clearest indication was that we got the "Cannot be Awkward" error in TTrees with zero entries—if it could have gotten past the AwkwardForth read, it would have encountered this error, anyway. (It didn't get past the AwkwardForth read because we don't generate AwkwardForth inside `read_object_any`.)

So this PR

  * takes the check out of `Library.finalize`
  * puts it into `_ranges_or_baskets_to_arrays`, on the main thread, before any reading starts[^1]
  * fixes an unrelated error in `_util`, but it was uncovered by this PR.

[^1]: Well, actually, `Source.chunks` has already been called, so the bytes have been read from local files or a remote server has been queried, but we haven't waited for any data to come back yet and won't be decompressing it or interpreting it if it does.