### PR TITLE
fix: state of context["forth"] after an entire TBasket is incomplete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ log_cli_level = "info"
 markers = [
   "slow",
   "network",
+  "distributed",
   "xrootd"
 ]
 minversion = "6.0"

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -198,7 +198,7 @@ class AsObjects(uproot.interpretation.Interpretation):
         )
         assert basket.byte_offsets is not None
 
-        if not hasattr(context["forth"], "vm"):
+        if getattr(context["forth"], "vm", None) is None:
             # context["forth"] is a threading.local()
             context["forth"].vm = None
             context["forth"].gen = uproot._awkwardforth.ForthGenerator(self)

--- a/tests/test_1063_dask_distributed.py
+++ b/tests/test_1063_dask_distributed.py
@@ -10,6 +10,7 @@ dask_awkward = pytest.importorskip("dask_awkward")
 dask_distributed = pytest.importorskip("dask.distributed")
 
 
+@pytest.mark.distributed
 @pytest.mark.parametrize(
     "handler",
     [None, uproot.source.file.MemmapSource, uproot.source.fsspec.FSSpecSource],

--- a/tests/test_1085_dask_write.py
+++ b/tests/test_1085_dask_write.py
@@ -64,6 +64,7 @@ def test_graph(tmp_path):
     assert ak.all(file_2["tree"]["a"].arrays()["a"][0] == arr[1]["a"])
 
 
+@pytest.mark.distributed
 def test_compute(tmp_path):
     print("here")
     partitions = 2


### PR DESCRIPTION
The TBranch described in #1099 contains many empty lists, and its AwkwardForth code can't be discovered until it sees at least one non-empty list. That happens after cycling from one TBasket to the next (about a dozen TBaskets, actually), and the `context["forth"].vm` state is `None`, rather than nonexistent, due to

https://github.com/scikit-hep/uproot5/blob/e592ae333c2d8d2ee7d65f1a2de1fcb3a8fea13f/src/uproot/interpretation/objects.py#L237

So the check for "Does an AwkwardForth VM exist?" should check for both the missing attribute case and the attribute is equal to None case.