### PR TITLE
feat: improve uri scheme parsing with list of available schemes from `fsspec`

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -280,9 +280,8 @@ def regularize_path(path):
 _windows_drive_letter_ending = re.compile(r".*\b[A-Za-z]$")
 _windows_absolute_path_pattern = re.compile(r"^[A-Za-z]:[\\/]")
 _windows_absolute_path_pattern_slash = re.compile(r"^[\\/][A-Za-z]:[\\/]")
-_might_be_port = re.compile(r"^[0-9].*")
-_remote_schemes = ["ROOT", "S3", "HTTP", "HTTPS"]
-_schemes = ["FILE", *_remote_schemes]
+_remote_schemes = ["root", "s3", "http", "https"]
+_schemes = ["file", *_remote_schemes]
 _uri_scheme = re.compile("^[a-zA-Z][a-zA-Z0-9+.-]*://")
 
 
@@ -983,7 +982,7 @@ def _regularize_files_inner(files, parse_colon, counter, HasBranches, steps_allo
 
         parsed_url = urlparse(file_path)
 
-        if parsed_url.scheme.upper() in _remote_schemes:
+        if parsed_url.scheme.lower() in _remote_schemes:
             yield file_path, object_path, maybe_steps
 
         else:

--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -149,8 +149,7 @@ def test_http(use_threads):
         assert [tobytes(x.raw_data) for x in chunks] == [one, two, three]
 
 
-@pytest.mark.skip(reason="RECHECK: example.com is flaky, too")
-def colons_and_ports():
+def test_colons_and_ports():
     assert uproot._util.file_object_path_split("https://example.com:443") == (
         "https://example.com:443",
         None,

--- a/tests/test_0976_path_object_split.py
+++ b/tests/test_0976_path_object_split.py
@@ -98,13 +98,6 @@ import pathlib
                 None,
             ),
         ),
-        (
-            "local/file.root://Events",
-            (
-                "local/file.root",
-                "//Events",
-            ),
-        ),
     ],
 )
 def test_url_split(input_value, expected_output):
@@ -112,3 +105,14 @@ def test_url_split(input_value, expected_output):
     url_expected, obj_expected = expected_output
     assert url == url_expected
     assert obj == obj_expected
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        "local/file.root://Events",
+    ],
+)
+def test_url_split_invalid(input_value):
+    with pytest.raises(ValueError):
+        uproot._util.file_object_path_split(input_value)


### PR DESCRIPTION
Use `fsspec` to get the list of supported uri schemes. Direct the user to this list in case of an invalid scheme.

**Changes**: paths such as `file.root://object-with-too-many-slashes` will now throw a `ValueError` saying that the `file.root://` scheme is not in the list of valid schemes.