### PR TITLE
feat: simplify object path split

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -274,13 +274,9 @@ _windows_drive_letter_ending = re.compile(r".*\b[A-Za-z]$")
 _windows_absolute_path_pattern = re.compile(r"^[A-Za-z]:[\\/]")
 _windows_absolute_path_pattern_slash = re.compile(r"^[\\/][A-Za-z]:[\\/]")
 
+# These schemes may not appear in fsspec if the corresponding libraries are not installed (e.g. s3fs)
 _remote_schemes = ["root", "s3", "http", "https"]
 _schemes = list({*_remote_schemes, *fsspec.available_protocols()})
-
-_uri_scheme = re.compile("^(" + "|".join([re.escape(x) for x in _schemes]) + ")://")
-_uri_scheme_chain = re.compile(
-    "^(" + "|".join([re.escape(x) for x in _schemes]) + ")::"
-)
 
 
 def file_object_path_split(urlpath: str) -> tuple[str, str | None]:

--- a/tests/test_0001_source_class.py
+++ b/tests/test_0001_source_class.py
@@ -148,13 +148,13 @@ def test_colons_and_ports():
         "https://example.com:443",
         None,
     )
-    assert uproot._util.file_object_path_split("https://example.com:443/something") == (
-        "https://example.com:443/something",
+    assert uproot._util.file_object_path_split("https://example.com:443/file.root") == (
+        "https://example.com:443/file.root",
         None,
     )
     assert uproot._util.file_object_path_split(
-        "https://example.com:443/something:else"
-    ) == ("https://example.com:443/something", "else")
+        "https://example.com:443/file.root:object"
+    ) == ("https://example.com:443/file.root", "object")
 
 
 @pytest.mark.parametrize("use_threads", [True, False], indirect=True)

--- a/tests/test_0692_fsspec_reading.py
+++ b/tests/test_0692_fsspec_reading.py
@@ -199,7 +199,7 @@ def test_fsspec_zip(tmp_path):
 
     # open with fsspec
     with uproot.open(
-        f"zip://{filename}::file://{filename_zip}:Events/MET_pt"
+        f"zip://{filename}:Events/MET_pt::file://{filename_zip}"
     ) as branch:
         data = branch.array(library="np")
         assert len(data) == 40

--- a/tests/test_0976_path_object_split.py
+++ b/tests/test_0976_path_object_split.py
@@ -176,7 +176,7 @@ def test_url_split(input_value, expected_output):
     [
         "local/file.root.zip://Events",
         "local/file.roo://Events",
-        "local/file.roo://Events",
+        "local/file://Events",
     ],
 )
 def test_url_split_invalid(input_value):

--- a/tests/test_0976_path_object_split.py
+++ b/tests/test_0976_path_object_split.py
@@ -112,6 +112,14 @@ import pathlib
                 None,
             ),
         ),
+        # https://github.com/scikit-hep/uproot5/issues/975
+        (
+            "DAOD_PHYSLITE_2023-09-13T1230.art.rntuple.root:RNT:CollectionTree",
+            (
+                "DAOD_PHYSLITE_2023-09-13T1230.art.rntuple.root",
+                "RNT:CollectionTree",
+            ),
+        ),
         (
             "zip://uproot-issue121.root:Events/MET_pt::file:///tmp/pytest-of-runner/pytest-0/test_fsspec_zip0/uproot-issue121.root.zip",
             (

--- a/tests/test_0976_path_object_split.py
+++ b/tests/test_0976_path_object_split.py
@@ -141,6 +141,27 @@ import pathlib
                 "Events/MET_pt",
             ),
         ),
+        (
+            "zip://uproot-issue121.root:Events/MET_pt::file:///some/weird/path:with:colons/file.root",
+            (
+                "zip://uproot-issue121.root::file:///some/weird/path:with:colons/file.root",
+                "Events/MET_pt",
+            ),
+        ),
+        (
+            "/some/weird/path:with:colons/file.root:Events/MET_pt",
+            (
+                "/some/weird/path:with:colons/file.root",
+                "Events/MET_pt",
+            ),
+        ),
+        (
+            "/some/weird/path:with:colons/file.root",
+            (
+                "/some/weird/path:with:colons/file.root",
+                None,
+            ),
+        ),
     ],
 )
 def test_url_split(input_value, expected_output):

--- a/tests/test_0976_path_object_split.py
+++ b/tests/test_0976_path_object_split.py
@@ -64,24 +64,38 @@ import pathlib
             ),
         ),
         (
-            "ssh://user@host:22/path/to/file:object",
+            "ssh://user@host:22/path/to/file.root:/object//path",
             (
-                "ssh://user@host:22/path/to/file",
-                "object",
+                "ssh://user@host:22/path/to/file.root",
+                "object/path",
             ),
         ),
         (
-            "ssh://user@host:50230/path/to/file",
+            "ssh://user@host:22/path/to/file.root:/object//path:with:colon:in:path/something/",
             (
-                "ssh://user@host:50230/path/to/file",
+                "ssh://user@host:22/path/to/file.root",
+                "object/path:with:colon:in:path/something",
+            ),
+        ),
+        (
+            "ssh://user@host:50230/path/to/file.root",
+            (
+                "ssh://user@host:50230/path/to/file.root",
                 None,
             ),
         ),
         (
-            "s3://bucket/path/to/file:object",
+            "s3://bucket/path/to/file.root:/dir////object",
             (
-                "s3://bucket/path/to/file",
-                "object",
+                "s3://bucket/path/to/file.root",
+                "dir/object",
+            ),
+        ),
+        (
+            "s3://bucket/path/to/file.root:",
+            (
+                "s3://bucket/path/to/file.root",
+                "",
             ),
         ),
         (
@@ -99,21 +113,21 @@ import pathlib
             ),
         ),
         (
-            "zip://uproot-issue121.root::file:///tmp/pytest-of-runner/pytest-0/test_fsspec_zip0/uproot-issue121.root.zip:Events/MET_pt",
+            "zip://uproot-issue121.root:Events/MET_pt::file:///tmp/pytest-of-runner/pytest-0/test_fsspec_zip0/uproot-issue121.root.zip",
             (
                 "zip://uproot-issue121.root::file:///tmp/pytest-of-runner/pytest-0/test_fsspec_zip0/uproot-issue121.root.zip",
                 "Events/MET_pt",
             ),
         ),
         (
-            "simplecache::zip://uproot-issue121.root::file:///tmp/pytest-of-runner/pytest-0/test_fsspec_zip0/uproot-issue121.root.zip:Events/MET_pt",
+            "simplecache::zip://uproot-issue121.root:Events/MET_pt::file:///tmp/pytest-of-runner/pytest-0/test_fsspec_zip0/uproot-issue121.root.zip",
             (
                 "simplecache::zip://uproot-issue121.root::file:///tmp/pytest-of-runner/pytest-0/test_fsspec_zip0/uproot-issue121.root.zip",
                 "Events/MET_pt",
             ),
         ),
         (
-            r"zip://uproot-issue121.root::file://C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\test_fsspec_zip0\uproot-issue121.root.zip:Events/MET_pt",
+            r"zip://uproot-issue121.root:Events/MET_pt::file://C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\test_fsspec_zip0\uproot-issue121.root.zip",
             (
                 r"zip://uproot-issue121.root::file://C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\test_fsspec_zip0\uproot-issue121.root.zip",
                 "Events/MET_pt",
@@ -131,9 +145,12 @@ def test_url_split(input_value, expected_output):
 @pytest.mark.parametrize(
     "input_value",
     [
-        "local/file.root://Events",
+        "local/file.root.zip://Events",
+        "local/file.roo://Events",
+        "local/file.roo://Events",
     ],
 )
 def test_url_split_invalid(input_value):
-    with pytest.raises(ValueError):
-        uproot._util.file_object_path_split(input_value)
+    path, obj = uproot._util.file_object_path_split(input_value)
+    assert obj is None
+    assert path == input_value


### PR DESCRIPTION
Closes #1025 

Bonus features:
- Able to parse object paths with colons in them e.g. file.root:dir/tree:with:colon -> file.root, dir/tree:with:colon

Limitations:
- Uses `.root` file extension as anchor, it's only able to split objects if the file has exactly a `.root` extension. This is technically a breaking change.