### PR TITLE
test: skip if dask-awkward, an optional dependency, is missing

### DIFF
--- a/tests/test_0603-dask-delayed-open.py
+++ b/tests/test_0603-dask-delayed-open.py
@@ -8,6 +8,7 @@ import uproot
 
 dask = pytest.importorskip("dask")
 da = pytest.importorskip("dask.array")
+dask_awkward = pytest.importorskip("dask-awkward")
 
 
 def test_single_delay_open():

--- a/tests/test_0916-read-from-s3.py
+++ b/tests/test_0916-read-from-s3.py
@@ -4,6 +4,8 @@ import pytest
 
 import uproot
 
+pytest.importorskip("minio")
+
 
 @pytest.mark.network
 def test_s3_fail():


### PR DESCRIPTION
We missed this because all of the test-runners that have Dask installed also have dask-awkward installed. In principle, someone might run the tests in an environment that does not.