### PR TITLE
test: allow aiohttp to leak HTTPS connections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,8 @@ profile = "black"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 filterwarnings = [
   "error",
-  "default:module 'sre_.*' is deprecated:DeprecationWarning"
+  "default:module 'sre_.*' is deprecated:DeprecationWarning",
+  "ignore:unclosed transport <asyncio.sslproto._SSLProtocolTransport"  # https://github.com/aio-libs/aiohttp/issues/1115
 ]
 log_cli_level = "info"
 markers = [


### PR DESCRIPTION
Because of aio-libs/aiohttp#1115, the aiohttp library can let an HTTPS connection dangle for one event longer than pytest or Python allows, triggering an "unclosed transport" ResourceError.

We _do_ want to be sticklers for open file handles in our tests, so the `filterwarnings` entry for this was made very narrow, to only include this case.

@lobis, did you know about this? Is the alternative of having `FSSpecSource` do

```python
await asyncio.sleep(0)
```

when it goes out of a context manager viable?