### PR TITLE
feat(draft): add `report=` argument for `uproot.dask`; trigger report collection (take 2!)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ requires-python = ">=3.8"
 [project.optional-dependencies]
 dev = [
   "boost_histogram>=0.13",
-  "dask-awkward>=2023.10.0",
+  "dask-awkward>=2023.12.1",
   "dask[array]",
   "hist>=1.2",
   "pandas",

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1072,7 +1072,7 @@ def _report_success(duration, *args, **kwargs):
 def time_it(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        start = time.monotonic()
+        start = time.time()
         result = f(*args, **kwargs)
         end = time.monotonic()
         return result, (end - start)

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1062,8 +1062,8 @@ def _report_success(duration, *args, **kwargs):
                 "kwargs": [[k, repr(v)] for k, v in kwargs.items()],
                 "exception": None,
                 "message": None,
-                "fqdn": socket.getfqdn(),
-                "hostname": socket.gethostname(),
+                "fqdn": None,
+                "hostname": None,
             }
         ]
     )

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import math
 import time
+import socket
 from collections.abc import Callable, Iterable, Mapping
 
 try:
@@ -40,7 +41,7 @@ def dask(
     allow_missing=False,
     open_files=True,
     form_mapping=None,
-    report=None,
+    report=False,
     **options,
 ):
     """
@@ -1036,6 +1037,8 @@ def _report_failure(exception, *args, **kwargs):
                 "kwargs": [[k, repr(v)] for k, v in kwargs.items()],
                 "exception": type(exception).__name__,
                 "message": str(exception),
+                "fqdn": socket.fqdn(),
+                "hostname": socket.gethostname(),
             }
         ]
     )
@@ -1051,6 +1054,8 @@ def _report_success(duration, *args, **kwargs):
                 "kwargs": [[k, repr(v)] for k, v in kwargs.items()],
                 "exception": None,
                 "message": None,
+                "fqdn": socket.fqdn(),
+                "hostname": socket.gethostname(),
             }
         ]
     )
@@ -1059,9 +1064,9 @@ def _report_success(duration, *args, **kwargs):
 def time_it(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        start = time.time()
+        start = time.monotonic()
         result = f(*args, **kwargs)
-        end = time.time()
+        end = time.monotonic()
         return result, (end - start)
 
     return wrapper
@@ -1230,6 +1235,7 @@ which has {num_entries} entries"""
             self.base_form,
             self.expected_form,
             self.form_mapping_info,
+            self.report,
         )
 
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1082,6 +1082,10 @@ class _UprootRead(UprootReadMixin):
         self.report = report
 
     @property
+    def allowed_exceptions(self):
+        return (OSError,)
+
+    @property
     def return_report(self) -> bool:
         return self.report
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1071,14 +1071,13 @@ def _report_success(duration, *args, **kwargs):
     )
 
 
-def with_time_info(f):
+def with_duration(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        call_time = time.time_ns()
         start = time.monotonic()
         result = f(*args, **kwargs)
         stop = time.monotonic()
-        return result, call_time, (stop - start)
+        return result, (stop - start)
 
     return wrapper
 
@@ -1116,10 +1115,9 @@ class _UprootRead(UprootReadMixin):
     def __call__(self, i_start_stop):
         i, start, stop = i_start_stop
         if self.return_report:
+            call_time = time.time_ns()
             try:
-                result, call_time, duration = with_time_info(self._call_impl)(
-                    i, start, stop
-                )
+                result, duration = with_duration(self._call_impl)(i, start, stop)
                 return (
                     result,
                     _report_success(
@@ -1215,8 +1213,9 @@ which has {num_entries} entries"""
         ) = blockwise_args
 
         if self.return_report:
+            call_time = time.time_ns()
             try:
-                result, call_time, duration = with_time_info(self._call_impl)(
+                result, duration = with_duration(self._call_impl)(
                     file_path, object_path, i_step_or_start, n_steps_or_stop, is_chunk
                 )
                 return (

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -949,9 +949,9 @@ class UprootReadMixin:
             behavior=self.form_mapping_info.behavior,
         )
 
-    def mock_empty() -> AwkArray:
+    def mock_empty(self) -> AwkArray:
         awkward = uproot.extras.awkward()
-        return ak.Array(
+        return awkward.Array(
             self.expected_form.length_zero_array(highlevel=False),
             behavior=self.form_mapping_info.behavior,
         )

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -898,6 +898,14 @@ class UprootReadMixin:
     interp_options: dict[str, Any]
     report: bool
 
+    @property
+    def allowed_exceptions(self):
+        return (OSError,)
+
+    @property
+    def return_report(self) -> bool:
+        return self.report
+
     def read_tree(self, tree: HasBranches, start: int, stop: int) -> AwkArray:
         assert start <= stop
 
@@ -1090,14 +1098,6 @@ class _UprootRead(UprootReadMixin):
         self.expected_form = expected_form
         self.form_mapping_info = form_mapping_info
         self.report = report
-
-    @property
-    def allowed_exceptions(self):
-        return (OSError,)
-
-    @property
-    def return_report(self) -> bool:
-        return self.report
 
     def project_keys(self: T, keys: frozenset[str]) -> T:
         return _UprootRead(

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1045,7 +1045,7 @@ def _report_failure(exception, *args, **kwargs):
                 "kwargs": [[k, repr(v)] for k, v in kwargs.items()],
                 "exception": type(exception).__name__,
                 "message": str(exception),
-                "fqdn": socket.fqdn(),
+                "fqdn": socket.getfqdn(),
                 "hostname": socket.gethostname(),
             }
         ]
@@ -1062,7 +1062,7 @@ def _report_success(duration, *args, **kwargs):
                 "kwargs": [[k, repr(v)] for k, v in kwargs.items()],
                 "exception": None,
                 "message": None,
-                "fqdn": socket.fqdn(),
+                "fqdn": socket.getfqdn(),
                 "hostname": socket.gethostname(),
             }
         ]

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -949,10 +949,12 @@ class UprootReadMixin:
             behavior=self.form_mapping_info.behavior,
         )
 
-    def mock_empty(self) -> AwkArray:
+    def mock_empty(self, backend="cpu") -> AwkArray:
         awkward = uproot.extras.awkward()
-        return awkward.Array(
+        return awkward.to_backend(
             self.expected_form.length_zero_array(highlevel=False),
+            backend=backend,
+            highlevel=True,
             behavior=self.form_mapping_info.behavior,
         )
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1334,7 +1334,7 @@ which has {entry_stop} entries"""
             partition_args,
             divisions=tuple(divisions),
             label="from-uproot",
-            empty_on_raise=(OSError,)
+            empty_on_raise=(OSError,),
             empty_backend="cpu",
         )
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -949,6 +949,13 @@ class UprootReadMixin:
             behavior=self.form_mapping_info.behavior,
         )
 
+    def mock_empty() -> AwkArray:
+        awkward = uproot.extras.awkward()
+        return ak.Array(
+            self.expected_form.length_zero_array(highlevel=False),
+            behavior=self.form_mapping_info.behavior,
+        )
+
     def prepare_for_projection(self) -> tuple[AwkArray, TypeTracerReport, dict]:
         awkward = uproot.extras.awkward()
         dask_awkward = uproot.extras.dask_awkward()

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -949,7 +949,7 @@ class UprootReadMixin:
             behavior=self.form_mapping_info.behavior,
         )
 
-    def mock_empty(self, backend="cpu") -> AwkArray:
+    def mock_empty(self, backend) -> AwkArray:
         awkward = uproot.extras.awkward()
         return awkward.to_backend(
             self.expected_form.length_zero_array(highlevel=False),
@@ -1334,7 +1334,7 @@ which has {entry_stop} entries"""
             partition_args,
             divisions=tuple(divisions),
             label="from-uproot",
-            empty_on_raise=(Exception,),
+            empty_on_raise=(OSError,)
             empty_backend="cpu",
         )
 
@@ -1439,7 +1439,7 @@ def _get_dak_array_delay_open(
             partition_args,
             divisions=None if divisions is None else tuple(divisions),
             label="from-uproot",
-            empty_on_raise=(Exception,),
+            empty_on_raise=(OSError,),
             empty_backend="cpu",
         )
 

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import functools
 import math
-import time
 import socket
+import time
 from collections.abc import Callable, Iterable, Mapping
 
 try:

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -895,6 +895,7 @@ class UprootReadMixin:
     form_mapping_info: ImplementsFormMappingInfo
     common_keys: frozenset[str]
     interp_options: dict[str, Any]
+    report: bool
 
     def read_tree(self, tree: HasBranches, start: int, stop: int) -> AwkArray:
         assert start <= stop
@@ -1154,7 +1155,7 @@ class _UprootOpenAndRead(UprootReadMixin):
         self.base_form = base_form
         self.expected_form = expected_form
         self.form_mapping_info = form_mapping_info
-        self.report = (self.report,)
+        self.report = report
 
     def __call__(self, blockwise_args) -> AwkArray:
         (

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import functools
 import math
+import time
 from collections.abc import Callable, Iterable, Mapping
 
 try:
@@ -1024,7 +1026,8 @@ class UprootReadMixin:
 
 
 def _report_failure(exception, *args, **kwargs):
-    return ak.Array(
+    awkward = uproot.extras.awkward()
+    return awkward.Array(
         [
             {
                 "duration": None,
@@ -1038,7 +1041,8 @@ def _report_failure(exception, *args, **kwargs):
 
 
 def _report_success(duration, *args, **kwargs):
-    return ak.Array(
+    awkward = uproot.extras.awkward()
+    return awkward.Array(
         [
             {
                 "duration": duration,

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1216,13 +1216,13 @@ which has {num_entries} entries"""
 
         if self.return_report:
             try:
-                result, time = time_it(self._call_impl)(
+                result, call_time, duration = with_time_info(self._call_impl)(
                     file_path, object_path, i_step_or_start, n_steps_or_stop, is_chunk
                 )
                 return (
                     result,
                     _report_success(
-                        time,
+                        duration,
                         file_path,
                         object_path,
                         i_step_or_start,
@@ -1235,6 +1235,7 @@ which has {num_entries} entries"""
                     self.mock_empty(backend="cpu"),
                     _report_failure(
                         err,
+                        call_time,
                         file_path,
                         object_path,
                         i_step_or_start,

--- a/tests/test_1058_dask_awkward_report.py
+++ b/tests/test_1058_dask_awkward_report.py
@@ -1,0 +1,25 @@
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+dask = pytest.importorskip("dask")
+dask_awkward = pytest.importorskip("dask_awkward")
+
+
+def test_with_report():
+    test_path1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
+    test_path2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root") + ":events"
+    test_path3 = "/some/file/that/doesnt/exist"
+    files = [test_path1, test_path2, test_path3]
+    collection, report = uproot.dask(
+        files,
+        library="ak",
+        open_files=False,
+        allow_read_errors_with_report=True,
+    )
+    _, creport = dask.compute(collection, report)
+    assert creport[0].exception is None  # test_path1 is good
+    assert creport[1].exception is None  # test_path2 is good
+    assert creport[2].exception == "FileNotFoundError"  # test_path3 is a bad file


### PR DESCRIPTION
Supersedes #1050 

This again boils down to adding a `report=` argument, but now the implementation to actually build the report is significant changed and based on PR https://github.com/dask-contrib/dask-awkward/pull/433 in dask-awkward instead of the combination of #1050 + https://github.com/dask-contrib/dask-awkward/pull/415

@lgray if you could take this for a spin on something that you know will potentially have `OSError` raised, that would be great! 