### PR TITLE
Fix changelog script

### DIFF
--- a/docs-sphinx/make_changelog.py
+++ b/docs-sphinx/make_changelog.py
@@ -12,7 +12,7 @@ tagslist_text = subprocess.run(
 ).stdout
 tagslist = {
     k: v
-    for k, v in re.findall(rb"([0-9a-f]{40}) refs/tags/([0-9\.rc]+)", tagslist_text)
+    for k, v in re.findall(rb"([0-9a-f]{40}) refs/tags/(v?[0-9\.rc]+)", tagslist_text)
     if not v.startswith(b"0.")
 }
 

--- a/docs-sphinx/make_changelog.py
+++ b/docs-sphinx/make_changelog.py
@@ -28,8 +28,8 @@ for pageid in range(numpages):
     print(f"Requesting GitHub data, page {pageid + 1} of {numpages}")
     github_connection.request(
         "GET",
-        rf"/repos/scikit-hep/uproot4/releases?page={pageid + 1}&per_page=30",
-        headers={"User-Agent": "uproot4-changelog"},
+        rf"/repos/scikit-hep/uproot5/releases?page={pageid + 1}&per_page=30",
+        headers={"User-Agent": "uproot5-changelog"},
     )
     github_releases_text = github_connection.getresponse().read()
     try:
@@ -214,7 +214,7 @@ Uproot versions 1 through 3 were in a different GitHub repository: `scikit-hep/u
 
 This was to allow users to transition from Awkward Array 0.x and Uproot 3.x, which had different interfaces (especially Awkward Array). The transition completed on December 1, 2020.
 
-.. image:: https://raw.githubusercontent.com/scikit-hep/uproot4/main/docs-img/diagrams/uproot-awkward-timeline.png
+.. image:: https://raw.githubusercontent.com/scikit-hep/uproot5/main/docs-img/diagrams/uproot-awkward-timeline.png
   :width: 100%
 """
     )


### PR DESCRIPTION
I noticed that https://uproot.readthedocs.io/en/latest/changelog.html currently doesn’t list any releases past `5.0.0rc2`; all PRs in later releases are listed under “Unreleased”. This is due to a change in the tag schema: Tags for all releases from `v5.0.0rc3` onward start with `v`, while tags for previous releases didn’t. This PR fixes the regex to accept both styles of tags.

This PR also updates the repo URL, since the old uproot4 repo URL now returns a redirect message instead of the expected releases:
```Python
>>> github_connection = http.client.HTTPSConnection("api.github.com")
>>> github_connection.request(
        "GET",
        rf"/repos/scikit-hep/uproot4/releases?page={pageid + 1}&per_page=30",
        headers={"User-Agent": "uproot4-changelog"},
    )
>>> github_connection.getresponse().read()
b'{"message":"Moved Permanently","url":"https://api.github.com/repositories/262422450/releases?page=3&per_page=30","documentation_url":"https://docs.github.com/v3/#http-redirects"}'
```

---

Note: Releases in the v4.3.x series are still ignored by this script, since they are on the separate `main-v4` branch, not on `main`. Do you think it’s worth adding something like
```Python
outfile.write("Note: Releases in the 4.3.x series were developed in parallel with v5.0 on a separate branch and are not included here. See https://github.com/scikit-hep/uproot5/releases for details on those releases.\n")
```
in line 78, after the “Release History” header, to avoid confusion?