### PR TITLE
chore: skip pandas test if pandas is not installed

### DIFF
--- a/tests/test_0930-expressions-in-pandas.py
+++ b/tests/test_0930-expressions-in-pandas.py
@@ -6,6 +6,7 @@ import uproot
 
 
 def test_expressions_in_pandas(tmp_path):
+    pandas = pytest.importorskip("pandas")
     filename = os.path.join(tmp_path, "uproot_test_pandas_expressions.root")
     # create tmp file
     with uproot.recreate(filename) as file:


### PR DESCRIPTION
The test introduced in #930 depends on pandas.
Like other tests, it should be skipped if pandas cannot be imported.