### PR TITLE
fix: typo in `uproot.source.xrootd.XRootDSource` name

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -432,7 +432,7 @@ after the first `import uproot` or use `@pytest.mark.filterwarnings("error:::upr
     elif parsed_url.scheme.upper() == "ROOT":
         out = options["xrootd_handler"]
         if out is None:
-            out = uproot.source.root.XRootDSource
+            out = uproot.source.xrootd.XRootDSource
         else:
             warnings.warn(
                 f"""In version 5.2.0, the 'xrootd_handler' argument will be removed from 'uproot.open'. Use

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -63,11 +63,15 @@ def test_open_fsspec_s3():
 
 @pytest.mark.network
 @pytest.mark.xrootd
-def test_open_fsspec_xrootd():
+@pytest.mark.parametrize(
+    "handler",
+    [uproot.source.fsspec.FSSpecSource, uproot.source.xrootd.XRootDSource, None],
+)
+def test_open_fsspec_xrootd(handler):
     pytest.importorskip("XRootD")
     with uproot.open(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
-        handler=uproot.source.fsspec.FSSpecSource,
+        handler=handler,
     ) as f:
         data = f["Events/run"].array(library="np", entry_stop=20)
         assert len(data) == 20


### PR DESCRIPTION
I scanned all of @lobis's PRs for "XRootDSource" and "source.root" and it only appeared in #971.

We need a test for it, though.