### PR TITLE
chore: add types to most of the `uproot.source` module

### DIFF
--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -60,7 +60,9 @@ class Source:
         :doc:`uproot.source.chunk.Chunk`.
         """
 
-    def chunks(self, ranges, notifications: queue.Queue) -> list[Chunk]:
+    def chunks(
+        self, ranges: list[(int, int)], notifications: queue.Queue
+    ) -> list[Chunk]:
         """
         Args:
             ranges (list of (int, int) 2-tuples): Intervals to fetch
@@ -164,7 +166,9 @@ class MultithreadedSource(Source):
         self._executor.submit(future)
         return chunk
 
-    def chunks(self, ranges, notifications: queue.Queue) -> list[Chunk]:
+    def chunks(
+        self, ranges: list[(int, int)], notifications: queue.Queue
+    ) -> list[Chunk]:
         self._num_requests += 1
         self._num_requested_chunks += len(ranges)
         self._num_requested_bytes += sum(stop - start for start, stop in ranges)

--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -31,7 +31,7 @@ class Resource:
     """
 
     @property
-    def file_path(self):
+    def file_path(self) -> str:
         """
         A path to the file (or URL).
         """
@@ -92,7 +92,7 @@ class Source:
         """
 
     @property
-    def file_path(self):
+    def file_path(self) -> str:
         """
         A path to the file (or URL).
         """

--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -464,7 +464,7 @@ outside expected range {self._start}:{self._stop} for this Chunk""",
             )
 
 
-def notifier(chunk: Chunk, notifications: queue.Queue) -> callable:
+def notifier(chunk: Chunk, notifications: queue.Queue):
     """
     Returns a function that puts the chunk on the notifications queue when called.
     The function has a 'future' argument to be compatible with the `concurrent.futures.Future.add_done_callback` method.

--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -244,7 +244,7 @@ class Chunk:
     _dtype = numpy.dtype(numpy.uint8)
 
     @classmethod
-    def wrap(cls, source: Source, data: numpy.ndarray, start: int = 0):
+    def wrap(cls, source: Source, data: numpy.ndarray | bytes, start: int = 0):
         """
         Args:
             source (:doc:`uproot.source.chunk.Source`): Source to attach to
@@ -374,7 +374,7 @@ for file path {self._source.file_path}"""
             self._future = None
 
     @property
-    def raw_data(self) -> numpy.ndarray:
+    def raw_data(self) -> numpy.ndarray | bytes:
         """
         Data from the Source as a ``numpy.ndarray`` of ``numpy.uint8``.
 

--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -49,7 +49,7 @@ class Source:
     the file.
     """
 
-    def chunk(self, start, stop) -> Chunk:
+    def chunk(self, start: int, stop: int) -> Chunk:
         """
         Args:
             start (int): Seek position of the first byte to include.
@@ -156,7 +156,7 @@ class MultithreadedSource(Source):
             type(self).__name__, path, self.num_workers, id(self)
         )
 
-    def chunk(self, start, stop) -> Chunk:
+    def chunk(self, start: int, stop: int) -> Chunk:
         self._num_requests += 1
         self._num_requested_chunks += 1
         self._num_requested_bytes += stop - start
@@ -190,7 +190,7 @@ class MultithreadedSource(Source):
         return self._executor
 
     @property
-    def num_workers(self):
+    def num_workers(self) -> int:
         """
         The number of :doc:`uproot.source.futures.ResourceWorker` threads in
         the :doc:`uproot.source.futures.ResourceThreadPoolExecutor`.
@@ -244,7 +244,7 @@ class Chunk:
     _dtype = numpy.dtype(numpy.uint8)
 
     @classmethod
-    def wrap(cls, source, data, start=0):
+    def wrap(cls, source: Source, data: numpy.ndarray, start: int = 0):
         """
         Args:
             source (:doc:`uproot.source.chunk.Source`): Source to attach to
@@ -259,7 +259,9 @@ class Chunk:
         future = uproot.source.futures.TrivialFuture(data)
         return Chunk(source, start, start + len(data), future)
 
-    def __init__(self, source, start, stop, future, is_memmap=False):
+    def __init__(
+        self, source: Source, start: int, stop: int, future, is_memmap: bool = False
+    ):
         self._source = source
         self._start = start
         self._stop = stop
@@ -271,21 +273,21 @@ class Chunk:
         return f"<Chunk {self._start}-{self._stop}>"
 
     @property
-    def source(self):
+    def source(self) -> Source:
         """
         Source from which this Chunk is derived.
         """
         return self._source
 
     @property
-    def start(self):
+    def start(self) -> int:
         """
         Seek position of the first byte to include.
         """
         return self._start
 
     @property
-    def stop(self):
+    def stop(self) -> int:
         """
         Seek position of the first byte to exclude (one greater than the last
         byte to include).
@@ -301,7 +303,7 @@ class Chunk:
         return self._future
 
     @property
-    def is_memmap(self):
+    def is_memmap(self) -> bool:
         """
         If True, the `raw_data` is or will be a view into a memmap file, which
         must be handled carefully. Accessing that data after the file is closed
@@ -330,7 +332,7 @@ class Chunk:
         else:
             return self
 
-    def __contains__(self, range):
+    def __contains__(self, range: tuple[int, int]):
         start, stop = range
         if isinstance(start, uproot.source.cursor.Cursor):
             start = start.index
@@ -338,7 +340,7 @@ class Chunk:
             stop = stop.index
         return self._start <= start and stop <= self._stop
 
-    def wait(self, insist=True):
+    def wait(self, insist: bool = True):
         """
         Args:
             insist (bool or int): If True, raise an OSError if ``raw_data`` does
@@ -372,7 +374,7 @@ for file path {self._source.file_path}"""
             self._future = None
 
     @property
-    def raw_data(self):
+    def raw_data(self) -> numpy.ndarray:
         """
         Data from the Source as a ``numpy.ndarray`` of ``numpy.uint8``.
 
@@ -383,7 +385,9 @@ for file path {self._source.file_path}"""
         self.wait()
         return self._raw_data
 
-    def get(self, start, stop, cursor, context):
+    def get(
+        self, start: int, stop: int, cursor: uproot.source.cursor.Cursor, context: dict
+    ) -> numpy.ndarray:
         """
         Args:
             start (int): Seek position of the first byte to include.
@@ -421,7 +425,9 @@ outside expected range {self._start}:{self._stop} for this Chunk""",
                 self._source.file_path,
             )
 
-    def remainder(self, start, cursor, context):
+    def remainder(
+        self, start: int, cursor: uproot.source.cursor.Cursor, context: dict
+    ) -> numpy.ndarray:
         """
         Args:
             start (int): Seek position of the first byte to include.
@@ -458,7 +464,7 @@ outside expected range {self._start}:{self._stop} for this Chunk""",
             )
 
 
-def notifier(chunk: Chunk, notifications: queue.Queue):
+def notifier(chunk: Chunk, notifications: queue.Queue) -> callable:
     """
     Returns a function that puts the chunk on the notifications queue when called.
     The function has a 'future' argument to be compatible with the `concurrent.futures.Future.add_done_callback` method.

--- a/src/uproot/source/cursor.py
+++ b/src/uproot/source/cursor.py
@@ -6,6 +6,7 @@ a thread-local pointer into a :doc:`uproot.source.chunk.Chunk` and performs
 the lowest level of interpretation (numbers, strings, raw arrays, etc.).
 """
 
+from __future__ import annotations
 
 import datetime
 import struct

--- a/src/uproot/source/cursor.py
+++ b/src/uproot/source/cursor.py
@@ -45,7 +45,7 @@ class Cursor:
     requested by :doc:`uproot.deserialization.read_object_any`.
     """
 
-    def __init__(self, index, origin=0, refs=None):
+    def __init__(self, index: int, origin: int = 0, refs: dict or None = None):
         self._index = index
         self._origin = origin
         self._refs = refs
@@ -67,7 +67,7 @@ class Cursor:
         return f"Cursor({self._index}{o}{r})"
 
     @property
-    def index(self):
+    def index(self) -> int:
         """
         Global seek position in the ROOT file or local position in an
         uncompressed :doc:`uproot.source.chunk.Chunk`.
@@ -75,7 +75,7 @@ class Cursor:
         return self._index
 
     @property
-    def origin(self):
+    def origin(self) -> int:
         """
         Zero-point for numerical keys in
         :ref:`uproot.source.cursor.Cursor.refs`.
@@ -83,7 +83,7 @@ class Cursor:
         return self._origin
 
     @property
-    def refs(self):
+    def refs(self) -> dict:
         """
         References to data already read in
         :doc:`uproot.deserialization.read_object_any`.
@@ -92,7 +92,7 @@ class Cursor:
             self._refs = {}
         return self._refs
 
-    def displacement(self, other=None):
+    def displacement(self, other: Cursor = None) -> int:
         """
         The number of bytes between this :doc:`uproot.source.cursor.Cursor`
         and its :ref:`uproot.source.cursor.Cursor.origin` (if None)
@@ -106,7 +106,7 @@ class Cursor:
         else:
             return self._index - other._index
 
-    def copy(self, link_refs=True):
+    def copy(self, link_refs: bool = True) -> Cursor:
         """
         Returns a copy of this :doc:`uproot.source.cursor.Cursor`. If
         ``link_refs`` is True, any :ref:`uproot.source.cursor.Cursor.refs`
@@ -117,14 +117,14 @@ class Cursor:
         else:
             return Cursor(self._index, origin=self._origin, refs=dict(self._refs))
 
-    def move_to(self, index):
+    def move_to(self, index: int):
         """
         Move the :ref:`uproot.source.cursor.Cursor.index` to a specified seek
         position.
         """
         self._index = index
 
-    def skip(self, num_bytes):
+    def skip(self, num_bytes: int):
         """
         Move the :ref:`uproot.source.cursor.Cursor.index` forward
         ``num_bytes``.
@@ -149,7 +149,7 @@ class Cursor:
             )
         self._index = start_cursor.index + num_bytes
 
-    def skip_over(self, chunk, context):
+    def skip_over(self, chunk: uproot.source.chunk.Chunk, context: dict):
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -172,7 +172,13 @@ class Cursor:
             self._index += num_bytes
             return True
 
-    def fields(self, chunk, format, context, move=True):
+    def fields(
+        self,
+        chunk: uproot.source.chunk.Chunk,
+        format: struct.Struct,
+        context: dict,
+        move: bool = True,
+    ):
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -194,7 +200,13 @@ class Cursor:
             self._index = stop
         return format.unpack(chunk.get(start, stop, self, context))
 
-    def field(self, chunk, format, context, move=True):
+    def field(
+        self,
+        chunk: uproot.source.chunk.Chunk,
+        format: struct.Struct,
+        context: dict,
+        move: bool = True,
+    ):
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -216,7 +228,9 @@ class Cursor:
             self._index = stop
         return format.unpack(chunk.get(start, stop, self, context))[0]
 
-    def double32(self, chunk, context, move=True):
+    def double32(
+        self, chunk: uproot.source.chunk.Chunk, context: dict, move: bool = True
+    ) -> float:
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -236,7 +250,13 @@ class Cursor:
             self._index = stop
         return _raw_double32.unpack(chunk.get(start, stop, self, context))[0]
 
-    def float16(self, chunk, num_bits, context, move=True):
+    def float16(
+        self,
+        chunk: uproot.source.chunk.Chunk,
+        num_bits: int,
+        context: dict,
+        move: bool = True,
+    ) -> float:
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -269,7 +289,7 @@ class Cursor:
 
         return out.item()
 
-    def byte(self, chunk, context, move=True):
+    def byte(self, chunk: uproot.source.chunk.Chunk, context: dict, move: bool = True):
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -307,7 +327,14 @@ class Cursor:
             self._index = stop
         return chunk.get(start, stop, self, context)
 
-    def array(self, chunk, length, dtype, context, move=True):
+    def array(
+        self,
+        chunk: uproot.source.chunk.Chunk,
+        length: int,
+        dtype: numpy.dtype,
+        context: dict,
+        move: bool = True,
+    ) -> numpy.ndarray:
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -331,7 +358,9 @@ class Cursor:
     _u1 = numpy.dtype("u1")
     _i4 = numpy.dtype(">i4")
 
-    def bytestring(self, chunk, context, move=True):
+    def bytestring(
+        self, chunk: uproot.source.chunk.Chunk, context: dict, move: bool = True
+    ) -> bytes:
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -362,7 +391,9 @@ class Cursor:
             self._index = stop
         return uproot._util.tobytes(chunk.get(start, stop, self, context))
 
-    def string(self, chunk, context, move=True):
+    def string(
+        self, chunk: uproot.source.chunk.Chunk, context: dict, move: bool = True
+    ) -> str:
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -383,7 +414,13 @@ class Cursor:
             errors="surrogateescape"
         )
 
-    def bytestring_with_length(self, chunk, context, length, move=True):
+    def bytestring_with_length(
+        self,
+        chunk: uproot.source.chunk.Chunk,
+        context: dict,
+        length: int,
+        move: bool = True,
+    ) -> bytes:
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -404,7 +441,13 @@ class Cursor:
         data = chunk.get(start, stop, self, context)
         return uproot._util.tobytes(data)
 
-    def string_with_length(self, chunk, context, length, move=True):
+    def string_with_length(
+        self,
+        chunk: uproot.source.chunk.Chunk,
+        context: dict,
+        length: int,
+        move: bool = True,
+    ) -> str:
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -422,7 +465,9 @@ class Cursor:
             errors="surrogateescape"
         )
 
-    def classname(self, chunk, context, move=True):
+    def classname(
+        self, chunk: uproot.source.chunk.Chunk, context: dict, move: bool = True
+    ) -> str:
         """
         Args:
             chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -456,7 +501,9 @@ of file path {}""".format(
             errors="surrogateescape"
         )
 
-    def rntuple_string(self, chunk, context, move=True):
+    def rntuple_string(
+        self, chunk: uproot.source.chunk.Chunk, context: dict, move: bool = True
+    ) -> str:
         if move:
             length = self.field(chunk, _rntuple_string_length, context)
             return self.string_with_length(chunk, context, length)
@@ -466,17 +513,19 @@ of file path {}""".format(
             self._index = index
             return out
 
-    def rntuple_datetime(self, chunk, context, move=True):
+    def rntuple_datetime(
+        self, chunk: uproot.source.chunk.Chunk, context: dict, move: bool = True
+    ) -> datetime.datetime:
         raw = self.field(chunk, _rntuple_datetime, context, move=move)
         return datetime.datetime.fromtimestamp(raw)
 
     def debug(
         self,
-        chunk,
-        context={},  # noqa: B006 (it's not actually mutated in the function)
-        limit_bytes=None,
-        dtype=None,
-        offset=0,
+        chunk: uproot.source.chunk.Chunk,
+        context: dict = {},  # noqa: B006 (it's not actually mutated in the function)
+        limit_bytes: int or None = None,
+        dtype: numpy.dtype = None,
+        offset: int = 0,
         stream=sys.stdout,
     ):
         """

--- a/src/uproot/source/cursor.py
+++ b/src/uproot/source/cursor.py
@@ -45,7 +45,7 @@ class Cursor:
     requested by :doc:`uproot.deserialization.read_object_any`.
     """
 
-    def __init__(self, index: int, origin: int = 0, refs: dict or None = None):
+    def __init__(self, index: int, origin: int = 0, refs: dict | None = None):
         self._index = index
         self._origin = origin
         self._refs = refs
@@ -523,7 +523,7 @@ of file path {}""".format(
         self,
         chunk: uproot.source.chunk.Chunk,
         context: dict = {},  # noqa: B006 (it's not actually mutated in the function)
-        limit_bytes: int or None = None,
+        limit_bytes: int | None = None,
         dtype: numpy.dtype = None,
         offset: int = 0,
         stream=sys.stdout,

--- a/src/uproot/source/file.py
+++ b/src/uproot/source/file.py
@@ -70,7 +70,7 @@ class FileResource(uproot.source.chunk.Resource):
 
     @staticmethod
     def future(
-        source: uproot.source.file.MultithreadedFileSource, start: int, stop: int
+        source: uproot.source.chunk.Source, start: int, stop: int
     ):
         """
         Args:

--- a/src/uproot/source/file.py
+++ b/src/uproot/source/file.py
@@ -56,7 +56,7 @@ class FileResource(uproot.source.chunk.Resource):
     def __exit__(self, exception_type, exception_value, traceback):
         self._file.__exit__(exception_type, exception_value, traceback)
 
-    def get(self, start, stop):
+    def get(self, start: int, stop: int) -> bytes:
         """
         Args:
             start (int): Seek position of the first byte to include.
@@ -69,7 +69,9 @@ class FileResource(uproot.source.chunk.Resource):
         return self._file.read(stop - start)
 
     @staticmethod
-    def future(source, start, stop):
+    def future(
+        source: uproot.source.file.MultithreadedFileSource, start: int, stop: int
+    ):
         """
         Args:
             source (:doc:`uproot.source.file.MultithreadedFileSource`): The
@@ -139,7 +141,7 @@ class MemmapSource(uproot.source.chunk.Source):
             fallback = " with fallback"
         return f"<{type(self).__name__} {path}{fallback} at 0x{id(self):012x}>"
 
-    def chunk(self, start, stop) -> uproot.source.chunk.Chunk:
+    def chunk(self, start: int, stop: int) -> uproot.source.chunk.Chunk:
         if self._fallback is None:
             if self.closed:
                 raise OSError(f"memmap is closed for file {self._file_path}")

--- a/src/uproot/source/file.py
+++ b/src/uproot/source/file.py
@@ -156,7 +156,7 @@ class MemmapSource(uproot.source.chunk.Source):
             return self._fallback.chunk(start, stop)
 
     def chunks(
-        self, ranges, notifications: queue.Queue
+        self, ranges: list[(int, int)], notifications: queue.Queue
     ) -> list[uproot.source.chunk.Chunk]:
         if self._fallback is None:
             if self.closed:

--- a/src/uproot/source/file.py
+++ b/src/uproot/source/file.py
@@ -32,7 +32,7 @@ class FileResource(uproot.source.chunk.Resource):
     A :doc:`uproot.source.chunk.Resource` for a simple file handle.
     """
 
-    def __init__(self, file_path):
+    def __init__(self, file_path: str):
         self._file_path = file_path
         try:
             self._file = open(self._file_path, "rb")
@@ -69,9 +69,7 @@ class FileResource(uproot.source.chunk.Resource):
         return self._file.read(stop - start)
 
     @staticmethod
-    def future(
-        source: uproot.source.chunk.Source, start: int, stop: int
-    ):
+    def future(source: uproot.source.chunk.Source, start: int, stop: int):
         """
         Args:
             source (:doc:`uproot.source.file.MultithreadedFileSource`): The
@@ -101,7 +99,7 @@ class MemmapSource(uproot.source.chunk.Source):
 
     _dtype = uproot.source.chunk.Chunk._dtype
 
-    def __init__(self, file_path, **options):
+    def __init__(self, file_path: str, **options):
         self._num_fallback_workers = options["num_fallback_workers"]
         self._fallback_opts = options
         self._num_requests = 0
@@ -244,7 +242,7 @@ class MultithreadedFileSource(uproot.source.chunk.MultithreadedSource):
 
     ResourceClass = FileResource
 
-    def __init__(self, file_path, **options):
+    def __init__(self, file_path: str, **options):
         self._num_requests = 0
         self._num_requested_chunks = 0
         self._num_requested_bytes = 0

--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -76,7 +76,7 @@ class FSSpecSource(uproot.source.chunk.Source):
         self._executor.shutdown()
         self._file.__exit__(exception_type, exception_value, traceback)
 
-    def chunk(self, start, stop) -> uproot.source.chunk.Chunk:
+    def chunk(self, start: int, stop: int) -> uproot.source.chunk.Chunk:
         """
         Args:
             start (int): Seek position of the first byte to include.

--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -22,7 +22,7 @@ class FSSpecSource(uproot.source.chunk.Source):
     to get many chunks in one request.
     """
 
-    def __init__(self, file_path, **options):
+    def __init__(self, file_path: str, **options):
         import fsspec.core
 
         default_options = uproot.reading.open.defaults

--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -98,7 +98,7 @@ class FSSpecSource(uproot.source.chunk.Source):
         return uproot.source.chunk.Chunk(self, start, stop, future)
 
     def chunks(
-        self, ranges, notifications: queue.Queue
+        self, ranges: list[(int, int)], notifications: queue.Queue
     ) -> list[uproot.source.chunk.Chunk]:
         """
         Args:

--- a/src/uproot/source/futures.py
+++ b/src/uproot/source/futures.py
@@ -21,6 +21,8 @@ This module defines a Python-like Future and Executor for Uproot in three levels
 These classes implement a *subset* of Python's Future and Executor interfaces.
 """
 
+from __future__ import annotations
+
 import os
 import queue
 import sys

--- a/src/uproot/source/futures.py
+++ b/src/uproot/source/futures.py
@@ -79,7 +79,7 @@ class TrivialExecutor:
         """
         return TrivialFuture(task(*args))
 
-    def shutdown(self, wait=True):
+    def shutdown(self, wait: bool = True):
         """
         Does nothing, since this object does not have threads to stop.
         """
@@ -146,13 +146,13 @@ class Worker(threading.Thread):
     :doc:`uproot.source.futures.ThreadPoolExecutor`.
     """
 
-    def __init__(self, work_queue):
+    def __init__(self, work_queue: queue.Queue):
         super().__init__()
         self.daemon = True
         self._work_queue = work_queue
 
     @property
-    def work_queue(self):
+    def work_queue(self) -> queue.Queue:
         """
         The worker calls ``get`` on this queue for tasks in the form of
         :doc:`uproot.source.futures.Future` objects and runs them. If it ever
@@ -190,7 +190,7 @@ class ThreadPoolExecutor:
     class.
     """
 
-    def __init__(self, max_workers=None):
+    def __init__(self, max_workers: int | None = None):
         if max_workers is None:
             if hasattr(os, "cpu_count"):
                 self._max_workers = os.cpu_count()
@@ -226,7 +226,7 @@ class ThreadPoolExecutor:
         return len(self._workers)
 
     @property
-    def workers(self):
+    def workers(self) -> list[Worker]:
         """
         A list of workers (:doc:`uproot.source.futures.Worker`).
         """
@@ -243,7 +243,7 @@ class ThreadPoolExecutor:
         self._work_queue.put(future)
         return future
 
-    def shutdown(self, wait=True):
+    def shutdown(self, wait: bool = True):
         """
         Stop every :doc:`uproot.source.futures.Worker` by putting None
         on the :ref:`uproot.source.futures.Worker.work_queue` until none of

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -17,9 +17,11 @@ Despite the name, both sources support secure HTTPS (selected by URL scheme).
 from __future__ import annotations
 
 import base64
+import http.client
 import queue
 import re
 import sys
+import urllib.parse
 from urllib.parse import urlparse
 
 import uproot
@@ -51,7 +53,7 @@ def make_connection(parsed_url: urllib.parse.ParseResult, timeout: float or None
         )
 
 
-def full_path(parsed_url):
+def full_path(parsed_url) -> str:
     """
     Returns the ``parsed_url.path`` with ``"?"`` and the ``parsed_url.query``
     if it exists, just the path otherwise.
@@ -353,7 +355,9 @@ for URL {}""".format(
     )
     _content_range = re.compile(b"Content-Range: bytes ([0-9]+-[0-9]+)", re.I)
 
-    def is_multipart_supported(self, ranges: list[(int, int)], response: http.client.HTTPResponse) -> bool:
+    def is_multipart_supported(
+        self, ranges: list[(int, int)], response: http.client.HTTPResponse
+    ) -> bool:
         """
         Helper function for :ref:`uproot.source.http.HTTPResource.multifuture`
         to check for multipart GET support.
@@ -560,7 +564,7 @@ class HTTPSource(uproot.source.chunk.Source):
 
     ResourceClass = HTTPResource
 
-    def __init__(self, file_path, **options):
+    def __init__(self, file_path: str, **options):
         self._num_fallback_workers = options["num_fallback_workers"]
         self._timeout = options["timeout"]
         self._num_requests = 0

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -27,7 +27,7 @@ import uproot.source.chunk
 import uproot.source.futures
 
 
-def make_connection(parsed_url, timeout):
+def make_connection(parsed_url, timeout: float or None):
     """
     Args:
         parsed_url (``urllib.parse.ParseResult``): The URL to connect to, which
@@ -78,7 +78,7 @@ def basic_auth_headers(parsed_url):
     return ret
 
 
-def get_num_bytes(file_path, parsed_url, timeout):
+def get_num_bytes(file_path, parsed_url, timeout) -> int:
     """
     Args:
         file_path (str): The URL to access as a raw string.
@@ -158,7 +158,7 @@ class HTTPResource(uproot.source.chunk.Resource):
         self._auth_headers = basic_auth_headers(self._parsed_url)
 
     @property
-    def timeout(self):
+    def timeout(self) -> float or None:
         """
         The timeout in seconds or None.
         """
@@ -184,7 +184,7 @@ class HTTPResource(uproot.source.chunk.Resource):
     def __exit__(self, exception_type, exception_value, traceback):
         pass
 
-    def get(self, connection, start, stop):
+    def get(self, connection, start: int, stop: int) -> bytes:
         """
         Args:
             start (int): Seek position of the first byte to include.
@@ -235,7 +235,7 @@ for URL {}""".format(
             connection.close()
 
     @staticmethod
-    def future(source, start, stop):
+    def future(source: uproot.source.chunk.Source, start: int, stop: int):
         """
         Args:
             source (:doc:`uproot.source.http.HTTPSource` or :doc:`uproot.source.http.MultithreadedHTTPSource`): The
@@ -260,7 +260,9 @@ for URL {}""".format(
         return uproot.source.futures.ResourceFuture(task)
 
     @staticmethod
-    def multifuture(source, ranges: list[(int, int)], futures, results):
+    def multifuture(
+        source: uproot.source.chunk.Source, ranges: list[(int, int)], futures, results
+    ):
         """
         Args:
             source (:doc:`uproot.source.http.HTTPSource`): The data source.
@@ -368,7 +370,13 @@ for URL {}""".format(
         else:
             return True
 
-    def handle_no_multipart(self, source, ranges: list[(int, int)], futures, results):
+    def handle_no_multipart(
+        self,
+        source: uproot.source.chunk.Source,
+        ranges: list[(int, int)],
+        futures,
+        results,
+    ):
         """
         Helper function for :ref:`uproot.source.http.HTTPResource.multifuture`
         to handle a lack of multipart GET support.
@@ -383,7 +391,14 @@ for URL {}""".format(
             results[chunk.start, chunk.stop] = chunk.raw_data
             futures[chunk.start, chunk.stop]._run(self)
 
-    def handle_multipart(self, source, futures, results, response, ranges):
+    def handle_multipart(
+        self,
+        source: uproot.source.chunk.Source,
+        futures,
+        results,
+        response,
+        ranges: list[(int, int)],
+    ):
         """
         Helper function for :ref:`uproot.source.http.HTTPResource.multifuture`
         to handle the multipart GET response.
@@ -477,7 +492,7 @@ for URL {}""".format(
         return range_string, size
 
     @staticmethod
-    def partfuture(results, start, stop):
+    def partfuture(results, start: int, stop: int):
         """
         Returns a :doc:`uproot.source.futures.ResourceFuture` to simply select
         the ``(start, stop)`` item from the ``results`` dict.
@@ -500,7 +515,7 @@ class _ResponseBuffer:
         self.already_read = b""
         self.stream = stream
 
-    def read(self, length):
+    def read(self, length: int):
         if length < len(self.already_read):
             out = self.already_read[:length]
             self.already_read = self.already_read[length:]
@@ -514,7 +529,7 @@ class _ResponseBuffer:
         else:
             return self.stream.read(length)
 
-    def readline(self):
+    def readline(self) -> bytes:
         while True:
             try:
                 index = self.already_read.index(b"\n")
@@ -594,7 +609,7 @@ class HTTPSource(uproot.source.chunk.Source):
             fallback = " with fallback"
         return f"<{type(self).__name__} {path}{fallback} at 0x{id(self):012x}>"
 
-    def chunk(self, start, stop) -> uproot.source.chunk.Chunk:
+    def chunk(self, start: int, stop: int) -> uproot.source.chunk.Chunk:
         self._num_requests += 1
         self._num_requested_chunks += 1
         self._num_requested_bytes += stop - start

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -27,7 +27,7 @@ import uproot.source.chunk
 import uproot.source.futures
 
 
-def make_connection(parsed_url, timeout: float or None):
+def make_connection(parsed_url: urllib.parse.ParseResult, timeout: float or None):
     """
     Args:
         parsed_url (``urllib.parse.ParseResult``): The URL to connect to, which
@@ -78,7 +78,7 @@ def basic_auth_headers(parsed_url):
     return ret
 
 
-def get_num_bytes(file_path, parsed_url, timeout) -> int:
+def get_num_bytes(file_path: str, parsed_url: urllib.parse.ParseResult, timeout) -> int:
     """
     Args:
         file_path (str): The URL to access as a raw string.
@@ -353,7 +353,7 @@ for URL {}""".format(
     )
     _content_range = re.compile(b"Content-Range: bytes ([0-9]+-[0-9]+)", re.I)
 
-    def is_multipart_supported(self, ranges: list[(int, int)], response) -> bool:
+    def is_multipart_supported(self, ranges: list[(int, int)], response: http.client.HTTPResponse) -> bool:
         """
         Helper function for :ref:`uproot.source.http.HTTPResource.multifuture`
         to check for multipart GET support.
@@ -396,7 +396,7 @@ for URL {}""".format(
         source: uproot.source.chunk.Source,
         futures,
         results,
-        response,
+        response: http.client.HTTPResponse,
         ranges: list[(int, int)],
     ):
         """

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -29,7 +29,7 @@ import uproot.source.chunk
 import uproot.source.futures
 
 
-def make_connection(parsed_url: urllib.parse.ParseResult, timeout: float or None):
+def make_connection(parsed_url: urllib.parse.ParseResult, timeout: float | None):
     """
     Args:
         parsed_url (``urllib.parse.ParseResult``): The URL to connect to, which
@@ -160,7 +160,7 @@ class HTTPResource(uproot.source.chunk.Resource):
         self._auth_headers = basic_auth_headers(self._parsed_url)
 
     @property
-    def timeout(self) -> float or None:
+    def timeout(self) -> float | None:
         """
         The timeout in seconds or None.
         """

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -260,7 +260,7 @@ for URL {}""".format(
         return uproot.source.futures.ResourceFuture(task)
 
     @staticmethod
-    def multifuture(source, ranges, futures, results):
+    def multifuture(source, ranges: list[(int, int)], futures, results):
         """
         Args:
             source (:doc:`uproot.source.http.HTTPSource`): The data source.
@@ -351,7 +351,7 @@ for URL {}""".format(
     )
     _content_range = re.compile(b"Content-Range: bytes ([0-9]+-[0-9]+)", re.I)
 
-    def is_multipart_supported(self, ranges, response):
+    def is_multipart_supported(self, ranges: list[(int, int)], response) -> bool:
         """
         Helper function for :ref:`uproot.source.http.HTTPResource.multifuture`
         to check for multipart GET support.
@@ -368,7 +368,7 @@ for URL {}""".format(
         else:
             return True
 
-    def handle_no_multipart(self, source, ranges, futures, results):
+    def handle_no_multipart(self, source, ranges: list[(int, int)], futures, results):
         """
         Helper function for :ref:`uproot.source.http.HTTPResource.multifuture`
         to handle a lack of multipart GET support.
@@ -605,7 +605,7 @@ class HTTPSource(uproot.source.chunk.Source):
         return chunk
 
     def chunks(
-        self, ranges, notifications: queue.Queue
+        self, ranges: list[(int, int)], notifications: queue.Queue
     ) -> list[uproot.source.chunk.Chunk]:
         if self._fallback is None:
             self._num_requests += 1

--- a/src/uproot/source/object.py
+++ b/src/uproot/source/object.py
@@ -53,7 +53,7 @@ class ObjectResource(uproot.source.chunk.Resource):
         if hasattr(self._obj, "__exit__"):
             self._obj.__exit__(exception_type, exception_value, traceback)
 
-    def get(self, start, stop):
+    def get(self, start: int, stop: int):
         """
         Args:
             start (int): Seek position of the first byte to include.
@@ -66,7 +66,7 @@ class ObjectResource(uproot.source.chunk.Resource):
         return self._obj.read(stop - start)
 
     @staticmethod
-    def future(source, start, stop):
+    def future(source: uproot.source.chunk.Source, start: int, stop: int):
         """
         Args:
             source (:doc:`uproot.source.object.ObjectSource`): The data source.

--- a/src/uproot/source/object.py
+++ b/src/uproot/source/object.py
@@ -8,6 +8,7 @@ object) and one source :doc:`uproot.source.object.ObjectSource` which always
 has exactly one worker (we can't assume that the object is thread-safe).
 """
 
+from __future__ import annotations
 
 import uproot
 import uproot.source.chunk

--- a/src/uproot/source/s3.py
+++ b/src/uproot/source/s3.py
@@ -4,6 +4,8 @@
 This module defines a physical layer for remote files, accessed via S3.
 """
 
+from __future__ import annotations
+
 import os
 from urllib.parse import parse_qsl, urlparse
 

--- a/src/uproot/source/s3.py
+++ b/src/uproot/source/s3.py
@@ -29,7 +29,7 @@ class S3Source(uproot.source.http.HTTPSource):
 
     def __init__(
         self,
-        file_path,
+        file_path: str,
         endpoint="s3.amazonaws.com",
         access_key=None,
         secret_key=None,

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -159,7 +159,7 @@ in file {self._file_path}"""
     def __exit__(self, exception_type, exception_value, traceback):
         self._file.close(timeout=self._xrd_timeout())
 
-    def get(self, start, stop):
+    def get(self, start: int, stop: int) -> bytes:
         """
         Args:
             start (int): Seek position of the first byte to include.
@@ -176,7 +176,7 @@ in file {self._file_path}"""
         return data
 
     @staticmethod
-    def future(source, start, stop):
+    def future(source, start: int, stop: int):
         """
         Args:
             source (:doc:`uproot.source.xrootd.MultithreadedXRootDSource`): The
@@ -196,7 +196,7 @@ in file {self._file_path}"""
         return uproot.source.futures.ResourceFuture(task)
 
     @staticmethod
-    def partfuture(results, start, stop):
+    def partfuture(results, start: int, stop: int):
         """
         Returns a :doc:`uproot.source.futures.ResourceFuture` to simply select
         the ``(start, stop)`` item from the ``results`` dict.
@@ -315,7 +315,7 @@ class XRootDSource(uproot.source.chunk.Source):
             path = repr("..." + self._file_path[-10:])
         return f"<{type(self).__name__} {path} at 0x{id(self):012x}>"
 
-    def chunk(self, start, stop) -> uproot.source.chunk.Chunk:
+    def chunk(self, start: int, stop: int) -> uproot.source.chunk.Chunk:
         self._num_requests += 1
         self._num_requested_chunks += 1
         self._num_requested_bytes += stop - start

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -85,7 +85,7 @@ class XRootDResource(uproot.source.chunk.Resource):
     A :doc:`uproot.source.chunk.Resource` for XRootD connections.
     """
 
-    def __init__(self, file_path: str, timeout):
+    def __init__(self, file_path: str, timeout: float | None):
         self._file_path = file_path
         self._timeout = timeout
         self._open()
@@ -108,7 +108,7 @@ class XRootDResource(uproot.source.chunk.Resource):
         self.__dict__ = state
         self._open()
 
-    def _xrd_timeout(self):
+    def _xrd_timeout(self) -> int:
         if self._timeout is None:
             return 0
         else:
@@ -129,7 +129,7 @@ in file {self._file_path}"""
             )
 
     @property
-    def timeout(self):
+    def timeout(self) -> float | None:
         """
         The timeout in seconds or None.
         """
@@ -414,7 +414,7 @@ class XRootDSource(uproot.source.chunk.Source):
         return self._resource
 
     @property
-    def timeout(self):
+    def timeout(self) -> float | None:
         """
         The timeout in seconds or None.
         """
@@ -474,7 +474,7 @@ class MultithreadedXRootDSource(uproot.source.chunk.MultithreadedSource):
             self._executor = uproot.source.futures.ResourceThreadPoolExecutor(
                 [
                     XRootDResource(self._file_path, self._timeout)
-                    for x in range(self._num_workers)
+                    for _ in range(self._num_workers)
                 ]
             )
         else:
@@ -492,7 +492,7 @@ class MultithreadedXRootDSource(uproot.source.chunk.MultithreadedSource):
         self._open()
 
     @property
-    def timeout(self):
+    def timeout(self) -> float | None:
         """
         The timeout in seconds or None.
         """

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -85,7 +85,7 @@ class XRootDResource(uproot.source.chunk.Resource):
     A :doc:`uproot.source.chunk.Resource` for XRootD connections.
     """
 
-    def __init__(self, file_path, timeout):
+    def __init__(self, file_path: str, timeout):
         self._file_path = file_path
         self._timeout = timeout
         self._open()
@@ -176,7 +176,7 @@ in file {self._file_path}"""
         return data
 
     @staticmethod
-    def future(source, start: int, stop: int):
+    def future(source: uproot.source.chunk.Source, start: int, stop: int):
         """
         Args:
             source (:doc:`uproot.source.xrootd.MultithreadedXRootDSource`): The
@@ -265,7 +265,7 @@ class XRootDSource(uproot.source.chunk.Source):
 
     ResourceClass = XRootDResource
 
-    def __init__(self, file_path, **options):
+    def __init__(self, file_path: str, **options):
         self._timeout = options["timeout"]
         self._desired_max_num_elements = options["max_num_elements"]
         self._use_threads = options["use_threads"]
@@ -339,7 +339,9 @@ class XRootDSource(uproot.source.chunk.Source):
         # this is to track which requests were split into smaller ranges and have to be merged
         sub_ranges = {}
 
-        def add_request_range(start, length, sub_ranges_list):
+        def add_request_range(
+            start: int, length: int, sub_ranges_list: list[(int, int)]
+        ):
             if len(all_request_ranges[-1]) >= self._max_num_elements:
                 all_request_ranges.append([])
             all_request_ranges[-1].append((start, length))
@@ -455,7 +457,7 @@ class MultithreadedXRootDSource(uproot.source.chunk.MultithreadedSource):
 
     ResourceClass = XRootDResource
 
-    def __init__(self, file_path, **options):
+    def __init__(self, file_path: str, **options):
         self._num_workers = options["num_workers"]
         self._timeout = options["timeout"]
         self._use_threads = options["use_threads"]

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -325,7 +325,7 @@ class XRootDSource(uproot.source.chunk.Source):
         return uproot.source.chunk.Chunk(self, start, stop, future)
 
     def chunks(
-        self, ranges, notifications: queue.Queue
+        self, ranges: list[(int, int)], notifications: queue.Queue
     ) -> list[uproot.source.chunk.Chunk]:
         self._num_requests += 1
         self._num_requested_chunks += len(ranges)


### PR DESCRIPTION
Add types to most of the sources module.

Only added types where I was sure of the type.

I left things such as urls, file paths, etc. untyped instead of typing them as `str` since user may pass a `pathlib` path or similar.