### PR TITLE
chore: don't repeat awkward dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dynamic = [
 
 [project.optional-dependencies]
 dev = [
-    "awkward>=2.0.0",
     "boost_histogram>=0.13",
     "dask-awkward>=2022.12a3;python_version >= \"3.8\"",
     "dask[array];python_version >= \"3.8\"",
@@ -58,7 +57,6 @@ dev = [
     "awkward-pandas;python_version >= \"3.8\"",
 ]
 test = [
-    "awkward>=2.0.0",
     "lz4",
     "pytest>=6",
     "pytest-timeout",


### PR DESCRIPTION
This is a code cleanup PR — we already define `awkward` as a core dependency, so we don't need to repeat this in the other dependency groups now.