### PR TITLE
feat: Record source performance counters in uproot.dask report

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -974,7 +974,9 @@ class UprootReadMixin:
     def return_report(self) -> bool:
         return bool(self.allow_read_errors_with_report)
 
-    def read_tree(self, tree: HasBranches, start: int, stop: int) -> tuple[AwkArray, SourcePerformanceCounters]:
+    def read_tree(
+        self, tree: HasBranches, start: int, stop: int
+    ) -> tuple[AwkArray, SourcePerformanceCounters]:
         assert start <= stop
 
         from awkward._nplikes.numpy import Numpy
@@ -1202,7 +1204,9 @@ class _UprootRead(UprootReadMixin):
         if self.return_report:
             call_time = time.time_ns()
             try:
-                (result, counters), duration = with_duration(self._call_impl)(i, start, stop)
+                (result, counters), duration = with_duration(self._call_impl)(
+                    i, start, stop
+                )
                 return (
                     result,
                     _report_success(

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1671,9 +1671,8 @@ class HasBranches(Mapping):
 
         Returns: uproot.source.chunk.Source or None
         """
-        if isinstance(self, uproot.model.Model):
-            if isinstance(self._file, uproot.reading.ReadOnlyFile):
-                return self._file.source
+        if isinstance(self, uproot.model.Model) and isinstance(self._file, uproot.reading.ReadOnlyFile):
+            return self._file.source
         return None
 
 

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1671,7 +1671,9 @@ class HasBranches(Mapping):
 
         Returns: uproot.source.chunk.Source or None
         """
-        if isinstance(self, uproot.model.Model) and isinstance(self._file, uproot.reading.ReadOnlyFile):
+        if isinstance(self, uproot.model.Model) and isinstance(
+            self._file, uproot.reading.ReadOnlyFile
+        ):
             return self._file.source
         return None
 

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -23,6 +23,7 @@ import numpy
 import uproot
 import uproot.interpretation.grouped
 import uproot.language.python
+import uproot.source.chunk
 from uproot._util import no_filter
 
 np_uint8 = numpy.dtype("u1")
@@ -1663,6 +1664,17 @@ class HasBranches(Mapping):
 
     def __len__(self):
         return len(self.branches)
+
+    @property
+    def source(self) -> uproot.source.chunk.Source | None:
+        """Returns the associated source of data for this container, if it exists
+
+        Returns: uproot.source.chunk.Source or None
+        """
+        if isinstance(self, uproot.model.Model):
+            if isinstance(self._file, uproot.reading.ReadOnlyFile):
+                return self._file.source
+        return None
 
 
 _branch_clean_name = re.compile(r"(.*\.)*([^\.\[\]]*)(\[.*\])*")

--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -12,6 +12,7 @@ Also defines abstract classes for :doc:`uproot.source.chunk.Resource` and
 
 from __future__ import annotations
 
+import dataclasses
 import numbers
 import queue
 
@@ -39,6 +40,17 @@ class Resource:
         A path to the file (or URL).
         """
         return self._file_path
+
+
+@dataclasses.dataclass
+class SourcePerformanceCounters:
+    """Container for performance counters"""
+    num_requested_bytes: int
+    num_requests: int
+    num_requested_chunks: int
+
+    def asdict(self) -> dict[str, int]:
+        return dataclasses.asdict(self)
 
 
 class Source:
@@ -137,6 +149,14 @@ class Source:
         The number of bytes that have been requested (performance counter).
         """
         return self._num_requested_bytes
+
+    @property
+    def performance_counters(self) -> SourcePerformanceCounters:
+        return SourcePerformanceCounters(
+            self._num_requested_bytes,
+            self._num_requests,
+            self._num_requested_chunks,
+        )
 
     def close(self):
         """

--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -45,6 +45,7 @@ class Resource:
 @dataclasses.dataclass
 class SourcePerformanceCounters:
     """Container for performance counters"""
+
     num_requested_bytes: int
     num_requests: int
     num_requested_chunks: int


### PR DESCRIPTION
Report type is now
```
type: 7 * {
    call_time: ?unknown,
    duration: float64,
    performance_counters: {
        num_requested_bytes: int64,
        num_requests: int64,
        num_requested_chunks: int64
    },
    args: var * string,
    kwargs: var * unknown,
    exception: ?unknown,
    message: ?unknown,
    fqdn: ?unknown,
    hostname: ?unknown
}
```