### PR TITLE
feat: supply a pre-calculated base form to avoid file opening

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -42,6 +42,7 @@ def dask(
     open_files=True,
     form_mapping=None,
     allow_read_errors_with_report=False,
+    known_base_form=None,
     **options,
 ):
     """
@@ -99,6 +100,8 @@ def dask(
             empty array for these nodes in the task graph. The return of this function then
             becomes a two element tuple, where the first return is the dask-awkward collection
             of interest and the second return is a report dask-awkward collection.
+        known_base_form (awkward.forms.Form | None): If not none use this form instead of opening
+            one file to determine the dataset's form. Only available with open_files=False.
         options: See below.
 
     Returns dask equivalents of the backends supported by uproot. If ``library='np'``,
@@ -200,6 +203,9 @@ def dask(
     else:
         steps_per_file = 1
 
+    if known_base_form is not None and open_files:
+        raise TypeError("known_base_form must be None if open_files is True")
+
     if library.name == "pd":
         raise NotImplementedError()
 
@@ -279,6 +285,7 @@ def dask(
                 form_mapping,
                 steps_per_file,
                 allow_read_errors_with_report,
+                known_base_form,
             )
     else:
         raise NotImplementedError()
@@ -1481,26 +1488,30 @@ def _get_dak_array_delay_open(
     form_mapping,
     steps_per_file,
     allow_read_errors_with_report,
+    known_base_form,
 ):
     dask_awkward = uproot.extras.dask_awkward()
     awkward = uproot.extras.awkward()
 
     ffile_path, fobject_path = files[0][0:2]
 
-    obj = uproot._util.regularize_object_path(
-        ffile_path, fobject_path, custom_classes, allow_missing, real_options
-    )
-    common_keys = obj.keys(
-        recursive=recursive,
-        filter_name=filter_name,
-        filter_typename=filter_typename,
-        filter_branch=filter_branch,
-        full_paths=full_paths,
-    )
-
-    base_form = _get_ttree_form(
-        awkward, obj, common_keys, interp_options.get("ak_add_doc")
-    )
+    if known_base_form is not None:
+        common_keys = list(known_base_form.fields)
+        base_form = known_base_form
+    else:
+        obj = uproot._util.regularize_object_path(
+            ffile_path, fobject_path, custom_classes, allow_missing, real_options
+        )
+        common_keys = obj.keys(
+            recursive=recursive,
+            filter_name=filter_name,
+            filter_typename=filter_typename,
+            filter_branch=filter_branch,
+            full_paths=full_paths,
+        )
+        base_form = _get_ttree_form(
+            awkward, obj, common_keys, interp_options.get("ak_add_doc")
+        )
 
     divisions = [0]
     partition_args = []


### PR DESCRIPTION
Add `known_base_form` option (`awkward.forms.Form | None`) to `uproot.dask` so that opening root files at the client can be avoided for mature analyses where the base forms of all files are well known.

Right now it is mutual exclusive with `open_files=True`, since it brings no advantage in that case.

An initial implementation is included.

I tested the speedup with the following code:
```python3
import uproot
import json
import gzip
import awkward

import pyinstrument

if __name__ == "__main__":

    prof = pyinstrument.Profiler()
    prof.start()

    with gzip.open("nano_form.json.gz", "r") as in_form:
	known_form = awkward.forms.from_json(in_form.read())

    for _ in range(20):
	events = uproot.dask({"tests/samples/nano_dy.root": {"object_path": "Events", "steps": [[0,40]]}}, open_files=False, known_base_form=known_form)

    prof.stop()
    print(prof.output_text(unicode=True, color=True, show_all=True))

    prof = pyinstrument.Profiler()
    prof.start()

    for _ in range(20):
        events = uproot.dask({"tests/samples/nano_dy.root": {"object_path": "Events", "steps": [[0,40]]}}, open_files=False)

    prof.stop()
    print(prof.output_text(unicode=True, color=True, show_all=True))
```

Which on a arm64 macbook pro with SSD gives about a 6x speedup. The gain will be enormous when using xrootd.
