### PR TITLE
test: testing sshfs with local ssh server

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,6 +44,17 @@ jobs:
           mamba install root
           conda list
 
+      - name: Install sshd for sshfs tests
+        if: runner.os != 'macOS'  &&  runner.os != 'Windows'
+        run: |
+          sudo apt-get install -y openssh-server
+          sudo service ssh restart
+          ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+          cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+          chmod og-wx ~/.ssh/authorized_keys
+          ssh-keyscan -H localhost >> ~/.ssh/known_hosts
+          ssh -o StrictHostKeyChecking=no localhost echo "ssh connection successful"
+
       - name: Install XRootD
         if: runner.os != 'macOS'  &&  runner.os != 'Windows'
         run: |

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -73,7 +73,7 @@ def test_open_fsspec_ssh():
     try:
         user = subprocess.check_output(["whoami"]).strip().decode("ascii")
         host = "localhost"
-        ssh_command = f"ssh {user}@{host} 'echo hello'"
+        ssh_command = ["ssh", f"{user}@{host}", "'echo hello'"]
         result = subprocess.run(
             ssh_command,
             shell=True,

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
 import fsspec
 import pytest
 import uproot


### PR DESCRIPTION
This PR adds an ssh server only to the ubuntu build of the CI to test accessing files over ssh via fsspec.

After testing it I realised that `sshfs` does not implement some interface required by uproot for this to work (`cat_file`) so it raises a `NotImplementedError`. I'm not sure if this is just not implemented and can be implemented or if there is a limitation why this has not been implemented (you cannot request a chunk of a file, you need to request it all?).

We could handle each `fsspec` case separately having a fallback in case some interface is not implemented, but I think it would complicate things too much.

After writing this PR I think it makes sense to raise a more detailed exception if fsspec does not implemented the required interface, so the user can post an issue in the corresponding fsspec repo. `fsspec` probably has a way to list the available methods (or it should!)