### PR TITLE
fix: Ignore semicolon in EOS token when separating file name and object name

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -293,6 +293,13 @@ def file_object_path_split(path):
         ):
             return path, None
 
+        # Unfortunately EOS tokens start with zteos:, so we should ignore
+        # the : when preceded by that string as it is part of the URL, and
+        # not a seperator between the file name and the path in the file
+        # Future versions of EOS will accept to have that character escaped.
+        if file_path.endswith(("zteos", "zteos64")):
+            return path, None
+
         file_path = file_path.rstrip()
         object_path = object_path.lstrip()
 


### PR DESCRIPTION
To use EOS tokens, the token must be appended to the file name, so the URLs are typically of the style:

root://eosserver//eos/path/file.root?xrd.wantprot=unix&authz=zteos64:BASE64TOKEN

Currently EOS does not accept the ":" to be escaped as %3A, and the semicolon is interpreted by uproot as the separator between the file name and the object name in the file.

This patch just ignores the semicolon if preceded by zteos64.



