### PR TITLE
feat: Support reading from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The following libraries are also useful in conjunction with Uproot, but are not 
 
 **For accessing remote files:**
 
-   * `xrootd`: if reading files with `root://` URLs.
+   * `minio`: if reading files with `s3://` URIs.
+   * `xrootd`: if reading files with `root://` URIs.
    * HTTP/S access is built in (Python standard library).
 
 **For distributed computing with [Dask](https://www.dask.org/):**

--- a/docs-sphinx/basic.rst
+++ b/docs-sphinx/basic.rst
@@ -18,7 +18,7 @@ The :doc:`uproot.reading.open` function can be (and usually should be) used like
     >>> with uproot.open("path/to/dataset.root") as file:
     ...     do_something...
 
-to automatically close the file after leaving the ``with`` block. The path-name argument can be a local file (as above), a URL ("``http://``" or "``https://``"), or XRootD ("``root://``") if you have the `Python interface to XRootD <https://anaconda.org/conda-forge/xrootd>`__ installed. It can also be a Python file-like object with ``read`` and ``seek`` methods, but such objects can't be read in parallel.
+to automatically close the file after leaving the ``with`` block. The path-name argument can be a local file (as above), a URL ("``http://``" or "``https://``"), S3 ("``s3://``) or XRootD ("``root://``") if you have the `Python interface to XRootD <https://anaconda.org/conda-forge/xrootd>`__ installed. It can also be a Python file-like object with ``read`` and ``seek`` methods, but such objects can't be read in parallel.
 
 The :doc:`uproot.reading.open` function has many options, including alternate handlers for each input type, ``num_workers`` to control parallel reading, and caches (``object_cache`` and ``array_cache``). The defaults attempt to optimize parallel processing, caching, and batching of remote requests, but better performance can often be obtained by tuning these parameters.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
 ]
 test = [
     "lz4",
+    "minio",
     "pytest>=6",
     "pytest-timeout",
     "pytest-rerunfailures",

--- a/src/uproot/__init__.py
+++ b/src/uproot/__init__.py
@@ -90,6 +90,7 @@ from uproot.source.http import HTTPSource
 from uproot.source.http import MultithreadedHTTPSource
 from uproot.source.xrootd import XRootDSource
 from uproot.source.xrootd import MultithreadedXRootDSource
+from uproot.source.s3 import S3Source
 from uproot.source.object import ObjectSource
 from uproot.source.cursor import Cursor
 from uproot.source.futures import TrivialExecutor

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -134,6 +134,7 @@ def dask(
 
     * file_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.file.MemmapSource`)
     * xrootd_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.xrootd.XRootDSource`)
+    * s3_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.s3.S3Source`)
     * http_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.http.HTTPSource`)
     * object_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.object.ObjectSource`)
     * timeout (float for HTTP, int for XRootD; 30)

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -377,8 +377,7 @@ def file_path_to_source_class(file_path, options):
         out = options["s3_handler"]
         if not (isinstance(out, type) and issubclass(out, uproot.source.chunk.Source)):
             raise TypeError(
-                "'s3' is not a class object inheriting from Source: "
-                + repr(out)
+                "'s3' is not a class object inheriting from Source: " + repr(out)
             )
         return out, file_path
 

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -154,6 +154,7 @@ def iterate(
 
     * file_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.file.MemmapSource`)
     * xrootd_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.xrootd.XRootDSource`)
+    * s3_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.s3.S3Source`)
     * http_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.http.HTTPSource`)
     * object_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.object.ObjectSource`)
     * timeout (float for HTTP, int for XRootD; 30)
@@ -325,6 +326,7 @@ def concatenate(
 
     * file_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.file.MemmapSource`)
     * xrootd_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.xrootd.XRootDSource`)
+    * s3_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.s3.S3Source`)
     * http_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.http.HTTPSource`)
     * object_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.object.ObjectSource`)
     * timeout (float for HTTP, int for XRootD; 30)

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -67,6 +67,26 @@ or
         return pandas
 
 
+def Minio_client():
+    """
+    Imports and returns ``minio.Minio``.
+    """
+    try:
+        from minio import Minio
+    except ModuleNotFoundError as err:
+        raise ModuleNotFoundError(
+            """install the 'minio' package with:
+
+    pip install minio
+
+or
+
+    conda install minio"""
+        ) from err
+    else:
+        return Minio
+
+
 def XRootD_client():
     """
     Imports and returns ``XRootD.client`` (after setting the

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -79,6 +79,7 @@ def open(
 
     * file_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.file.MemmapSource`)
     * xrootd_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.xrootd.XRootDSource`)
+    * s3_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.s3.S3Source`)
     * http_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.http.HTTPSource`)
     * object_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.object.ObjectSource`)
     * timeout (float for HTTP, int for XRootD; 30)
@@ -179,6 +180,7 @@ class _OpenDefaults(dict):
 open.defaults = _OpenDefaults(
     {
         "file_handler": uproot.source.file.MemmapSource,
+        "s3_handler": uproot.source.s3.S3Source,
         "http_handler": uproot.source.http.HTTPSource,
         "object_handler": uproot.source.object.ObjectSource,
         "timeout": 30,
@@ -534,6 +536,7 @@ class ReadOnlyFile(CommonFileMethods):
 
     * file_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.file.MemmapSource`)
     * xrootd_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.xrootd.XRootDSource`)
+    * s3_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.xrootd.S3Source`)
     * http_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.http.HTTPSource`)
     * object_handler (:doc:`uproot.source.chunk.Source` class; :doc:`uproot.source.object.ObjectSource`)
     * timeout (float for HTTP, int for XRootD; 30)

--- a/src/uproot/source/__init__.py
+++ b/src/uproot/source/__init__.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
 
 """
-This module defines the "physical layer" of file-reading, which interacts with local
-filesystems or remote protocols like HTTP(S) and XRootD. The "physical layer"
-is distinguished from "interpretation" in that the meaning of the bytes that
-have been read are not relevant in this layer. The "interpretation layer"
-interacts with the "physical layer" by requesting a
+This module defines the "physical layer" of file-reading, which interacts with
+local filesystems or remote protocols like HTTP(S), S3 and XRootD. The
+"physical layer" is distinguished from "interpretation" in that the meaning of
+the bytes that have been read are not relevant in this layer. The
+"interpretation layer" interacts with the "physical layer" by requesting a
 :doc:`uproot.source.chunk.Chunk` from a :doc:`uproot.source.chunk.Source` and
 inspecting it with a :doc:`uproot.source.cursor.Cursor`.
 

--- a/src/uproot/source/s3.py
+++ b/src/uproot/source/s3.py
@@ -5,7 +5,7 @@ This module defines a physical layer for remote files, accessed via S3.
 """
 
 import os
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import parse_qsl, urlparse
 
 import uproot.extras
 import uproot.source.http
@@ -25,15 +25,33 @@ class S3Source(uproot.source.http.HTTPSource):
         options: See :doc:`uproot.source.http.HTTPSource.__init__`
     """
 
-    def __init__(self, file_path, endpoint="s3.amazonaws.com", access_key=None, secret_key=None, session_token=None, secure=True, region=None, http_client=None, credentials=None, **options):
+    def __init__(
+        self,
+        file_path,
+        endpoint="s3.amazonaws.com",
+        access_key=None,
+        secret_key=None,
+        session_token=None,
+        secure=True,
+        region=None,
+        http_client=None,
+        credentials=None,
+        **options,
+    ):
         Minio = uproot.extras.Minio_client()
 
         if access_key is None:
-            access_key = os.environ.get("S3_ACCESS_KEY", os.environ.get("AWS_ACCESS_KEY_ID", None))
+            access_key = os.environ.get(
+                "S3_ACCESS_KEY", os.environ.get("AWS_ACCESS_KEY_ID", None)
+            )
         if secret_key is None:
-            secret_key = os.environ.get("S3_SECRET_KEY", os.environ.get("AWS_SECRET_ACCESS_KEY", None))
+            secret_key = os.environ.get(
+                "S3_SECRET_KEY", os.environ.get("AWS_SECRET_ACCESS_KEY", None)
+            )
         if session_token is None:
-            session_token = os.environ.get("S3_SESSION_TOKEN", os.environ.get("AWS_SESSION_TOKEN", None))
+            session_token = os.environ.get(
+                "S3_SESSION_TOKEN", os.environ.get("AWS_SESSION_TOKEN", None)
+            )
         if region is None:
             region = os.environ.get("AWS_DEFAULT_REGION", None)
 

--- a/src/uproot/source/s3.py
+++ b/src/uproot/source/s3.py
@@ -20,8 +20,8 @@ class S3Source(uproot.source.http.HTTPSource):
         secret_key: Secret key of your S3 account
         session_token: Session token of your S3 account
         secure: Flag to enable use of TLS
-        http_client (urllib3.poolmanager.PoolManager): Instance of `urllib3.poolmanager.PoolManager`
-        credentials (minio.credentials.Provider): Instance of `minio.credentials.Provider`
+        http_client (urllib3.poolmanager.PoolManager): Instance of :doc:`urllib3.poolmanager.PoolManager`
+        credentials (minio.credentials.Provider): Instance of :doc:`minio.credentials.Provider`
         options: See :doc:`uproot.source.http.HTTPSource.__init__`
     """
 

--- a/src/uproot/source/s3.py
+++ b/src/uproot/source/s3.py
@@ -58,7 +58,8 @@ class S3Source(uproot.source.http.HTTPSource):
         parsed_url = urlparse(file_path)
 
         bucket_name = parsed_url.netloc
-        object_name = parsed_url.path
+        assert parsed_url.path[0] == "/"
+        object_name = parsed_url.path[1:]
 
         parsed_query = dict(parse_qsl(parsed_url.query))
         # There is no standard scheme for s3:// URI query parameters,

--- a/src/uproot/source/s3.py
+++ b/src/uproot/source/s3.py
@@ -29,11 +29,11 @@ class S3Source(uproot.source.http.HTTPSource):
         Minio = uproot.extras.Minio_client()
 
         if access_key is None:
-            access_key = os.environ.get("AWS_ACCESS_KEY_ID", None)
+            access_key = os.environ.get("S3_ACCESS_KEY", os.environ.get("AWS_ACCESS_KEY_ID", None))
         if secret_key is None:
-            secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
+            secret_key = os.environ.get("S3_SECRET_KEY", os.environ.get("AWS_SECRET_ACCESS_KEY", None))
         if session_token is None:
-            session_token = os.environ.get("AWS_SESSION_TOKEN", None)
+            session_token = os.environ.get("S3_SESSION_TOKEN", os.environ.get("AWS_SESSION_TOKEN", None))
         if region is None:
             region = os.environ.get("AWS_DEFAULT_REGION", None)
 

--- a/src/uproot/source/s3.py
+++ b/src/uproot/source/s3.py
@@ -1,0 +1,66 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""
+This module defines a physical layer for remote files, accessed via S3.
+"""
+
+import os
+from urllib.parse import urlparse, parse_qsl
+
+import uproot.extras
+import uproot.source.http
+
+
+class S3Source(uproot.source.http.HTTPSource):
+    """
+    Args:
+        file_path (str): A URL of the file to open.
+        endpoint: S3 endpoint (defaults to AWS)
+        access_key: Access key of your S3 account
+        secret_key: Secret key of your S3 account
+        session_token: Session token of your S3 account
+        secure: Flag to enable use of TLS
+        http_client (urllib3.poolmanager.PoolManager): Instance of `urllib3.poolmanager.PoolManager`
+        credentials (minio.credentials.Provider): Instance of `minio.credentials.Provider`
+        options: See :doc:`uproot.source.http.HTTPSource.__init__`
+    """
+
+    def __init__(self, file_path, endpoint="s3.amazonaws.com", access_key=None, secret_key=None, session_token=None, secure=True, region=None, http_client=None, credentials=None, **options):
+        Minio = uproot.extras.Minio_client()
+
+        if access_key is None:
+            access_key = os.environ.get("AWS_ACCESS_KEY_ID", None)
+        if secret_key is None:
+            secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
+        if session_token is None:
+            session_token = os.environ.get("AWS_SESSION_TOKEN", None)
+        if region is None:
+            region = os.environ.get("AWS_DEFAULT_REGION", None)
+
+        parsed_url = urlparse(file_path)
+
+        bucket_name = parsed_url.netloc
+        object_name = parsed_url.path
+
+        parsed_query = dict(parse_qsl(parsed_url.query))
+        # There is no standard scheme for s3:// URI query parameters,
+        # but some are often introduced to support extra flexibility:
+        if "endpoint" in parsed_query:
+            endpoint = parsed_query["endpoint"]
+        if "region" in parsed_query:
+            region = parsed_query["region"]
+
+        client = Minio(
+            endpoint,
+            access_key=access_key,
+            secret_key=secret_key,
+            session_token=session_token,
+            secure=secure,
+            region=region,
+            http_client=http_client,
+            credentials=credentials,
+        )
+
+        url = client.get_presigned_url("GET", bucket_name, object_name)
+
+        super().__init__(url, **options)

--- a/tests/test_0916-read-from-s3.py
+++ b/tests/test_0916-read-from-s3.py
@@ -19,5 +19,5 @@ def test_read_s3():
     with uproot.open(
         "s3://pivarski-princeton/pythia_ppZee_run17emb.picoDst.root:PicoDst"
     ) as f:
-        data = f["Track/Track.mPMomentum"].array(library="np")
-        assert len(data) == 100000
+        data = f["Event/Event.mEventId"].array(library="np")
+        assert len(data) == 8004

--- a/tests/test_0916-read-from-s3.py
+++ b/tests/test_0916-read-from-s3.py
@@ -14,7 +14,6 @@ def test_s3_fail():
             tobytes(source.chunk(0, 100).raw_data)
 
 
-@pytest.mark.xfail
 @pytest.mark.network
 def test_read_s3():
     with uproot.open(

--- a/tests/test_0916-read-from-s3.py
+++ b/tests/test_0916-read-from-s3.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import pytest
+
+import uproot
+
+
+@pytest.mark.network
+def test_s3_fail():
+    with pytest.raises(Exception):
+        with uproot.source.http.S3Source(
+            "s3://pivarski-princeton/does-not-exist", timeout=0.1
+        ) as source:
+            tobytes(source.chunk(0, 100).raw_data)
+
+
+@pytest.mark.xfail
+@pytest.mark.network
+def test_read_s3():
+    with uproot.open(
+        "s3://pivarski-princeton/pythia_ppZee_run17emb.picoDst.root:PicoDst"
+    ) as f:
+        data = f["Track/Track.mPMomentum"].array(library="np")
+        assert len(data) == 100000


### PR DESCRIPTION
This introduces support for for accessing files from S3. The `minio` client is used to interact with S3 service provider to obtain a presigned http URL that is valid for 7 days. The S3 method for getting objects is not used for simplicity, but also there is an assumption that the HTTP multipart queries might have a better performance.

With regards to choice of URI format, the `s3://<bucket>/<object>` schema as supported by the `aws` tool is implemented with some extensions to allow for non-AWS endpoints. Officially, there are also supposed to be another two formats[1]:

 - *virtual-hosted-style* `https://<bucket>.s3.<region>.amazonaws.com/<object>`
 - *path-style* `https://s3.<region>.amazonaws.com/<bucket>/<object>` which is "deprecated"

For these urls is not clear how to differentiate between the standard HTTPS and the S3 in the case when non-AWS endpoint is used.
It is worth noting that, in ROOT, `TS3WebFile` introduces some *path-style* schemas that don't fit any of the known tools.

[1] https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html

### TODO:
 - [x] update documentation
 - [x] add tests (need permanent public instance)

Resolves: #443

cc @wdconinc @sly2j