### PR TITLE
feat: update the executor submit interface to take keyword arguments and be compatible with `concurrent.futures.ThreadPoolExecutor`

### DIFF
--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -154,9 +154,9 @@ class FSSpecSource(uproot.source.chunk.Source):
             # Loop executor takes a coroutine while ThreadPoolExecutor takes a function.
             future = self._executor.submit(
                 self._fs._cat_file if self._use_async else self._fs.cat_file,
-                self._file_path,
-                start,
-                stop,
+                path=self._file_path,
+                start=start,
+                end=stop,
             )
             chunk = uproot.source.chunk.Chunk(self, start, stop, future)
             future.add_done_callback(uproot.source.chunk.notifier(chunk, notifications))
@@ -192,10 +192,10 @@ class FSSpecLoopExecutor(uproot.source.futures.Executor):
     def __init__(self, loop: asyncio.AbstractEventLoop):
         self.loop = loop
 
-    def submit(self, coroutine, *args) -> concurrent.futures.Future:
+    def submit(self, coroutine, /, *args, **kwargs) -> concurrent.futures.Future:
         if not asyncio.iscoroutinefunction(coroutine):
             raise TypeError("loop executor can only submit coroutines")
         if not self.loop.is_running():
             raise RuntimeError("cannot submit coroutine while loop is not running")
-        coroutine_object = coroutine(*args)
+        coroutine_object = coroutine(*args, **kwargs)
         return asyncio.run_coroutine_threadsafe(coroutine_object, self.loop)

--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -154,7 +154,8 @@ class FSSpecSource(uproot.source.chunk.Source):
             # Loop executor takes a coroutine while ThreadPoolExecutor takes a function.
             future = self._executor.submit(
                 self._fs._cat_file if self._use_async else self._fs.cat_file,
-                path=self._file_path,
+                # it is assumed that the first argument is the file path / url (can have different names: 'url', 'path')
+                self._file_path,
                 start=start,
                 end=stop,
             )

--- a/src/uproot/source/futures.py
+++ b/src/uproot/source/futures.py
@@ -43,7 +43,7 @@ class Executor(ABC):
         return f"<{self.__class__.__name__} at 0x{id(self):012x}>"
 
     @abstractmethod
-    def submit(self, task, *args):
+    def submit(self, task, /, *args, **kwargs):
         """
         Submit a task to be run in the background and return a Future object
         representing that task.
@@ -97,11 +97,11 @@ class TrivialExecutor(Executor):
     ``task`` synchronously.
     """
 
-    def submit(self, task, *args):
+    def submit(self, task, /, *args, **kwargs):
         """
         Immediately runs ``task(*args)``.
         """
-        return TrivialFuture(task(*args))
+        return TrivialFuture(task(*args, **kwargs))
 
 
 ##################### use-case 2: Python-like Futures/Executor for compute
@@ -249,14 +249,14 @@ class ThreadPoolExecutor(Executor):
         """
         return self._workers
 
-    def submit(self, task, *args):
+    def submit(self, task, /, *args, **kwargs):
         """
         Pass the ``task`` and ``args`` onto the workers'
         :ref:`uproot.source.futures.Worker.work_queue` as a
         :doc:`uproot.source.futures.Future` so that it will be executed when
         one is available.
         """
-        future = Future(task, args)
+        future = Future(task, *args, **kwargs)
         self._work_queue.put(future)
         return future
 

--- a/src/uproot/source/futures.py
+++ b/src/uproot/source/futures.py
@@ -256,7 +256,7 @@ class ThreadPoolExecutor(Executor):
         :doc:`uproot.source.futures.Future` so that it will be executed when
         one is available.
         """
-        future = Future(task, *args, **kwargs)
+        future = Future(task, args)
         self._work_queue.put(future)
         return future
 

--- a/src/uproot/source/futures.py
+++ b/src/uproot/source/futures.py
@@ -385,7 +385,7 @@ class ResourceThreadPoolExecutor(ThreadPoolExecutor):
         for worker in self._workers:
             worker.start()
 
-    def submit(self, future):
+    def submit(self, future: ResourceFuture) -> ResourceFuture:
         """
         Pass the ``task`` onto the workers'
         :ref:`uproot.source.futures.ResourceWorker.work_queue` as a


### PR DESCRIPTION
We were passing arguments to the tasks as positional, this makes some of the fsspec sources behave differently because they may have different number / order of arguments.

I also modified the definitions to keep the same as `concurrent.futures.ThreadPoolExecutor`.

I noticied after debugging https://github.com/scikit-hep/uproot5/pull/999 failure.