### PR TITLE
test: do not skip aiohttp tests for Python 3.12 - update pytest rerun settings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          python -m pytest -vv tests --reruns 3 --reruns-delay 30 --only-rerun "(?i)http|timeout|connection|socket"
+          python -m pytest -vv tests --reruns 5 --reruns-delay 60 --only-rerun "(?i)http|timeout|connection|socket"
 
   vanilla-build:
     strategy:
@@ -91,4 +91,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          python -m pytest -vv tests --reruns 3 --reruns-delay 30 --only-rerun "(?i)http|timeout|connection|socket"
+          python -m pytest -vv tests --reruns 5 --reruns-delay 60 --only-rerun "(?i)http|timeout|connection|socket"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|timeout|connection|socket"
+          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|ssl|timeout|expired|connection|socket"
 
   vanilla-build:
     strategy:
@@ -91,4 +91,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|timeout|connection|socket"
+          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|ssl|timeout|expired|connection|socket"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          python -m pytest -vv tests --reruns 5 --reruns-delay 60 --only-rerun "(?i)http|timeout|connection|socket"
+          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|timeout|connection|socket"
 
   vanilla-build:
     strategy:
@@ -91,4 +91,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          python -m pytest -vv tests --reruns 5 --reruns-delay 60 --only-rerun "(?i)http|timeout|connection|socket"
+          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|timeout|connection|socket"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,10 @@ test = [
   "xxhash",
   "zstandard",
   "minio",
-  "aiohttp; python_version<\"3.12\"",  # asyncio not available
+  "aiohttp",
   "fsspec",
   "fsspec-xrootd",
-  "s3fs; python_version<\"3.12\"",  # asyncio not available
+  "s3fs",
   "paramiko",
   "pytest>=6",
   "pytest-timeout",


### PR DESCRIPTION
`aiohttp` appears to be available for python 3.12 so we can remove the skip.

I also increased the number of reruns in the pytest command to avoid failure due to flaky xrootd.