### PR TITLE
feat: chunk specification in uproot.dask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ test = [
     "requests",
     "scikit-hep-testdata",
     "xxhash",
+    "awkward>=2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ test = [
     "requests",
     "scikit-hep-testdata",
     "xxhash",
-    "awkward>=2",
 ]
 
 [project.urls]

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -47,16 +47,16 @@ def dask(
             with slashes (``/``); otherwise, use the descendant's name as
             the field name.
         step_size (int or str): If an integer, the maximum number of entries to
-            include in each chunk; if a string, the maximum memory_size to include
-            in each chunk. The string must be a number followed by a memory unit,
+            include in each chunk/partition; if a string, the maximum memory_size to include
+            in each chunk/partition. The string must be a number followed by a memory unit,
             such as "100 MB". Mutually incompatible with steps_per_file: only set
             step_size or steps_per_file, not both. Cannot be used with
             ``open_files=False``.
         steps_per_file (int, default 1):
-            Subdivide files into the specified number of chunks. Mutually incompatible
+            Subdivide files into the specified number of chunks/partitions. Mutually incompatible
             with step_size: only set step_size or steps_per_file, not both.
             If both ``step_size`` and ``steps_per_file`` are unset,
-            ``steps_per_file``'s default value of 1 (whole file per chunk) is used,
+            ``steps_per_file``'s default value of 1 (whole file per chunk/partition) is used,
             regardless of ``open_files``.
         library (str or :doc:`uproot.interpretation.library.Library`): The library
             that is used to represent arrays. If ``library='np'`` it returns a dict
@@ -122,10 +122,10 @@ def dask(
       Examples: ``Path("rel/*.root")``, ``"/abs/*.root:tdirectory/ttree"``
     * dict: keys are filesystem paths, values are objects-within-ROOT paths.
       Example: ``{{"/data_v1/*.root": "ttree_v1", "/data_v2/*.root": "ttree_v2"}}``
-    * dict: keys are filesystem paths, values are dicts containing objects-within-ROOT
-      and chunks as a list of starts and stops or chunks as a list of offsets
-      Example: ``{{"/data_v1/tree1.root": {"object_path": "ttree_v1", "chunks": [[0, 10000], [15000, 20000], ...]},
-                   "/data_v1/tree2.root": {"object_path": "ttree_v1", "chunks": [0, 10000, 20000, ...]}}}``
+    * dict: keys are filesystem paths, values are dicts containing objects-within-ROOT and
+      steps (chunks/partitions) as a list of starts and stops or steps as a list of offsets
+      Example: ``{{"/data_v1/tree1.root": {"object_path": "ttree_v1", "steps": [[0, 10000], [15000, 20000], ...]},
+                   "/data_v1/tree2.root": {"object_path": "ttree_v1", "steps": [0, 10000, 20000, ...]}}}``
       (This ``files`` pattern is incompatible with ``step_size`` and ``steps_per_file``.)
     * already-open TTree objects.
     * iterables of the above.
@@ -154,7 +154,7 @@ def dask(
       array from ``TTrees``.
     """
 
-    files = uproot._util.regularize_files(files, chunks_allowed=True)
+    files = uproot._util.regularize_files(files, steps_allowed=True)
 
     is_3arg = [len(x) == 3 for x in files]
     if any(is_3arg):

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1148,6 +1148,7 @@ def _get_dak_array_delay_open(
         interp_options.get("ak_add_doc"),
     )
 
+    divisions = [0]
     partition_args = []
     for ifile_iobject_maybeichunks in files:
         chunks = None
@@ -1157,6 +1158,7 @@ def _get_dak_array_delay_open(
 
         if chunks is not None:
             for start, stop in chunks:
+                divisions.append(divisions[-1] + (stop - start))
                 partition_args.append(
                     (
                         ifile_path,
@@ -1167,6 +1169,7 @@ def _get_dak_array_delay_open(
                     )
                 )
         else:
+            divisions = None  # they all have it or none of them have it
             for istep in range(steps_per_file):
                 partition_args.append(
                     (
@@ -1190,6 +1193,7 @@ def _get_dak_array_delay_open(
             rendered_form=None if form_mapping is None else form,
         ),
         partition_args,
+        divisions=None if divisions is None else tuple(divisions),
         label="from-uproot",
         behavior=None if form_mapping is None else form_mapping.behavior,
         meta=meta,

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -124,8 +124,8 @@ def dask(
       Example: ``{{"/data_v1/*.root": "ttree_v1", "/data_v2/*.root": "ttree_v2"}}``
     * dict: keys are filesystem paths, values are dicts containing objects-within-ROOT
       and chunks as a list of starts and stops or chunks as a list of offsets
-      Example: ``{{"/data_v1/tree1.root": {"objectpath": "ttree_v1", "chunks": [[0, 10000], [15000, 20000], ...]},
-                   "/data_v1/tree2.root": {"objectpath": "ttree_v1", "chunks": [0, 10000, 20000, ...]}}}``
+      Example: ``{{"/data_v1/tree1.root": {"object_path": "ttree_v1", "chunks": [[0, 10000], [15000, 20000], ...]},
+                   "/data_v1/tree2.root": {"object_path": "ttree_v1", "chunks": [0, 10000, 20000, ...]}}}``
     * already-open TTree objects.
     * iterables of the above.
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -126,6 +126,7 @@ def dask(
       and chunks as a list of starts and stops or chunks as a list of offsets
       Example: ``{{"/data_v1/tree1.root": {"object_path": "ttree_v1", "chunks": [[0, 10000], [15000, 20000], ...]},
                    "/data_v1/tree2.root": {"object_path": "ttree_v1", "chunks": [0, 10000, 20000, ...]}}}``
+      (This ``files`` pattern is incompatible with ``step_size`` and ``steps_per_file``.)
     * already-open TTree objects.
     * iterables of the above.
 
@@ -154,6 +155,21 @@ def dask(
     """
 
     files = uproot._util.regularize_files(files, chunks_allowed=True)
+
+    is_3arg = [len(x) == 3 for x in files]
+    if any(is_3arg):
+        if not all(is_3arg):
+            raise TypeError(
+                "partition sizes for some but not all 'files' have been assigned"
+            )
+        if step_size is not unset:
+            raise TypeError(
+                "partition sizes for 'files' is incompatible with 'step_size'"
+            )
+        if steps_per_file is not unset:
+            raise TypeError(
+                "partition sizes for 'files' is incompatible with 'steps_per_file'"
+            )
 
     library = uproot.interpretation.library._regularize_library(library)
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -491,6 +491,7 @@ def _get_dask_array(
     steps_per_file,
 ):
     ttrees = []
+    explicit_chunks = []
     common_keys = None
     is_self = []
 
@@ -518,6 +519,10 @@ def _get_dask_array(
                 real_filter_branch = filter_branch
 
             ttrees.append(obj)
+            if len(file_object_maybechunks) == 3:
+                explicit_chunks.append(file_object_maybechunks[2])
+            else:
+                explicit_chunks = None  # they all have it or none of them have it
 
             new_keys = obj.keys(
                 recursive=recursive,
@@ -604,14 +609,22 @@ def _get_dask_array(
             entry_start = 0
             entry_stop = ttree.num_entries
 
-            def foreach(start):
-                stop = min(start + entry_step, entry_stop)  # noqa: B023
-                length = stop - start
-                chunks.append(length)  # noqa: B023
-                chunk_args.append((i, start, stop))  # noqa: B023
-
-            for start in range(entry_start, entry_stop, entry_step):
-                foreach(start)
+            if explicit_chunks is None:
+                for start in range(entry_start, entry_stop, entry_step):
+                    stop = min(start + entry_step, entry_stop)
+                    length = stop - start
+                    if length > 0:
+                        chunks.append(length)
+                        chunk_args.append((i, start, stop))
+            else:
+                for explicit_start, explicit_stop in explicit_chunks[i]:
+                    # clip to the end of the TTree
+                    start = min(explicit_start, entry_stop)
+                    stop = min(explicit_stop, entry_stop)
+                    length = stop - start
+                    if length > 0:
+                        chunks.append(length)
+                        chunk_args.append((i, start, stop))
 
         if len(chunk_args) == 0:
             chunks.append(0)

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -487,7 +487,9 @@ def _get_dask_array(
     is_self = []
 
     count = 0
-    for file_path, object_path in files:
+    for file_object_maybechunks in files:
+        file_path, object_path = file_object_maybechunks[0:2]
+
         obj = uproot._util.regularize_object_path(
             file_path, object_path, custom_classes, allow_missing, real_options
         )
@@ -631,7 +633,7 @@ def _get_dask_array_delay_open(
     interp_options,
     steps_per_file,
 ):
-    ffile_path, fobject_path = files[0]
+    ffile_path, fobject_path = files[0][0:2]
     obj = uproot._util.regularize_object_path(
         ffile_path, fobject_path, custom_classes, allow_missing, real_options
     )
@@ -653,7 +655,11 @@ def _get_dask_array_delay_open(
             dt, inner_shape = dt.subdtype
 
         partition_args = []
-        for ifile_path, iobject_path in files:
+        for ifile_iobject_maybeichunks in files:
+            ifile_path, iobject_path = ifile_iobject_maybeichunks[0:2]
+            if len(ifile_iobject_maybeichunks) == 3:
+                ifile_iobject_maybeichunks[2]
+
             for istep in range(steps_per_file):
                 partition_args.append(
                     (
@@ -917,8 +923,6 @@ def _get_dak_array(
     count = 0
     for file_object_maybechunks in files:
         file_path, object_path = file_object_maybechunks[0:2]
-        if len(file_object_maybechunks) == 3:
-            file_object_maybechunks[2]
 
         obj = uproot._util.regularize_object_path(
             file_path, object_path, custom_classes, allow_missing, real_options

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1058,12 +1058,9 @@ def _get_dak_array(
         entry_start = 0
         entry_stop = ttree.num_entries
 
-        def foreach(start):
-            stop = min(start + entry_step, entry_stop)  # noqa: B023
-            partition_args.append((i, start, stop))  # noqa: B023
-
         for start in range(entry_start, entry_stop, entry_step):
-            foreach(start)
+            stop = min(start + entry_step, entry_stop)
+            partition_args.append((i, start, stop))
 
     meta, form = _get_meta_array(
         awkward,

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -823,7 +823,7 @@ def regularize_steps(steps):
             )
 
     elif len(out.shape) == 2:
-        if not (all(out[:, 1] >= out[:, 0]) and out.shape[1] == 2):
+        if not (out.shape[1] == 2 and all(out[:, 1] >= out[:, 0])):
             raise ValueError(
                 "if 'files' argument's steps are (two-dimensional) start-stop pairs, all stops must be greater than or equal to their corresponding starts"
             )

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -823,7 +823,7 @@ def regularize_steps(steps):
             )
 
     elif len(out.shape) == 2:
-        if not all(out[:, 1] >= out[:, 0]):
+        if not (all(out[:, 1] >= out[:, 0]) and out.shape[1] == 2):
             raise ValueError(
                 "if 'files' argument's steps are (two-dimensional) start-stop pairs, all stops must be greater than or equal to their corresponding starts"
             )
@@ -834,9 +834,9 @@ def regularize_steps(steps):
         )
 
     if len(out.shape) == 1:
-        out = numpy.stack((out[:-1], out[1:]), axis=1).tolist()
+        out = numpy.stack((out[:-1], out[1:]), axis=1)
 
-    return out
+    return out.tolist()
 
 
 def _regularize_files_inner(files, parse_colon, counter, HasBranches, steps_allowed):

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -918,7 +918,7 @@ def _regularize_files_inner(files, parse_colon, counter, HasBranches, chunks_all
         )
 
 
-def regularize_files(files, chunks_allowed=False):
+def regularize_files(files, chunks_allowed):
     """
     Common code for regularizing the possible file inputs accepted by uproot so they can be used by uproot internal functions.
     """

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -175,7 +175,7 @@ def iterate(
       array from ``TTrees``.
     * :doc:`uproot._dask.dask`: returns an unevaluated Dask array from ``TTrees``.
     """
-    files = uproot._util.regularize_files(files)
+    files = uproot._util.regularize_files(files, chunks_allowed=False)
     decompression_executor, interpretation_executor = _regularize_executors(
         decompression_executor, interpretation_executor, None
     )
@@ -343,7 +343,7 @@ def concatenate(
       single concatenated array from ``TTrees``.
     * :doc:`uproot._dask.dask`: returns an unevaluated Dask array from ``TTrees``.
     """
-    files = uproot._util.regularize_files(files)
+    files = uproot._util.regularize_files(files, chunks_allowed=False)
     decompression_executor, interpretation_executor = _regularize_executors(
         decompression_executor, interpretation_executor, None
     )

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -175,7 +175,7 @@ def iterate(
       array from ``TTrees``.
     * :doc:`uproot._dask.dask`: returns an unevaluated Dask array from ``TTrees``.
     """
-    files = uproot._util.regularize_files(files, chunks_allowed=False)
+    files = uproot._util.regularize_files(files, steps_allowed=False)
     decompression_executor, interpretation_executor = _regularize_executors(
         decompression_executor, interpretation_executor, None
     )
@@ -343,7 +343,7 @@ def concatenate(
       single concatenated array from ``TTrees``.
     * :doc:`uproot._dask.dask`: returns an unevaluated Dask array from ``TTrees``.
     """
-    files = uproot._util.regularize_files(files, chunks_allowed=False)
+    files = uproot._util.regularize_files(files, steps_allowed=False)
     decompression_executor, interpretation_executor = _regularize_executors(
         decompression_executor, interpretation_executor, None
     )

--- a/src/uproot/models/TTree.py
+++ b/src/uproot/models/TTree.py
@@ -959,7 +959,7 @@ def num_entries(paths):
     Returns an iterator over the number of entries over each TTree in the input.
     This is a shortcut method and reads lesser data than normal file opening.
     """
-    paths2 = uproot._util.regularize_files(paths)
+    paths2 = uproot._util.regularize_files(paths, chunks_allowed=False)
 
     if isinstance(paths, dict):
         paths = list(paths.items())

--- a/src/uproot/models/TTree.py
+++ b/src/uproot/models/TTree.py
@@ -959,7 +959,7 @@ def num_entries(paths):
     Returns an iterator over the number of entries over each TTree in the input.
     This is a shortcut method and reads lesser data than normal file opening.
     """
-    paths2 = uproot._util.regularize_files(paths, chunks_allowed=False)
+    paths2 = uproot._util.regularize_files(paths, steps_allowed=False)
 
     if isinstance(paths, dict):
         paths = list(paths.items())

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -61,7 +61,7 @@ def test_supplied_chunks(open_files, library):
 
     if library == "ak":
         if open_files:
-            assert daskarr.divisions == (None, None, None, None, None)
+            assert daskarr.divisions == (0, 1000, 2304, 3304, 4608)
         else:
             assert daskarr.divisions == (None, None, None, None, None)
     else:

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -40,7 +40,8 @@ def test_multiple_delay_open():
     assert arr.all()
 
 
-def test_supplied_chunks():
+@pytest.mark.parametrize("open_files", [False, True])
+def test_supplied_chunks(open_files):
     filename1 = skhep_testdata.data_path("uproot-Zmumu.root")
     filename2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
     true_val = uproot.concatenate([filename1 + ":events", filename2 + ":events"])
@@ -53,9 +54,13 @@ def test_supplied_chunks():
         filename2: {"object_path": "events", "chunks": chunks2},
     }
 
-    assert uproot.dask(files, open_files=False)["px1"].divisions == (None, None, None)
+    assert uproot.dask(files, open_files=open_files)["px1"].divisions == (
+        None,
+        None,
+        None,
+    )
     arr = (
-        uproot.dask([filename1, filename2], open_files=False)["px1"].compute()
+        uproot.dask([filename1, filename2], open_files=open_files)["px1"].compute()
         == true_val["px1"]
     )
     assert arr.to_numpy().all()

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -41,11 +41,12 @@ def test_multiple_delay_open():
 
 
 @pytest.mark.parametrize("open_files", [False, True])
-def test_supplied_chunks(open_files):
+@pytest.mark.parametrize("library", ["np", "ak"])
+def test_supplied_chunks(open_files, library):
     filename1 = skhep_testdata.data_path("uproot-Zmumu.root")
     filename2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
     true_val = uproot.concatenate(
-        [filename1 + ":events", filename2 + ":events"], "px1"
+        [filename1 + ":events", filename2 + ":events"], "px1", library=library
     )["px1"]
 
     chunks1 = [0, 1000, 2304]
@@ -56,11 +57,12 @@ def test_supplied_chunks(open_files):
         filename2: {"object_path": "events", "chunks": chunks2},
     }
 
-    daskarr = uproot.dask(files, open_files=open_files)["px1"]
+    daskarr = uproot.dask(files, open_files=open_files, library=library)["px1"]
 
-    if open_files:
-        assert daskarr.divisions == (None, None, None)  # FIXME! (Jim)
-    else:
-        assert daskarr.divisions == (None, None, None, None, None)
+    if library == "ak":
+        if open_files:
+            assert daskarr.divisions == (None, None, None)  # FIXME! (Jim)
+        else:
+            assert daskarr.divisions == (None, None, None, None, None)
 
     assert numpy.all(daskarr.compute() == true_val)

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -47,7 +47,7 @@ def test_supplied_chunks(open_files, library):
     filename2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
     true_val = uproot.concatenate(
         [filename1 + ":events", filename2 + ":events"], "px1", library=library
-    )["px1"]
+    )["px1"].tolist()
 
     chunks1 = [0, 1000, 2304]
     chunks2 = [[0, 1000], [1000, 2304]]
@@ -64,5 +64,10 @@ def test_supplied_chunks(open_files, library):
             assert daskarr.divisions == (None, None, None)  # FIXME! (Jim)
         else:
             assert daskarr.divisions == (None, None, None, None, None)
+    else:
+        if open_files:
+            assert daskarr.chunks == ((2304, 2304),)  # FIXME! (Jim)
+        else:
+            assert daskarr.chunks == ((1000, 1304, 1000, 1304),)
 
-    assert numpy.all(daskarr.compute() == true_val)
+    assert daskarr.compute().tolist() == true_val

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -38,3 +38,24 @@ def test_multiple_delay_open():
         == true_val["px1"]
     )
     assert arr.all()
+
+
+def test_supplied_chunks():
+    filename1 = skhep_testdata.data_path("uproot-Zmumu.root")
+    filename2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
+    true_val = uproot.concatenate([filename1 + ":events", filename2 + ":events"])
+
+    chunks1 = [0, 2305]
+    chunks2 = [[0, 2305]]
+
+    files = {
+        filename1: {"object_path": "events", "chunks": chunks1},
+        filename2: {"object_path": "events", "chunks": chunks2},
+    }
+
+    assert uproot.dask(files, open_files=False)["px1"].divisions == (None, None, None)
+    arr = (
+        uproot.dask([filename1, filename2], open_files=False)["px1"].compute()
+        == true_val["px1"]
+    )
+    assert arr.to_numpy().all()

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -49,21 +49,35 @@ def test_supplied_chunks(open_files, library):
         [filename1 + ":events", filename2 + ":events"], "px1", library=library
     )["px1"]
 
+    files = [filename1, filename2]
+    daskarr = uproot.dask(files, open_files=open_files, library=library)["px1"]
+
+    if library == "ak":
+        if open_files:
+            assert daskarr.divisions == (0, 2304, 4608)
+        else:
+            assert daskarr.divisions == (None, None, None)
+    else:
+        if open_files:
+            assert daskarr.chunks == ((2304, 2304),)
+        else:
+            assert daskarr.chunks == ((numpy.nan, numpy.nan),)
+
+    assert daskarr.compute().tolist() == true_val.tolist()
+
     chunks1 = [0, 1000, 2304]
     chunks2 = [[0, 1000], [1000, 2304]]
-
     files = {
         filename1: {"object_path": "events", "chunks": chunks1},
         filename2: {"object_path": "events", "chunks": chunks2},
     }
-
     daskarr = uproot.dask(files, open_files=open_files, library=library)["px1"]
 
     if library == "ak":
         if open_files:
             assert daskarr.divisions == (0, 1000, 2304, 3304, 4608)
         else:
-            assert daskarr.divisions == (None, None, None, None, None)
+            assert daskarr.divisions == (0, 1000, 2304, 3304, 4608)
     else:
         if open_files:
             assert daskarr.chunks == ((1000, 1304, 1000, 1304),)

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -61,7 +61,7 @@ def test_supplied_chunks(open_files, library):
 
     if library == "ak":
         if open_files:
-            assert daskarr.divisions == (None, None, None)  # FIXME! (Jim)
+            assert daskarr.divisions == (None, None, None, None, None)
         else:
             assert daskarr.divisions == (None, None, None, None, None)
     else:

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -44,7 +44,9 @@ def test_multiple_delay_open():
 def test_supplied_chunks(open_files):
     filename1 = skhep_testdata.data_path("uproot-Zmumu.root")
     filename2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
-    true_val = uproot.concatenate([filename1 + ":events", filename2 + ":events"])
+    true_val = uproot.concatenate(
+        [filename1 + ":events", filename2 + ":events"], "px1"
+    )["px1"]
 
     chunks1 = [0, 1000, 2304]
     chunks2 = [[0, 1000], [1000, 2304]]
@@ -61,8 +63,4 @@ def test_supplied_chunks(open_files):
     else:
         assert daskarr.divisions == (None, None, None, None, None)
 
-    arr = (
-        uproot.dask([filename1, filename2], open_files=open_files)["px1"].compute()
-        == true_val["px1"]
-    )
-    assert arr.to_numpy().all()
+    assert numpy.all(daskarr.compute() == true_val)

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -66,7 +66,7 @@ def test_supplied_chunks(open_files, library):
     assert daskarr.compute().tolist() == true_val.tolist()
 
     chunks1 = [0, 1000, 2304]
-    chunks2 = [[0, 1000], [1000, 2304]]
+    chunks2 = [[0, 1200], [1200, 2304]]
     files = {
         filename1: {"object_path": "events", "chunks": chunks1},
         filename2: {"object_path": "events", "chunks": chunks2},
@@ -75,13 +75,13 @@ def test_supplied_chunks(open_files, library):
 
     if library == "ak":
         if open_files:
-            assert daskarr.divisions == (0, 1000, 2304, 3304, 4608)
+            assert daskarr.divisions == (0, 1000, 2304, 3504, 4608)
         else:
-            assert daskarr.divisions == (0, 1000, 2304, 3304, 4608)
+            assert daskarr.divisions == (0, 1000, 2304, 3504, 4608)
     else:
         if open_files:
-            assert daskarr.chunks == ((1000, 1304, 1000, 1304),)
+            assert daskarr.chunks == ((1000, 1304, 1200, 1104),)
         else:
-            assert daskarr.chunks == ((1000, 1304, 1000, 1304),)
+            assert daskarr.chunks == ((1000, 1304, 1200, 1104),)
 
     assert daskarr.compute().tolist() == true_val.tolist()

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -47,7 +47,7 @@ def test_supplied_chunks(open_files, library):
     filename2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
     true_val = uproot.concatenate(
         [filename1 + ":events", filename2 + ":events"], "px1", library=library
-    )["px1"].tolist()
+    )["px1"]
 
     chunks1 = [0, 1000, 2304]
     chunks2 = [[0, 1000], [1000, 2304]]
@@ -66,8 +66,8 @@ def test_supplied_chunks(open_files, library):
             assert daskarr.divisions == (None, None, None, None, None)
     else:
         if open_files:
-            assert daskarr.chunks == ((2304, 2304),)  # FIXME! (Jim)
+            assert daskarr.chunks == ((1000, 1304, 1000, 1304),)
         else:
             assert daskarr.chunks == ((1000, 1304, 1000, 1304),)
 
-    assert daskarr.compute().tolist() == true_val
+    assert daskarr.compute().tolist() == true_val.tolist()

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -42,7 +42,7 @@ def test_multiple_delay_open():
 
 @pytest.mark.parametrize("open_files", [False, True])
 @pytest.mark.parametrize("library", ["np", "ak"])
-def test_supplied_chunks(open_files, library):
+def test_supplied_steps(open_files, library):
     filename1 = skhep_testdata.data_path("uproot-Zmumu.root")
     filename2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
     true_val = uproot.concatenate(
@@ -65,11 +65,11 @@ def test_supplied_chunks(open_files, library):
 
     assert daskarr.compute().tolist() == true_val.tolist()
 
-    chunks1 = [0, 1000, 2304]
-    chunks2 = [[0, 1200], [1200, 2304]]
+    steps1 = [0, 1000, 2304]
+    steps2 = [[0, 1200], [1200, 2304]]
     files = {
-        filename1: {"object_path": "events", "chunks": chunks1},
-        filename2: {"object_path": "events", "chunks": chunks2},
+        filename1: {"object_path": "events", "steps": steps1},
+        filename2: {"object_path": "events", "steps": steps2},
     }
     daskarr = uproot.dask(files, open_files=open_files, library=library)["px1"]
 

--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -46,19 +46,21 @@ def test_supplied_chunks(open_files):
     filename2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
     true_val = uproot.concatenate([filename1 + ":events", filename2 + ":events"])
 
-    chunks1 = [0, 2305]
-    chunks2 = [[0, 2305]]
+    chunks1 = [0, 1000, 2304]
+    chunks2 = [[0, 1000], [1000, 2304]]
 
     files = {
         filename1: {"object_path": "events", "chunks": chunks1},
         filename2: {"object_path": "events", "chunks": chunks2},
     }
 
-    assert uproot.dask(files, open_files=open_files)["px1"].divisions == (
-        None,
-        None,
-        None,
-    )
+    daskarr = uproot.dask(files, open_files=open_files)["px1"]
+
+    if open_files:
+        assert daskarr.divisions == (None, None, None)  # FIXME! (Jim)
+    else:
+        assert daskarr.divisions == (None, None, None, None, None)
+
     arr = (
         uproot.dask([filename1, filename2], open_files=open_files)["px1"].compute()
         == true_val["px1"]


### PR DESCRIPTION
Fixes #891

Example implemented for delayed-open.

---------------

From @jpivarski: implemented for four cases, `open_files=False`,`True` and `library="np"`,`"ak"`.

If any user-specified steps (we're calling them "steps," not "chunks" now) are out of bounds, this raises a `ValueError` in all four cases (though the `open_files=False` cases raise errors later than `open_files=True`).

If steps are specified, all four cases set Dask array `chunks` and dask-awkward `divisions`.

Also new: the `open_files=True` and `library="ak"` case wasn't setting `divisions`, though it should have been.