### PR TITLE
fix: remove unused hist import in test_0965

### DIFF
--- a/tests/test_0965-inverted-axes-variances-hist-888.py
+++ b/tests/test_0965-inverted-axes-variances-hist-888.py
@@ -2,10 +2,10 @@
 
 import pytest
 import numpy
-import hist
 import uproot
 import skhep_testdata
 
+pytest.importorskip("hist")
 ROOT = pytest.importorskip("ROOT")
 
 


### PR DESCRIPTION
Test 0965 fails:
```
==================================== ERRORS ====================================_____ ERROR collecting tests/test_0965-inverted-axes-variances-hist-888.py _____ImportError while importing test module '/build/source/tests/test_0965-inverted-axes-variances-hist-888.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/nix/store/pzf6dnxg8gf04xazzjdwarm7s03cbrgz-python3-3.10.12/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_0965-inverted-axes-variances-hist-888.py:5: in <module>
    import hist
E   ModuleNotFoundError: No module named 'hist'
```

It seems that the other tests relying on `hist` import it using `hist = pytest.importorskip("hist")`.
I did the same in this problematic test.