### PR TITLE
fix: test suite creates files not in tmp_path

### DIFF
--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -58,23 +58,25 @@ def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
 
 @pytest.mark.parametrize(
     "input_value",
-    ['\\file.root'
-     ,'\\file%2Eroot'
-     ,'\\my%E2%80%92file.root'
-     ,'\\my%20file.root'
-     ,'file:\\file.root'
-     ,'file:\\file%2Eroot'
-     ,'file:\\my%E2%80%92file.root'
-     ,'file:\\my%20file.root'
-     ,'file://\\file.root'
-     ,'file://\\file%2Eroot'
-     ,'file://\\my%E2%80%92file.root'
-     ,'file://\\my%20file.root'
-     ,'simplecache::file://\\file.root'
-     ,'simplecache::file://\\file%2Eroot'
-     ,'simplecache::file://\\my%E2%80%92file.root'
-     ,'simplecache::file://\\my%20file.root'
-     ])
+    [
+        "\\file.root",
+        "\\file%2Eroot",
+        "\\my%E2%80%92file.root",
+        "\\my%20file.root",
+        "file:\\file.root",
+        "file:\\file%2Eroot",
+        "file:\\my%E2%80%92file.root",
+        "file:\\my%20file.root",
+        "file://\\file.root",
+        "file://\\file%2Eroot",
+        "file://\\my%E2%80%92file.root",
+        "file://\\my%20file.root",
+        "simplecache::file://\\file.root",
+        "simplecache::file://\\file%2Eroot",
+        "simplecache::file://\\my%E2%80%92file.root",
+        "simplecache::file://\\my%20file.root",
+    ],
+)
 def test_fsspec_backslash_prefix(input_value):
     # for slash_prefix `\` avoid testing the creation of files and only check if the uri is parsed correctly
     url, obj = uproot._util.file_object_path_split(input_value)

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -56,6 +56,7 @@ def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
         assert f["tree"]["x"].array().tolist() == [1, 2, 3]
 
     import shutil
+
     try:
         shutil.rmtree("\\")
     except:

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -46,7 +46,7 @@ def test_fsspec_writing_local(tmp_path, scheme):
 )
 @pytest.mark.parametrize(
     "slash_prefix",
-    ["", "/", "\\"],
+    ["", "/"],
 )
 def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
     uri = scheme + slash_prefix + os.path.join(tmp_path, "some", "path", filename)
@@ -55,12 +55,31 @@ def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
     with uproot.open(uri) as f:
         assert f["tree"]["x"].array().tolist() == [1, 2, 3]
 
-    import shutil
 
-    try:
-        shutil.rmtree("\\")
-    except:
-        pass
+@pytest.mark.parametrize(
+    "input_value",
+    ['\\file.root'
+     ,'\\file%2Eroot'
+     ,'\\my%E2%80%92file.root'
+     ,'\\my%20file.root'
+     ,'file:\\file.root'
+     ,'file:\\file%2Eroot'
+     ,'file:\\my%E2%80%92file.root'
+     ,'file:\\my%20file.root'
+     ,'file://\\file.root'
+     ,'file://\\file%2Eroot'
+     ,'file://\\my%E2%80%92file.root'
+     ,'file://\\my%20file.root'
+     ,'simplecache::file://\\file.root'
+     ,'simplecache::file://\\file%2Eroot'
+     ,'simplecache::file://\\my%E2%80%92file.root'
+     ,'simplecache::file://\\my%20file.root'
+     ])
+def test_fsspec_backslash_prefix(input_value):
+    # for slash_prefix `\` avoid testing the creation of files and only check if the uri is parsed correctly
+    url, obj = uproot._util.file_object_path_split(input_value)
+    assert obj is None
+    assert url == input_value
 
 
 @pytest.mark.parametrize(

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -74,8 +74,7 @@ def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
     ],
 )
 def test_fsspec_writing_create(tmp_path, scheme):
-    uri = scheme + os.path.join("some", "path", "file.root")
-    os.chdir(tmp_path)
+    uri = scheme + os.path.join(tmp_path, "some", "path", "file.root")
     with uproot.create(uri) as f:
         f["tree"] = {"x": np.array([1, 2, 3])}
 
@@ -123,8 +122,7 @@ def test_fsspec_writing_http(http_server):
     ],
 )
 def test_fsspec_writing_local_update(tmp_path, scheme):
-    uri = scheme + os.path.join("some", "path", "file.root")
-    os.chdir(tmp_path)
+    uri = scheme + os.path.join(tmp_path, "some", "path", "file.root")
     with uproot.recreate(uri) as f:
         f["tree1"] = {"x": np.array([1, 2, 3])}
 

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -50,11 +50,16 @@ def test_fsspec_writing_local(tmp_path, scheme):
 )
 def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
     uri = scheme + slash_prefix + os.path.join(tmp_path, "some", "path", filename)
-    print(uri)
     with uproot.create(uri) as f:
         f["tree"] = {"x": np.array([1, 2, 3])}
     with uproot.open(uri) as f:
         assert f["tree"]["x"].array().tolist() == [1, 2, 3]
+
+    import shutil
+    try:
+        shutil.rmtree("\\")
+    except:
+        pass
 
 
 @pytest.mark.parametrize(
@@ -68,7 +73,8 @@ def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
     ],
 )
 def test_fsspec_writing_create(tmp_path, scheme):
-    uri = scheme + os.path.join(tmp_path, "some", "path", "file.root")
+    uri = scheme + os.path.join("some", "path", "file.root")
+    os.chdir(tmp_path)
     with uproot.create(uri) as f:
         f["tree"] = {"x": np.array([1, 2, 3])}
 
@@ -116,7 +122,8 @@ def test_fsspec_writing_http(http_server):
     ],
 )
 def test_fsspec_writing_local_update(tmp_path, scheme):
-    uri = scheme + os.path.join(tmp_path, "some", "path", "file.root")
+    uri = scheme + os.path.join("some", "path", "file.root")
+    os.chdir(tmp_path)
     with uproot.recreate(uri) as f:
         f["tree1"] = {"x": np.array([1, 2, 3])}
 


### PR DESCRIPTION
In testing fsspec writing for configurations in scheme + slash_prefix a "\\" directory gets made with what should be temporary files. 

Moving to the tmp_path before creating the file doesn't work, thus we can simply remove the newly created folder. 

We can do this immediately after testing each file (`test_fsspec_writing_local_uri` in `test_0692_fsspec_writing`) or after all the versions of that test have been executed. 

 