### PR TITLE
test: xrootd server fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def serve():
 
 
 @pytest.fixture(scope="module")
-def server():
+def http_server():
     with serve() as server_url:
         yield server_url
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
-
+import shutil
+import subprocess
 import pytest
 import threading
 import contextlib
 import skhep_testdata
 from functools import partial
 import os
+import time
 
 # The base http server does not support range requests. Watch https://github.com/python/cpython/issues/86809 for updates
 from http.server import HTTPServer
@@ -21,7 +23,7 @@ def reset_classes():
 
 
 @contextlib.contextmanager
-def serve():
+def serve_http():
     # serve files from the skhep_testdata cache directory.
     # This directory is initially empty and files are downloaded on demand
     class Handler(RangeRequestHandler):
@@ -68,10 +70,24 @@ def serve():
 
 @pytest.fixture(scope="module")
 def http_server():
-    with serve() as server_url:
+    with serve_http() as server_url:
         yield server_url
 
 
 @pytest.fixture(scope="module")
 def tests_directory() -> str:
     return os.path.dirname(os.path.realpath(__file__))
+
+
+@pytest.fixture(scope="module")
+def xrootd_server(tmpdir_factory):
+    server_dir = tmpdir_factory.mktemp("server")
+    temp_path = os.path.join(server_dir, "Folder")
+    os.mkdir(temp_path)
+    xrootd = shutil.which("xrootd")
+    proc = subprocess.Popen([xrootd, server_dir])
+    time.sleep(2)  # give it some startup
+    yield "root://localhost/" + str(temp_path), temp_path
+    proc.terminate()
+    proc.wait(timeout=10)
+    shutil.rmtree(server_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,9 @@ def tests_directory() -> str:
 
 @pytest.fixture(scope="module")
 def xrootd_server(tmpdir_factory):
+    pytest.importorskip("XRootD")
+    pytest.importorskip("fsspec_xrootd")
+
     server_dir = tmpdir_factory.mktemp("server")
     temp_path = os.path.join(server_dir, "Folder")
     os.mkdir(temp_path)

--- a/tests/test_0001_source_class.py
+++ b/tests/test_0001_source_class.py
@@ -184,8 +184,8 @@ def test_http_port(use_threads):
 
 
 @pytest.mark.parametrize("use_threads", [True, False])
-def test_http_size(server, use_threads):
-    url = f"{server}/uproot-issue121.root"
+def test_http_size(http_server, use_threads):
+    url = f"{http_server}/uproot-issue121.root"
     with uproot.source.http.HTTPSource(
         url,
         timeout=10,
@@ -282,8 +282,8 @@ def test_no_multipart_fail(use_threads, num_workers):
 
 
 @pytest.mark.parametrize("use_threads, num_workers", [(True, 1), (True, 2), (False, 0)])
-def test_fallback(server, use_threads, num_workers):
-    url = f"{server}/uproot-issue121.root"
+def test_fallback(http_server, use_threads, num_workers):
+    url = f"{http_server}/uproot-issue121.root"
     with uproot.source.http.HTTPSource(
         url,
         timeout=10,

--- a/tests/test_0006_notify_when_downloaded.py
+++ b/tests/test_0006_notify_when_downloaded.py
@@ -64,8 +64,8 @@ def test_memmap(tmpdir):
             expected.pop((chunk.start, chunk.stop))
 
 
-def test_http_multipart(server):
-    url = f"{server}/uproot-issue121.root"
+def test_http_multipart(http_server):
+    url = f"{http_server}/uproot-issue121.root"
     notifications = queue.Queue()
     with uproot.source.http.HTTPSource(
         url, timeout=10, num_fallback_workers=1, use_threads=True
@@ -79,8 +79,8 @@ def test_http_multipart(server):
             expected.pop((chunk.start, chunk.stop))
 
 
-def test_http(server):
-    url = f"{server}/uproot-issue121.root"
+def test_http(http_server):
+    url = f"{http_server}/uproot-issue121.root"
     notifications = queue.Queue()
     with uproot.source.http.MultithreadedHTTPSource(
         url, timeout=10, num_workers=1, use_threads=True
@@ -94,8 +94,8 @@ def test_http(server):
             expected.pop((chunk.start, chunk.stop))
 
 
-def test_http_workers(server):
-    url = f"{server}/uproot-issue121.root"
+def test_http_workers(http_server):
+    url = f"{http_server}/uproot-issue121.root"
     notifications = queue.Queue()
     with uproot.source.http.MultithreadedHTTPSource(
         url, timeout=10, num_workers=2, use_threads=True
@@ -109,8 +109,8 @@ def test_http_workers(server):
             expected.pop((chunk.start, chunk.stop))
 
 
-def test_http_fallback(server):
-    url = f"{server}/uproot-issue121.root"
+def test_http_fallback(http_server):
+    url = f"{http_server}/uproot-issue121.root"
     notifications = queue.Queue()
     with uproot.source.http.HTTPSource(
         url,
@@ -127,8 +127,8 @@ def test_http_fallback(server):
             expected.pop((chunk.start, chunk.stop))
 
 
-def test_http_fallback_workers(server):
-    url = f"{server}/uproot-issue121.root"
+def test_http_fallback_workers(http_server):
+    url = f"{http_server}/uproot-issue121.root"
     notifications = queue.Queue()
     with uproot.source.http.HTTPSource(
         url,

--- a/tests/test_0007_single_chunk_interface.py
+++ b/tests/test_0007_single_chunk_interface.py
@@ -77,8 +77,8 @@ def test_memmap(tmpdir):
     "num_workers",
     [1, 2],
 )
-def test_http(server, num_workers):
-    url = f"{server}/uproot-issue121.root"
+def test_http(http_server, num_workers):
+    url = f"{http_server}/uproot-issue121.root"
     with uproot.source.http.MultithreadedHTTPSource(
         url, num_workers=num_workers, timeout=10, use_threads=True
     ) as source:
@@ -103,8 +103,8 @@ def test_http_fail(num_workers):
             source.chunk(0, 100)
 
 
-def test_http_multipart(server):
-    url = f"{server}/uproot-issue121.root"
+def test_http_multipart(http_server):
+    url = f"{http_server}/uproot-issue121.root"
     with uproot.source.http.HTTPSource(
         url, timeout=10, num_fallback_workers=1, use_threads=True
     ) as source:

--- a/tests/test_0692_fsspec_reading.py
+++ b/tests/test_0692_fsspec_reading.py
@@ -156,16 +156,24 @@ def test_open_fsspec_ssh(handler):
         None,
     ],
 )
-def test_open_fsspec_xrootd(handler):
+def test_open_fsspec_xrootd(handler, xrootd_server):
     pytest.importorskip("XRootD")
     pytest.importorskip("fsspec_xrootd")
+
+    filename = "uproot-issue121.root"
+    remote_path, local_path = xrootd_server
+    with open(skhep_testdata.data_path(filename), "rb") as f_read:
+        with open(os.path.join(local_path, filename), "wb") as f_write:
+            f_write.write(f_read.read())
+
+    print(remote_path, local_path)
+
     with uproot.open(
-        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
+        os.path.join(remote_path, filename),
         handler=handler,
     ) as f:
-        data = f["Events/run"].array(library="np", entry_stop=20)
-        assert len(data) == 20
-        assert (data == 194778).all()
+        data = f["Events/MET_pt"].array(library="np")
+        assert len(data) == 40
 
 
 @pytest.mark.parametrize(

--- a/tests/test_0692_fsspec_reading.py
+++ b/tests/test_0692_fsspec_reading.py
@@ -157,9 +157,6 @@ def test_open_fsspec_ssh(handler):
     ],
 )
 def test_open_fsspec_xrootd(handler, xrootd_server):
-    pytest.importorskip("XRootD")
-    pytest.importorskip("fsspec_xrootd")
-
     filename = "uproot-issue121.root"
     remote_path, local_path = xrootd_server
     with open(skhep_testdata.data_path(filename), "rb") as f_read:

--- a/tests/test_0692_fsspec_reading.py
+++ b/tests/test_0692_fsspec_reading.py
@@ -47,10 +47,10 @@ def test_invalid_handler(to_open, handler):
         uproot.open(to_open, handler=handler)
 
 
-def test_open_fsspec_http(server):
+def test_open_fsspec_http(http_server):
     pytest.importorskip("aiohttp")
 
-    url = f"{server}/uproot-issue121.root"
+    url = f"{http_server}/uproot-issue121.root"
     with uproot.open(
         url,
         handler=uproot.source.fsspec.FSSpecSource,
@@ -223,10 +223,10 @@ def test_issue_1054_object_path_split(handler):
         assert len(data) == 40
 
 
-def test_fsspec_chunks(server):
+def test_fsspec_chunks(http_server):
     pytest.importorskip("aiohttp")
 
-    url = f"{server}/uproot-issue121.root"
+    url = f"{http_server}/uproot-issue121.root"
 
     notifications = queue.Queue()
     with uproot.source.fsspec.FSSpecSource(url) as source:

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -93,10 +93,10 @@ def test_issue_1029(tmp_path):
         assert f["tree_2"]["y"].array().tolist() == [4, 5, 6]
 
 
-def test_fsspec_writing_http(server):
+def test_fsspec_writing_http(http_server):
     pytest.importorskip("aiohttp")
 
-    uri = f"{server}/file.root"
+    uri = f"{http_server}/file.root"
 
     with pytest.raises(NotImplementedError):
         # TODO: review this when fsspec supports writing to http


### PR DESCRIPTION
Add a pytest fixture for xrootd server which can be used to serve files locally over xrootd. We might want to switch to use this for all xrootd tests to avoid networking / server issues.

I updated one xrootd test to use this new fixture.

I also renamed the old "server" fixture to "http_server" since now we have more than one server fixture.
