### PR TITLE
feat: Allow uproot.dask to know about entry_start and entry_stop

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -884,8 +884,9 @@ def _get_meta_array(
     if form_mapping is not None:
         form = form_mapping(form)
 
-    empty_arr = form.length_zero_array(
-        behavior=None if form_mapping is None else form_mapping.behavior
+    empty_arr = awkward.Array(
+        form.length_zero_array(highlevel=False),
+        behavior=None if form_mapping is None else form_mapping.behavior,
     )
 
     return dask_awkward.core.typetracer_array(empty_arr), form


### PR DESCRIPTION
This addresses a sub-issue here: https://github.com/CoffeaTeam/coffea/issues/807

Where it would be nice indeed to focus in on buggy/interesting sub-ranges through uproot.dask, which is not possible right now in a simple way.

I've included one implementation as example!

It composes nicely with `steps_per_file` and `step_size` as well.