### PR TITLE
fix: AwkwardForth was nesting the same ListOffsetArray (same node name) multiple times

### DIFF
--- a/tests/test_0798_DAOD_PHYSLITE.py
+++ b/tests/test_0798_DAOD_PHYSLITE.py
@@ -1,0 +1,103 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import numpy
+import pytest
+import skhep_testdata
+
+import uproot
+
+pytest.importorskip("awkward")
+
+
+@pytest.mark.parametrize("is_forth", [False, True])
+def test_AnalysisJetsAuxDyn_GhostTrack(is_forth):
+    expected_type = '2 * var * var * struct[{m_persKey: uint32, m_persIndex: uint32}, parameters={"__record__": "ElementLink<DataVector<xAOD::IParticle>>"}]'
+    expected_data = [
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 490246363, "m_persIndex": 5},
+        {"m_persKey": 0, "m_persIndex": 0},
+        {"m_persKey": 490246363, "m_persIndex": 3},
+        {"m_persKey": 490246363, "m_persIndex": 0},
+        {"m_persKey": 490246363, "m_persIndex": 4},
+    ]
+
+    with uproot.open(skhep_testdata.data_path("uproot-issue-798.root")) as file:
+        branch = file["CollectionTree"]["AnalysisJetsAuxDyn.GhostTrack"]
+        interp = uproot.interpretation.identify.interpretation_of(branch, {}, False)
+        interp._forth = is_forth
+        array = branch.array(interp, library="ak", entry_stop=2)
+        assert str(array.type) == expected_type
+        assert array[0, 0].tolist() == expected_data
+        assert array.layout.form == interp.awkward_form(branch.file)
+
+
+@pytest.mark.parametrize("is_forth", [False, True])
+def test_TruthBosonAuxDyn_childLinks(is_forth):
+    expected_type = '2 * var * var * struct[{m_persKey: uint32, m_persIndex: uint32}, parameters={"__record__": "ElementLink<DataVector<xAOD::TruthParticle_v1>>"}]'
+    expected_data = [
+        [],
+        [
+            {"m_persKey": 375408000, "m_persIndex": 0},
+            {"m_persKey": 13267281, "m_persIndex": 0},
+            {"m_persKey": 368360608, "m_persIndex": 0},
+        ],
+    ]
+
+    with uproot.open(skhep_testdata.data_path("uproot-issue-798.root")) as file:
+        branch = file["CollectionTree"]["TruthBosonAuxDyn.childLinks"]
+        interp = uproot.interpretation.identify.interpretation_of(branch, {}, False)
+        interp._forth = is_forth
+        array = branch.array(interp, library="ak", entry_stop=2)
+        assert str(array.type) == expected_type
+        assert array[0].tolist() == expected_data
+        assert array.layout.form == interp.awkward_form(branch.file)
+
+
+@pytest.mark.parametrize("is_forth", [False, True])
+def test_TruthPhotonsAuxDyn_parentLinks(is_forth):
+    expected_type = '2 * var * var * struct[{m_persKey: uint32, m_persIndex: uint32}, parameters={"__record__": "ElementLink<DataVector<xAOD::TruthParticle_v1>>"}]'
+    expected_data = [
+        [{"m_persKey": 614719239, "m_persIndex": 1}],
+        [],
+        [],
+        [],
+        [{"m_persKey": 779635413, "m_persIndex": 2}],
+        [{"m_persKey": 779635413, "m_persIndex": 3}],
+        [{"m_persKey": 779635413, "m_persIndex": 3}],
+    ]
+
+    with uproot.open(skhep_testdata.data_path("uproot-issue-798.root")) as file:
+        branch = file["CollectionTree"]["TruthPhotonsAuxDyn.parentLinks"]
+        interp = uproot.interpretation.identify.interpretation_of(branch, {}, False)
+        interp._forth = is_forth
+        array = branch.array(interp, library="ak", entry_stop=2)
+        assert str(array.type) == expected_type
+        assert array[0].tolist() == expected_data
+        assert array.layout.form == interp.awkward_form(branch.file)
+
+
+@pytest.mark.parametrize("is_forth", [False, True])
+def test_TruthTopAuxDyn_parentLinks(is_forth):
+    expected_type = '2 * var * var * struct[{m_persKey: uint32, m_persIndex: uint32}, parameters={"__record__": "ElementLink<DataVector<xAOD::TruthParticle_v1>>"}]'
+    expected_data = [
+        [],
+        [],
+        [{"m_persKey": 660928181, "m_persIndex": 0}],
+        [{"m_persKey": 660928181, "m_persIndex": 1}],
+    ]
+
+    with uproot.open(skhep_testdata.data_path("uproot-issue-798.root")) as file:
+        branch = file["CollectionTree"]["TruthTopAuxDyn.parentLinks"]
+        interp = uproot.interpretation.identify.interpretation_of(branch, {}, False)
+        interp._forth = is_forth
+        array = branch.array(interp, library="ak", entry_stop=2)
+        assert str(array.type) == expected_type
+        assert array[0].tolist() == expected_data
+        assert array.layout.form == interp.awkward_form(branch.file)


### PR DESCRIPTION
cc @nikoladze and @lgray

Two of the problematic TBranches in #798 have been fixed by a previous PR, probably this one: #851.

The other two had the same error: the first few `std::vectors` in the first entry were empty and the last few were not empty. Stepping through the empty ones created the ListOffsetArray Form node and Forth code multiple times, nesting it each time. (This is entirely in the code-generation stage, and the "input names, output names, variable names, and user-defined words must all be unique" error message was just the first symptom.)

The non-empty `std::vectors` already knew that they're not supposed to keep creating ListOffsetArray nodes. Despite over 3 hours of @nikoladze and me looking at this code, we didn't understand the code path of how the working part is supposed to work (in order to apply the same principle to the non-working part, the case of empty `std::vectors`). This code will _have to_ at some point be refactored into something maintainable; that will probably need to be another project in itself. (It would be an easier project than the first time around, because there is a working example to examine, but the whole concept of constantly changing `forth_obj.awkward_model` variables will have to be reconsidered. This code is functional, in that it works, but it is not functional enough, in the sense of avoiding mutable state.)

Nevertheless, we did manage to patch the current implementation. We couldn't simply skip the Form-and-Forth generation when `length == 0` because that broke existing tests (in multiple different ways; we didn't try to understand why and how). But if we're at a point in the codebase where we're considering a node key (`f"node{key}"`) that is equal to the current `forth_obj.awkward_model["name"]`, nesting a new node like that within `forth_obj.awkward_model["content"]` and adding to the Form would definitely be wrong, so the patch in this PR avoids doing that for all list types. (We only observed the issue in `AsVector`, but if it applies to `std::vector`, it ought to apply to `std::set`, `std::map`, etc.)

The patch does seem to break an abstraction layer: code outside of `ForthGenerator` is checking the value of `ForthGenerator.awkward_model` and making decisions based on it; it looks like the current code tries to hide this in `ForthGenerator.add_node`. But extending `add_node` and `should_add_form` to check a new `node_key` would require passing that in as an argument, and I didn't want to change all calls to these two functions, since they handle more cases than list-building and this is only an issue for list-building. (Only lists can be empty.)

I think this is an improvement, but we'll definitely need an AwkwardForth-revamping project at some point in the future.