### PR TITLE
feat: Add extras for optional remote access dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ dev = [
   "pandas",
   "awkward-pandas"
 ]
+http = []
+s3 = ["minio"]
 test = [
   "isal",
   "xxhash",
@@ -77,6 +79,7 @@ test = [
   "scikit-hep-testdata",
   "rangehttpserver"
 ]
+xrootd = ["fsspec-xrootd"]
 
 [project.urls]
 Download = "https://github.com/scikit-hep/uproot5/releases"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
   "awkward-pandas"
 ]
 http = []
-s3 = ["minio"]
+s3 = ["aiobotocore"]
 test = [
   "isal",
   "xxhash",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,8 @@ dev = [
   "pandas",
   "awkward-pandas"
 ]
-http = []
-s3 = ["aiobotocore"]
+http = ["aiohttp"]
+s3 = ["s3fs"]
 test = [
   "isal",
   "xxhash",


### PR DESCRIPTION
This makes it possible to install/depend on `uproot[xrootd,http,s3]` to decouple the user facing feature from the implementation details in uproot.

Closes #1153 