### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,6 @@ exclude = [
     "src/uproot/__init__.py",
     "docs-sphinx/*.py",
 ]
-target-version = "py37"
 src = ["src"]
 
 [tool.ruff.mccabe]


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos