### PR TITLE
fix: get package import messages up-to-date

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -92,22 +92,6 @@ def dask(
         >>> uproot.dask(root_file,library='np')
         {'Type': dask.array<Type-from-uproot, shape=(2304,), dtype=object, chunksize=(2304,), chunktype=numpy.ndarray>, ...}
 
-
-    This function (naturally) depends on Dask. To use it with ``library="np"``:
-
-    .. code-block:: bash
-
-        # with pip
-        pip install "dask[complete]"
-        # or with conda
-        conda install dask
-
-    For using ``library='ak'``
-
-    .. code-block:: bash
-
-        pip install dask-awkward   # not on conda-forge yet
-
     Allowed types for the ``files`` parameter:
 
     * str/bytes: relative or absolute filesystem path or URL, without any colons

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -323,8 +323,7 @@ def dask_awkward():
             """for uproot.dask, install 'dask' and the 'dask-awkward' package with:
     pip install "dask[complete] dask-awkward"
 or
-    conda install dask
-    pip install dask-awkward   # not on conda-forge yet"""
+    conda install -c conda-forge dask dask-awkward"""
         ) from err
     else:
         return dask_awkward
@@ -339,7 +338,9 @@ def awkward_pandas():
     except ModuleNotFoundError as err:
         raise ModuleNotFoundError(
             """install the 'awkward-pandas' package with:
-    pip install awkward-pandas # not on conda-forge yet"""
+    pip install awkward-pandas
+or
+    conda install -c conda-forge awkward-pandas"""
         ) from err
     else:
         return awkward_pandas


### PR DESCRIPTION
dask-awkward and awkward-pandas are both on conda now.

Also consistently added `-c conda-forge` to the packages that are only on conda-forge (though users would have a problem if they mix conda channels, but we can't force conda channel hygene on them).

Removed the text from the `uproot.dask` docstring about installing Dask, just to ensure that the message is in only one place (error message when you attempt to use a package that isn't there), so that it can be updated in one place. That's the whole reason for having an extras.py, after all.