### PR TITLE
feat: implement TGraph-writing

### DIFF
--- a/src/uproot/models/TGraph.py
+++ b/src/uproot/models/TGraph.py
@@ -338,16 +338,18 @@ class Model_TGraph_v4(uproot.behaviors.TGraph.TGraph, uproot.model.VersionedMode
         where = len(out)
         for x in self._bases:
             x._serialize(out, True, name, tobject_flags)
-        out.extend([
-            struct.pack(">i", self._members["fNpoints"]),
-            b"\x01",
-            self._members["fX"].astype(">f8").tobytes(),
-            b"\x01",
-            self._members["fY"].astype(">f8").tobytes(),
-            b"@\x00\x00\x1f\xff\xff\xff\xffTList\x00@\x00\x00\x11\x00\x05\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-            struct.pack(">d", self._members["fMinimum"]),
-            struct.pack(">d", self._members["fMaximum"]),
-        ])
+        out.extend(
+            [
+                struct.pack(">i", self._members["fNpoints"]),
+                b"\x01",
+                self._members["fX"].astype(">f8").tobytes(),
+                b"\x01",
+                self._members["fY"].astype(">f8").tobytes(),
+                b"@\x00\x00\x1f\xff\xff\xff\xffTList\x00@\x00\x00\x11\x00\x05\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+                struct.pack(">d", self._members["fMinimum"]),
+                struct.pack(">d", self._members["fMaximum"]),
+            ]
+        )
         if header:
             num_bytes = sum(len(x) for x in out[where:])
             version = 4

--- a/src/uproot/models/TGraph.py
+++ b/src/uproot/models/TGraph.py
@@ -338,7 +338,16 @@ class Model_TGraph_v4(uproot.behaviors.TGraph.TGraph, uproot.model.VersionedMode
         where = len(out)
         for x in self._bases:
             x._serialize(out, True, name, tobject_flags)
-        raise NotImplementedError("FIXME")
+        out.extend([
+            struct.pack(">i", self._members["fNpoints"]),
+            b"\x01",
+            self._members["fX"].astype(">f8").tobytes(),
+            b"\x01",
+            self._members["fY"].astype(">f8").tobytes(),
+            b"@\x00\x00\x1f\xff\xff\xff\xffTList\x00@\x00\x00\x11\x00\x05\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+            struct.pack(">d", self._members["fMinimum"]),
+            struct.pack(">d", self._members["fMaximum"]),
+        ])
         if header:
             num_bytes = sum(len(x) for x in out[where:])
             version = 4


### PR DESCRIPTION
This is a draft. It needs TGraphErrors, TGraphAsymmErrors, tests of writing to actual files and reading them back with ROOT, and maybe some high-level interface so that we can

```python
output_file["name"] = XYZ
```

for a Python object XYZ that would be interpreted as a TGraph (or TGraphErrors, or TGraphAsymmErrors). What should that XYZ be? Not raw NumPy arrays, since a tuple of NumPy arrays is already interpreted as a histogram. Does it need to be some kind of `uproot.make_TGraph` function? It would be nice to have something more Pythonic.

Should any Pandas DataFrame with columns named `x` and `y` be interpreted as a TGraph? A Pandas DataFrame would supply a title.

Thoughts, @grzanka? 