### PR TITLE
docs: _dask.py: fix docstring formatting

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -105,11 +105,14 @@ def dask(
     * glob syntax in str/bytes and pathlib.Path.
       Examples: ``Path("rel/*.root")``, ``"/abs/*.root:tdirectory/ttree"``
     * dict: keys are filesystem paths, values are objects-within-ROOT paths.
-      Example: ``{{"/data_v1/*.root": "ttree_v1", "/data_v2/*.root": "ttree_v2"}}``
+      Example: ``{"/data_v1/*.root": "ttree_v1", "/data_v2/*.root": "ttree_v2"}``
     * dict: keys are filesystem paths, values are dicts containing objects-within-ROOT and
       steps (chunks/partitions) as a list of starts and stops or steps as a list of offsets
-      Example: ``{{"/data_v1/tree1.root": {"object_path": "ttree_v1", "steps": [[0, 10000], [15000, 20000], ...]},
-                   "/data_v1/tree2.root": {"object_path": "ttree_v1", "steps": [0, 10000, 20000, ...]}}}``
+      Example:
+      
+          {{"/data_v1/tree1.root": {"object_path": "ttree_v1", "steps": [[0, 10000], [15000, 20000], ...]},
+            "/data_v1/tree2.root": {"object_path": "ttree_v1", "steps": [0, 10000, 20000, ...]}}}
+            
       (This ``files`` pattern is incompatible with ``step_size`` and ``steps_per_file``.)
     * already-open TTree objects.
     * iterables of the above.

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -109,10 +109,10 @@ def dask(
     * dict: keys are filesystem paths, values are dicts containing objects-within-ROOT and
       steps (chunks/partitions) as a list of starts and stops or steps as a list of offsets
       Example:
-      
+
           {{"/data_v1/tree1.root": {"object_path": "ttree_v1", "steps": [[0, 10000], [15000, 20000], ...]},
             "/data_v1/tree2.root": {"object_path": "ttree_v1", "steps": [0, 10000, 20000, ...]}}}
-            
+
       (This ``files`` pattern is incompatible with ``step_size`` and ``steps_per_file``.)
     * already-open TTree objects.
     * iterables of the above.


### PR DESCRIPTION
* Remove extra {} around the dictionary example.
* Multiline literals are not a thing, convert that to a code block.