### PR TITLE
test: use `paramiko` for ssh instead of `sshfs`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
   "fsspec",
   "fsspec-xrootd",
   "s3fs; python_version<\"3.12\"",  # asyncio not available
-  "sshfs; python_version<\"3.12\"",  # asyncio not available
+  "paramiko",
   "pytest>=6",
   "pytest-timeout",
   "pytest-rerunfailures",

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -421,13 +421,14 @@ after the first `import uproot` or use `@pytest.mark.filterwarnings("error:::upr
         elif _windows_absolute_path_pattern_slash.match(parsed_url_path) is not None:
             windows_absolute_path = parsed_url_path[1:]
 
+    scheme = parsed_url.scheme.lower()
     if (
-        parsed_url.scheme.upper() == "FILE"
+        scheme == "file"
         or len(parsed_url.scheme) == 0
         or windows_absolute_path is not None
     ):
         if windows_absolute_path is None:
-            if parsed_url.netloc.upper() == "LOCALHOST":
+            if parsed_url.netloc.lower() == "localhost":
                 file_path = parsed_url_path
             else:
                 file_path = parsed_url.netloc + parsed_url_path
@@ -458,7 +459,7 @@ after the first `import uproot` or use `@pytest.mark.filterwarnings("error:::upr
             )
         return out, os.path.expanduser(file_path)
 
-    elif parsed_url.scheme.upper() == "ROOT":
+    elif scheme == "root":
         out = options["xrootd_handler"]
         if out is None:
             out = uproot.source.xrootd.XRootDSource
@@ -482,7 +483,7 @@ after the first `import uproot` or use `@pytest.mark.filterwarnings("error:::upr
             )
         return out, file_path
 
-    elif parsed_url.scheme.upper() in {"S3"}:
+    elif scheme == "s3":
         out = options["s3_handler"]
         if out is None:
             out = uproot.source.s3.S3Source
@@ -505,7 +506,7 @@ after the first `import uproot` or use `@pytest.mark.filterwarnings("error:::upr
             )
         return out, file_path
 
-    elif parsed_url.scheme.upper() in {"HTTP", "HTTPS"}:
+    elif scheme in ("http", "https"):
         out = options["http_handler"]
         if out is None:
             out = uproot.source.http.HTTPSource
@@ -530,6 +531,10 @@ after the first `import uproot` or use `@pytest.mark.filterwarnings("error:::upr
         return out, file_path
 
     else:
+        # try to use fsspec before raising an error
+        if scheme in _schemes:
+            return uproot.source.fsspec.FSSpecSource, file_path
+
         raise ValueError(f"URI scheme not recognized: {file_path}")
 
 

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -82,10 +82,10 @@ def test_open_fsspec_ssh(handler):
         host = "localhost"
         user = subprocess.check_output(["whoami"]).strip().decode("ascii")
         port = 22
-        client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(hostname=host, port=port, username=user)
-    except Exception as e:
+        with paramiko.SSHClient() as client:
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            client.connect(hostname=host, port=port, username=user)
+    except paramiko.ssh_exception.NoValidConnectionsError as e:
         pytest.skip(f"ssh connection to host failed: {e}")
 
     # cache the file

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -66,7 +66,14 @@ def test_open_fsspec_s3(handler):
         assert len(data) == 8004
 
 
-def test_open_fsspec_ssh():
+@pytest.mark.parametrize(
+    "handler",
+    [
+        uproot.source.fsspec.FSSpecSource,
+        None,
+    ],
+)
+def test_open_fsspec_ssh(handler):
     pytest.importorskip("paramiko")
     import paramiko
 
@@ -85,7 +92,7 @@ def test_open_fsspec_ssh():
     local_path = skhep_testdata.data_path("uproot-issue121.root")
 
     uri = f"ssh://{user}@{host}:{port}{local_path}"
-    with uproot.open(uri, handler=uproot.source.fsspec.FSSpecSource) as f:
+    with uproot.open(uri, handler=handler) as f:
         data = f["Events/MET_pt"].array(library="np")
         assert len(data) == 40
 

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -78,15 +78,21 @@ def test_open_fsspec_ssh(handler):
     import paramiko
 
     # only test this if we can connect to the host (this will work in GitHub Actions)
+    client = None
     try:
         host = "localhost"
         user = subprocess.check_output(["whoami"]).strip().decode("ascii")
         port = 22
-        with paramiko.SSHClient() as client:
-            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            client.connect(hostname=host, port=port, username=user)
-    except paramiko.ssh_exception.NoValidConnectionsError as e:
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(hostname=host, port=port, username=user)
+    except Exception as e:
         pytest.skip(f"ssh connection to host failed: {e}")
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
 
     # cache the file
     local_path = skhep_testdata.data_path("uproot-issue121.root")

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-import fsspec
 import pytest
 import uproot
 import uproot.source.fsspec
@@ -68,31 +67,19 @@ def test_open_fsspec_s3(handler):
 
 
 def test_open_fsspec_ssh():
-    pytest.importorskip("sshfs")
+    pytest.importorskip("paramiko")
+    import paramiko
 
-    # check localhost has ssh access to itself
+    # only test if we can connect to the host (enabled in GitHub Actions)
     try:
-        user = subprocess.check_output(["whoami"]).strip().decode("ascii")
         host = "localhost"
-        ssh_command = ["ssh", f"{user}@{host}", "'echo hello'"]
-        result = subprocess.run(
-            ssh_command,
-            shell=True,
-            text=True,
-            capture_output=True,
-        )
-        assert (
-            result.returncode == 0
-        ), f"ssh access to localhost failed with {result.stderr}"
+        user = subprocess.check_output(["whoami"]).strip().decode("ascii")
+        port = 22
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(hostname=host, port=port, username=user)
     except Exception as e:
-        pytest.skip(f"ssh access to localhost failed with {e}")
-
-    # at this time sshfs does not implement cat_file. This will alert us if it ever does
-    with pytest.raises(NotImplementedError):
-        fs = fsspec.filesystem("ssh", host="localhost")
-        fs.cat_file("some-file", start=0, end=100)
-
-    pytest.skip("sshfs does not implement cat_file")
+        pytest.skip(f"ssh connection to host failed: {e}")
 
     # cache the file
     local_path = skhep_testdata.data_path("uproot-issue121.root")

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -85,7 +85,7 @@ def test_open_fsspec_ssh(handler):
         with paramiko.SSHClient() as client:
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             client.connect(hostname=host, port=port, username=user)
-    except paramiko.ssh_exception.NoValidConnectionsError as e:
+    except paramiko.ssh_exception.SSHException as e:
         pytest.skip(f"ssh connection to host failed: {e}")
 
     # cache the file

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -76,12 +76,14 @@ def test_open_fsspec_s3(handler):
 def test_open_fsspec_ssh(handler):
     pytest.importorskip("paramiko")
     import paramiko
+    import getpass
+
+    user = getpass.getuser()
+    host = "localhost"
+    port = 22
 
     # only test this if we can connect to the host (this will work in GitHub Actions)
     try:
-        host = "localhost"
-        user = subprocess.check_output(["whoami"]).strip().decode("ascii")
-        port = 22
         with paramiko.SSHClient() as client:
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             client.connect(hostname=host, port=port, username=user)

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -78,21 +78,15 @@ def test_open_fsspec_ssh(handler):
     import paramiko
 
     # only test this if we can connect to the host (this will work in GitHub Actions)
-    client = None
     try:
         host = "localhost"
         user = subprocess.check_output(["whoami"]).strip().decode("ascii")
         port = 22
-        client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(hostname=host, port=port, username=user)
-    except Exception as e:
+        with paramiko.SSHClient() as client:
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            client.connect(hostname=host, port=port, username=user)
+    except paramiko.ssh_exception.NoValidConnectionsError as e:
         pytest.skip(f"ssh connection to host failed: {e}")
-    finally:
-        try:
-            client.close()
-        except Exception:
-            pass
 
     # cache the file
     local_path = skhep_testdata.data_path("uproot-issue121.root")

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -70,7 +70,7 @@ def test_open_fsspec_ssh():
     pytest.importorskip("paramiko")
     import paramiko
 
-    # only test if we can connect to the host (enabled in GitHub Actions)
+    # only test this if we can connect to the host (this will work in GitHub Actions)
     try:
         host = "localhost"
         user = subprocess.check_output(["whoami"]).strip().decode("ascii")
@@ -84,7 +84,7 @@ def test_open_fsspec_ssh():
     # cache the file
     local_path = skhep_testdata.data_path("uproot-issue121.root")
 
-    uri = f"ssh://{user}@{host}:22{local_path}"
+    uri = f"ssh://{user}@{host}:{port}{local_path}"
     with uproot.open(uri, handler=uproot.source.fsspec.FSSpecSource) as f:
         data = f["Events/MET_pt"].array(library="np")
         assert len(data) == 40

--- a/tests/test_0692_fsspec.py
+++ b/tests/test_0692_fsspec.py
@@ -85,7 +85,10 @@ def test_open_fsspec_ssh(handler):
         with paramiko.SSHClient() as client:
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             client.connect(hostname=host, port=port, username=user)
-    except paramiko.ssh_exception.SSHException as e:
+    except (
+        paramiko.ssh_exception.SSHException,
+        paramiko.ssh_exception.NoValidConnectionsError,
+    ) as e:
         pytest.skip(f"ssh connection to host failed: {e}")
 
     # cache the file


### PR DESCRIPTION
After https://github.com/scikit-hep/uproot5/pull/1013 I opened an issue in fsspec https://github.com/fsspec/filesystem_spec/issues/1411 to discuss the issue of not having `cat_files` as part of the interface for the ssh backend.

I realised that I was using the wrong package: `sshfs` which is a third party implementation of an ssh backend (to my defense `s3fs` is the name for the `fsspec` `s3` backend...). `fsspec` already has an ssh backend that can be used if the `paramiko` package is installed. And it implements the `cat_file` interface so it works!

This PR updates the tests to reflect this (now the tests actually access the file over ssh).

**Minor feature**:

I noticed that if the fsspec handler was not being explicitly specified the ssh would faild because it would default to the old sources. I modified the behaviour so that instead of failing when an scheme is not recognized by the old sources, it will now use fsspec instead (if possible). When fsspec becomes default this can be removed.