### PR TITLE
feat(draft): add `report=` argument to `uproot.dask`; triggers report collection for failed reads

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -949,9 +949,9 @@ class UprootReadMixin:
             behavior=self.form_mapping_info.behavior,
         )
 
-    def mock_empty() -> AwkArray:
+    def mock_empty(self) -> AwkArray:
         awkward = uproot.extras.awkward()
-        return ak.Array(
+        return awkward.Array(
             self.expected_form.length_zero_array(highlevel=False),
             behavior=self.form_mapping_info.behavior,
         )

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -949,10 +949,12 @@ class UprootReadMixin:
             behavior=self.form_mapping_info.behavior,
         )
 
-    def mock_empty(self) -> AwkArray:
+    def mock_empty(self, backend="cpu") -> AwkArray:
         awkward = uproot.extras.awkward()
-        return awkward.Array(
+        return awkward.to_backend(
             self.expected_form.length_zero_array(highlevel=False),
+            backend=backend,
+            highlevel=True,
             behavior=self.form_mapping_info.behavior,
         )
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1334,7 +1334,7 @@ which has {entry_stop} entries"""
             partition_args,
             divisions=tuple(divisions),
             label="from-uproot",
-            empty_on_raise=(OSError,)
+            empty_on_raise=(OSError,),
             empty_backend="cpu",
         )
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -949,6 +949,13 @@ class UprootReadMixin:
             behavior=self.form_mapping_info.behavior,
         )
 
+    def mock_empty() -> AwkArray:
+        awkward = uproot.extras.awkward()
+        return ak.Array(
+            self.expected_form.length_zero_array(highlevel=False),
+            behavior=self.form_mapping_info.behavior,
+        )
+
     def prepare_for_projection(self) -> tuple[AwkArray, TypeTracerReport, dict]:
         awkward = uproot.extras.awkward()
         dask_awkward = uproot.extras.dask_awkward()

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -949,7 +949,7 @@ class UprootReadMixin:
             behavior=self.form_mapping_info.behavior,
         )
 
-    def mock_empty(self, backend="cpu") -> AwkArray:
+    def mock_empty(self, backend) -> AwkArray:
         awkward = uproot.extras.awkward()
         return awkward.to_backend(
             self.expected_form.length_zero_array(highlevel=False),
@@ -1334,7 +1334,7 @@ which has {entry_stop} entries"""
             partition_args,
             divisions=tuple(divisions),
             label="from-uproot",
-            empty_on_raise=(Exception,),
+            empty_on_raise=(OSError,)
             empty_backend="cpu",
         )
 
@@ -1439,7 +1439,7 @@ def _get_dak_array_delay_open(
             partition_args,
             divisions=None if divisions is None else tuple(divisions),
             label="from-uproot",
-            empty_on_raise=(Exception,),
+            empty_on_raise=(OSError,),
             empty_backend="cpu",
         )
 


### PR DESCRIPTION
This PR pairs with https://github.com/dask-contrib/dask-awkward/pull/415. It adds a new `report` argument to `uproot.dask`. It causes the call to return two collections, the actual array of interest represented by the first collection, and a report collection as the second return.

As it stands if `report` is not `None` we create a report collection; it's designed to be computed simultaneously with whatever collection of the interest is. An example where we have two field access calls and then a `dak.max` call:

```python
dataset, report = uproot.dask({"/path/to/files/*.root": "tree"}, report=True)
measurement = dak.max(dataset.thing1 + datasetset.thing2, axis=1)
result, report = dask.compute(measurement, report)
```
If any of the files at that path end up as failure-to-read (raise an exception), the the `measurement` collection will have those partitions get computed to an empty array, so the `result` array object will be pieced together from a concatenation where some of the ingredients are empty, and the `report` array object will be an awkward array of length `dataset.npartitions`, (one element in the array per partition)

---

We have some flexibility here with the `report=` argument. The `from_map` API in dask-awkward via https://github.com/dask-contrib/dask-awkward/pull/415 has 4 arguments that can steer the behavior here
1. which exceptions should be absorbed to send back an empty array at that failed node
2. which backend for the empty array (for now I think is is always "cpu")
3. a callback function to run on nodes where the read was successful (this is an entry point for customizing the report for successful reads). (The default is `None`)
4. a callback function to run on nodes where the read was a failure (this is an entry point for customizing the report for failed reads). (The default is construct a record array which hold information about the error and the function arguments passed to the read function that failed)

cc @lgray 