### PR TITLE
chore: loosen cramjam version constraint to >=2.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
   "awkward>=2.4.6",
-  "cramjam>=2.8.1",
+  "cramjam>=2.5.0",
   "importlib-metadata;python_version<\"3.8\"",
   "numpy",
   "fsspec",

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -179,9 +179,9 @@ class _DecompressLZMA:
             getattr(cramjam, "experimental", None), "lzma", None
         )
         if lzma is None:
-            raise RuntimeError(
-                "lzma not found in the cramjam package! (requires cramjam >= 2.8.1)"
-            )
+            import lzma
+
+            return lzma.decompress(data)
         if uncompressed_bytes is None:
             raise ValueError(
                 "lzma decompression requires the number of uncompressed bytes"
@@ -226,9 +226,7 @@ class LZMA(Compression, _DecompressLZMA):
             getattr(cramjam, "experimental", None), "lzma", None
         )
         if lzma is None:
-            raise RuntimeError(
-                "lzma not found in the cramjam package! (requires cramjam >= 2.8.1)"
-            )
+            import lzma
         return lzma.compress(data, preset=self._level)
 
 


### PR DESCRIPTION
The latest version of cramjam in conda-forge is 2.8.0. With this, the Uproot 5.3.1 release will be able to go into conda-forge without waiting for cramjam to update.

This adds a fallback instead of an error if cramjam doesn't have an LZMA module, and then the minimum version of cramjam can be loosened to 2.5.0. A fallback for something as invisible as compression is a little dangerous because if the Python standard library LZMA behaves a little differently from the cramjam LZMA, we'd have to carefully check that in any debugging.

However, compression algorithms almost always work—I think it's highly unlikely that we'll need to debug it at all—and the corner of space between cramjam 2.8.0 and 2.8.1 is tiny. (If someone actually gets something in the 2.5.0‒2.8.0 range, it's because they're not updating everything with their package manager, which is also a bit weird.) So, I'm willing to take that risk for the reward of not having to monitor cramjam's conda updates.