### PR TITLE
test: skip RNTuple test until #928 is fixed

### DIFF
--- a/tests/test_0662-rntuple-stl-containers.py
+++ b/tests/test_0662-rntuple-stl-containers.py
@@ -13,6 +13,9 @@ import uproot
 ak = pytest.importorskip("awkward")
 
 
+@pytest.mark.skip(
+    reason="FIXME: skipping test_ntuple_stl_containers.root until #928 is fixed"
+)
 def test_rntuple_stl_containers():
     filename = skhep_testdata.data_path("test_ntuple_stl_containers.root")
     with uproot.open(filename) as f:


### PR DESCRIPTION
We're going to need a stable set of tests for vetting #966. Perhaps it hasn't been happening in CI, but tests/test_0662-rntuple-stl-containers.py has been failing for me locally, presumably because #928 is not resolved (and CI is somehow skipping this one?).