### PR TITLE
fix: allow writing generic UHI-compatible histograms

### DIFF
--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -265,7 +265,8 @@ def to_writable(obj):
             data = obj.values(flow=True)
             fSumw2 = (
                 obj.variances(flow=True)
-                if boost_histogram is None or obj.storage_type == boost_histogram.storage.Weight
+                if boost_histogram is None
+                or obj.storage_type == boost_histogram.storage.Weight
                 else None
             )
 
@@ -293,7 +294,8 @@ def to_writable(obj):
 
             tmp = (
                 obj.variances()
-                if boost_histogram is None or obj.storage_type == boost_histogram.storage.Weight
+                if boost_histogram is None
+                or obj.storage_type == boost_histogram.storage.Weight
                 else None
             )
             fSumw2 = None

--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -265,7 +265,7 @@ def to_writable(obj):
             data = obj.values(flow=True)
             fSumw2 = (
                 obj.variances(flow=True)
-                if obj.storage_type == boost_histogram.storage.Weight
+                if boost_histogram is None or obj.storage_type == boost_histogram.storage.Weight
                 else None
             )
 
@@ -293,7 +293,7 @@ def to_writable(obj):
 
             tmp = (
                 obj.variances()
-                if obj.storage_type == boost_histogram.storage.Weight
+                if boost_histogram is None or obj.storage_type == boost_histogram.storage.Weight
                 else None
             )
             fSumw2 = None


### PR DESCRIPTION
Commit ec80b887 broke support for writing histograms that fulfill the Unified Histogram Interface, but are neither from hist nor from boost_histogram. UHI compatible histograms always have a function `variances`, but do not have a `storage_type` attribute, so that attribute should only be checked if the histogram is indeed from boost_histogram.