### PR TITLE
fix: replaced incorrect AwkwardForth `var_set` logic with a check to see if the Form is complete

### DIFF
--- a/src/uproot/_awkward_forth.py
+++ b/src/uproot/_awkward_forth.py
@@ -26,7 +26,7 @@ class ForthGenerator:
     This class is passed through the Forth code generation, collecting Forth snippets and concatenating them at the end.
     """
 
-    def __init__(self, aform=None, count_obj=0, var_set=False):
+    def __init__(self, aform=None, count_obj=0):
         self.dummy_form = False
         self.top_dummy = None
         self.dummy_aform = None
@@ -42,7 +42,6 @@ class ForthGenerator:
         self.final_header = []
         self.final_init = []
         self.form_keys = []
-        self.var_set = var_set
         self.count_obj = count_obj
 
     def traverse_aform(self):
@@ -82,7 +81,7 @@ class ForthGenerator:
                 init = node["init_code"] + init
                 header = node["header_code"] + header
                 return pre2 + post2, "", init, header
-        elif self.var_set:
+        else:
             return "", "", "", ""
 
     def should_add_form(self):

--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -88,8 +88,6 @@ def _read_nested(
         values = numpy.empty(length, dtype=_stl_object_type)
         if isinstance(model, AsContainer):
             if forth_stash is not None:
-                if length == 0:
-                    forth_obj.var_set = True
                 temp_count = context["forth"].gen.count_obj
             for i in range(length):
                 if forth_stash is not None:
@@ -756,8 +754,6 @@ in file {}""".format(
                         {},
                     )
 
-                if cursor.index >= chunk.stop and forth_stash is not None:
-                    forth_obj.var_set = True
                 out = []
                 if forth_stash is not None:
                     temp_count = forth_obj.count_obj
@@ -828,8 +824,6 @@ in file {}""".format(
                         {},
                     )
 
-                if cursor.index >= chunk.stop and forth_stash is not None:
-                    forth_obj.var_set = True
                 out = []
                 if forth_stash is not None:
                     temp_count = forth_obj.count_obj
@@ -1147,9 +1141,6 @@ class AsVector(AsContainer):
                 )
                 context["temp_ref"] = temp
 
-            if length == 0 and forth_stash is not None:
-                forth_obj.var_set = True
-
             values = _read_nested(
                 self._values, length, chunk, cursor, context, file, selffile, parent
             )
@@ -1297,8 +1288,6 @@ in file {}""".format(
                 1,
                 {},
             )
-        if length == 0 and forth_stash is not None:
-            forth_obj.var_set = True
         keys = _read_nested(
             self._keys, length, chunk, cursor, context, file, selffile, parent
         )

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -270,9 +270,28 @@ class AsObjects(uproot.interpretation.Interpretation):
 
         return output
 
+    def _any_NULL(self, form):
+        if form == "NULL":
+            return True
+        else:
+            content = form.get("content")
+            if content is not None:
+                return self._any_NULL(content)
+            contents = form.get("contents")
+            if isinstance(contents, list):
+                for content in contents:
+                    if self._any_NULL(content):
+                        return True
+            elif isinstance(contents, dict):
+                for content in contents.values():
+                    if self._any_NULL(content):
+                        return True
+            return False
+
     def _discover_forth(self, data, byte_offsets, branch, context, cursor_offset):
         output = numpy.empty(len(byte_offsets) - 1, dtype=numpy.dtype(object))
         context["cancel_forth"] = False
+
         for i in range(len(byte_offsets) - 1):
             byte_start = byte_offsets[i]
             byte_stop = byte_offsets[i + 1]
@@ -281,8 +300,10 @@ class AsObjects(uproot.interpretation.Interpretation):
             cursor = uproot.source.cursor.Cursor(
                 0, origin=-(byte_start + cursor_offset)
             )
+
             if "forth" in context.keys():
-                context["forth"].gen.var_set = False
+                context["forth"].gen.count_obj = 0
+
             output[i] = self._model.read(
                 chunk,
                 cursor,
@@ -291,11 +312,15 @@ class AsObjects(uproot.interpretation.Interpretation):
                 branch.file.detached,
                 branch,
             )
+
             if context["cancel_forth"] and "forth" in context.keys():
                 del context["forth"]
+
             if "forth" in context.keys():
                 context["forth"].gen.awkward_model = context["forth"].gen.top_node
-                if not context["forth"].gen.var_set:
+
+                discovered_form = context["forth"].gen.top_form
+                if not self._any_NULL(discovered_form):
                     context["forth"].prereaddone = True
                     self._assemble_forth(
                         context["forth"].gen, context["forth"].gen.top_node["content"]
@@ -312,8 +337,9 @@ class AsObjects(uproot.interpretation.Interpretation):
     loop
     """
                     self._forth_form_keys = tuple(context["forth"].gen.form_keys)
-                    self._form = context["forth"].gen.top_form
+                    self._form = discovered_form
                     return None  # we should re-read all the data with Forth
+
         return output  # Forth-generation was unsuccessful: this is Python output
 
     def _assemble_forth(self, forth_obj, awkward_model):


### PR DESCRIPTION
@mpad saw factors of 200× speed difference between some TBranches in #850. It turned out to depend on whether any `std::vectors` are empty or not: TBranches that contain any empty `std::vectors` in all entries were slow, those that didn't were fast.

It's because the AwkwardForth code-generation step has to consider, at the end of each entry, whether the code that it has is complete or if it's not complete because it's never observed a given list as occupied (and therefore could learn how many bytes its headers are, if there had been any objects in it). The logic, as-written, would mark an entry incomplete (`var_set = True`) if any list anywhere within it is empty. However, data like this:

```
[[[]], [[]], [[]], [[]], [[]], [[123]]]
```

or this:

```
[[[123]], [[]], [[]], [[]], [[]], [[]]]
```

should not be considered incomplete because the walk over data reached all parts of the corresponding type tree _at some point_. Rather than asking if there is _any_ empty list, the appropriate question would be whether they're _all_ empty lists.

But there's more than that: this determination must be made separately at each level of depth (and in multiple branches, possibly at the same level, if there are any C++ classes/Awkward record arrays). It needs to reach all points of the _type_ tree for any part of the _value_ tree. To extend the current logic, `var_set` would have to become a container with as many items as list nodes in the type tree, the walk over values would start pessimistic and would toggle to a good value if any list value for a given list type node has non-zero length, and the final check would require all items to be good values.

Perhaps it could have been solved by using `ForthGenerator.get_keys(1)` to identify the current list node in the type tree during the walk over values, though I would first need to know the full set of keys to expect. (It could be done by examining the Form, generated before reading any data using `AsObjects.awkward_form(TBranch.file)`.)

However, I think there's an easier way, implemented in this PR. The same walk that generates AwkwardForth code generates an Awkward Form. If we don't get to a particular node to discover whether how many bytes its header has (to put the right `skip` command into the AwkwardForth code), then we also don't get to make the corresponding Form node. They're built in tandem. (Right?) So instead of checking `var_set`, I added a check to the current state of the Form (which is made of Python dicts and lists), to see if there are any missing nodes. Missing nodes are all labeled by a string, `"NULL"`. (Right?) If the Form does not contain any `"NULL"`, then the Forth code must be complete, too, and we can consider the code-generation phase to be complete.

Also, this means we can remove the `var_set` entirely, which didn't have a good name, anyway. (It wasn't clear what it was supposed to mean by just looking at it.)

@aryan26roy, could you check my assumptions? This PR fixes #850 and all of the tests still run. I also verified that one of the tests would have `var_set is False` after the first entry, so the new logic is being exercised to some degree. But if you can see any mistaken assumptions that wouldn't hold in general, I should fix them.