### PR TITLE
fix: missing '_fh' and '_file' attributes after unpickling

### DIFF
--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -70,6 +70,8 @@ class FSSpecSource(uproot.source.chunk.Source):
 
     def __setstate__(self, state):
         self.__dict__ = state
+        self._file = None
+        self._fh = None
         self._open()
 
     def __enter__(self):


### PR DESCRIPTION
I have not tested this as a fix for #1117, but it seemed like an obviously missing thing that should be filled in anyway.