### PR TITLE
ci: Add upload nightly wheel and dist build workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/workflows/build-distributions.yml
+++ b/.github/workflows/build-distributions.yml
@@ -1,0 +1,32 @@
+name: Build sdist and wheel
+
+on:
+  # Run on demand with workflow dispatch
+  workflow_dispatch:
+  # Use from other workflows
+  workflow_call:
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build sdist and wheel
+        run: pipx run build
+
+      - name: Check metadata
+        run: pipx run twine check --strict dist/*
+
+      - name: List contents of sdist
+        run: python -m tarfile --list dist/uproot-*.tar.gz
+
+      - name: List contents of wheel
+        run: python -m zipfile --list dist/uproot-*.whl
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: distribution-artifact
+          path: dist/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,33 +6,30 @@ on:
     types:
       - published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  dist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
-      - name: Build wheel and SDist
-        run: pipx run build
-
-      - name: Check metadata
-        run: pipx run twine check dist/*
-
-      - uses: actions/upload-artifact@v4
-        with:
-          path: dist/*
-
+  build_dist:
+    name: Build and upload sdist and wheel
+    if: github.repository_owner == 'scikit-hep'
+    uses: ./.github/workflows/build-distributions.yml
 
   publish:
-    needs: [dist]
+    needs: [build_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: distribution-artifact
           path: dist
+
+      - name: List distributions to be deployed
+        run: ls -lha dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/upload-nightly-wheels.yml
+++ b/.github/workflows/upload-nightly-wheels.yml
@@ -1,0 +1,39 @@
+name: Upload nightly wheels to Anaconda Cloud
+
+on:
+  # Run daily at 1:23 UTC
+  schedule:
+    - cron: 23 1 * * *
+  # Run on demand with workflow dispatch
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build_wheel:
+    name: Build and upload wheel
+    if: github.repository_owner == 'scikit-hep'
+    uses: ./.github/workflows/build-distributions.yml
+
+  upload_nightly_wheels:
+    name: Upload nightly wheels to Anaconda Cloud
+    needs: [build_wheel]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: distribution-artifact
+          path: dist
+
+      - name: List wheel to be deployed
+        run: ls -lha dist/*.whl
+
+      - name: Upload wheel to Anaconda Cloud as nightly
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}


### PR DESCRIPTION
* Add build distributions workflow that is reusable across other workflows.
* Add upload nightly wheels workflow to upload nightly to Anaconda cloud.
* Use the build distributions workflow in the deploy workflow.
* Group dependabot updates to reduce the number of PRs.
   - c.f. sp-repo-review GH212: Require GHA update grouping
     https://learn.scientific-python.org/development/guides/gha-basic/#GH212

By using the

```yaml
jobs:

  build_wheel:
    ...
    if: github.repository_owner == 'scikit-hep'
    uses: ./.github/workflows/build-distributions.yml
```

syntax the "Build sdist and wheel" workflow becomes a step in the following workflows (first box) run as test jobs on another branch where the deploy steps are commented out:

* Upload nightly wheels to Anaconda Cloud
![image](https://github.com/scikit-hep/uproot5/assets/5142394/551b2f16-9a2a-401f-88e9-3f8a01f4ec81)

* Deploy to PyPI
![image](https://github.com/scikit-hep/uproot5/assets/5142394/ffdb9fc1-e7d4-41c6-86f9-59e1aa1eb514)
