### PR TITLE
feat: allow user to supply tuple of allowed exceptions

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -908,8 +908,8 @@ class UprootReadMixin:
 
     @property
     def allowed_exceptions(self):
-        if isinstance(allow_read_errors_with_report, tuple):
-            return allow_read_errors_with_report
+        if isinstance(self.allow_read_errors_with_report, tuple):
+            return self.allow_read_errors_with_report
         return (OSError,)
 
     @property

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -96,10 +96,12 @@ def dask(
         form_mapping (Callable[awkward.forms.Form] -> awkward.forms.Form | None): If not none
             and library="ak" then apply this remapping function to the awkward form of the input
             data. The form keys of the desired form should be available data in the input form.
-        allow_read_errors_with_report (bool): If True, catch OSError exceptions and return an
-            empty array for these nodes in the task graph. The return of this function then
-            becomes a two element tuple, where the first return is the dask-awkward collection
-            of interest and the second return is a report dask-awkward collection.
+        allow_read_errors_with_report (bool or tuple or exceptions): If True, catch OSError
+            exceptions and return an empty array for these nodes in the task graph. If a tuple,
+            catch any of those exceptions and return empty arrays for those nodes. In either of
+            those cases, The return of this function becomes a two element tuple, where the
+            first return is the dask-awkward collection of interest and the second return is a
+            report dask-awkward collection.
         known_base_form (awkward.forms.Form | None): If not none use this form instead of opening
             one file to determine the dataset's form. Only available with open_files=False.
         options: See below.
@@ -902,15 +904,17 @@ class UprootReadMixin:
     form_mapping_info: ImplementsFormMappingInfo
     common_keys: frozenset[str]
     interp_options: dict[str, Any]
-    allow_read_errors_with_report: bool
+    allow_read_errors_with_report: bool | tuple[type[BaseException], ...]
 
     @property
     def allowed_exceptions(self):
+        if isinstance(allow_read_errors_with_report, tuple):
+            return allow_read_errors_with_report
         return (OSError,)
 
     @property
     def return_report(self) -> bool:
-        return self.allow_read_errors_with_report
+        return bool(self.allow_read_errors_with_report)
 
     def read_tree(self, tree: HasBranches, start: int, stop: int) -> AwkArray:
         assert start <= stop
@@ -1097,7 +1101,7 @@ class _UprootRead(UprootReadMixin):
         base_form: Form,
         expected_form: Form,
         form_mapping_info: ImplementsFormMappingInfo,
-        allow_read_errors_with_report: bool,
+        allow_read_errors_with_report: bool | tuple[type[BaseException], ...],
     ) -> None:
         self.ttrees = ttrees
         self.common_keys = frozenset(common_keys)
@@ -1162,7 +1166,7 @@ class _UprootOpenAndRead(UprootReadMixin):
         base_form: Form,
         expected_form: Form,
         form_mapping_info: ImplementsFormMappingInfo,
-        allow_read_errors_with_report: bool,
+        allow_read_errors_with_report: bool | tuple[type[BaseException], ...],,
     ) -> None:
         self.custom_classes = custom_classes
         self.allow_missing = allow_missing

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1166,7 +1166,7 @@ class _UprootOpenAndRead(UprootReadMixin):
         base_form: Form,
         expected_form: Form,
         form_mapping_info: ImplementsFormMappingInfo,
-        allow_read_errors_with_report: bool | tuple[type[BaseException], ...],,
+        allow_read_errors_with_report: bool | tuple[type[BaseException], ...],
     ) -> None:
         self.custom_classes = custom_classes
         self.allow_missing = allow_missing

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -96,7 +96,7 @@ def dask(
         form_mapping (Callable[awkward.forms.Form] -> awkward.forms.Form | None): If not none
             and library="ak" then apply this remapping function to the awkward form of the input
             data. The form keys of the desired form should be available data in the input form.
-        allow_read_errors_with_report (bool or tuple or exceptions): If True, catch OSError
+        allow_read_errors_with_report (bool or tuple of exceptions): If True, catch OSError
             exceptions and return an empty array for these nodes in the task graph. If a tuple,
             catch any of those exceptions and return empty arrays for those nodes. In either of
             those cases, The return of this function becomes a two element tuple, where the

--- a/tests/test_1058_dask_awkward_report.py
+++ b/tests/test_1058_dask_awkward_report.py
@@ -8,7 +8,10 @@ dask = pytest.importorskip("dask")
 dask_awkward = pytest.importorskip("dask_awkward")
 
 
-def test_with_report():
+@pytest.mark.parametrize(
+    "allowed", [True, (OSError,), (FileNotFoundError, RuntimeError)]
+)
+def test_with_report(allowed):
     test_path1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
     test_path2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root") + ":events"
     test_path3 = "/some/file/that/doesnt/exist"
@@ -17,9 +20,26 @@ def test_with_report():
         files,
         library="ak",
         open_files=False,
-        allow_read_errors_with_report=True,
+        allow_read_errors_with_report=allowed,
     )
     _, creport = dask.compute(collection, report)
     assert creport[0].exception is None  # test_path1 is good
     assert creport[1].exception is None  # test_path2 is good
     assert creport[2].exception == "FileNotFoundError"  # test_path3 is a bad file
+
+
+def test_with_report_exception_missed():
+    test_path1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
+    test_path2 = skhep_testdata.data_path("uproot-Zmumu-uncompressed.root") + ":events"
+    test_path3 = "/some/file/that/doesnt/exist"
+    files = [test_path1, test_path2, test_path3]
+    collection, report = uproot.dask(
+        files,
+        library="ak",
+        open_files=False,
+        allow_read_errors_with_report=(
+            ValueError,  # allow ValueErrors, but that's not what happens!
+        ),
+    )
+    with pytest.raises(FileNotFoundError):
+        _, creport = dask.compute(collection, report)


### PR DESCRIPTION
Change `uproot.dask`'s `allow_read_errors_with_report` argument to also allow a tuple of exceptions to be passed in. Original `=True` behavior keeps the `(OSError,)` only tuple