### PR TITLE
feat: special case for reading std::string from a TDirectory

### DIFF
--- a/src/uproot/models/TString.py
+++ b/src/uproot/models/TString.py
@@ -104,3 +104,4 @@ in file {self.file.file_path}"""
 
 
 uproot.classes["TString"] = Model_TString
+uproot.classes["string"] = Model_TString

--- a/src/uproot/models/TString.py
+++ b/src/uproot/models/TString.py
@@ -104,4 +104,3 @@ in file {self.file.file_path}"""
 
 
 uproot.classes["TString"] = Model_TString
-uproot.classes["string"] = Model_TString

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -2473,12 +2473,8 @@ class ReadOnlyKey:
         else:
             chunk, cursor = self.get_uncompressed_chunk_cursor()
             start_cursor = cursor.copy()
-            context = {"breadcrumbs": (), "TKey": self}
-
-            if self._fClassName == "string":
-                return cursor.string(chunk, context)
-
             cls = self._file.class_named(self._fClassName)
+            context = {"breadcrumbs": (), "TKey": self}
 
             try:
                 out = cls.read(chunk, cursor, context, self._file, selffile, parent)

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -2473,8 +2473,12 @@ class ReadOnlyKey:
         else:
             chunk, cursor = self.get_uncompressed_chunk_cursor()
             start_cursor = cursor.copy()
-            cls = self._file.class_named(self._fClassName)
             context = {"breadcrumbs": (), "TKey": self}
+
+            if self._fClassName == "string":
+                return cursor.string(chunk, context)
+
+            cls = self._file.class_named(self._fClassName)
 
             try:
                 out = cls.read(chunk, cursor, context, self._file, selffile, parent)

--- a/tests/test_0692_fsspec_reading.py
+++ b/tests/test_0692_fsspec_reading.py
@@ -395,6 +395,7 @@ def test_issue_1035(handler):
             assert len(data) == 40
 
 
+@pytest.mark.skip(reason="This test occasionally takes too long: GitHub kills it.")
 @pytest.mark.network
 @pytest.mark.xrootd
 @pytest.mark.parametrize(

--- a/tests/test_1160_std_string_in_TDirectory.py
+++ b/tests/test_1160_std_string_in_TDirectory.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import json
+
+import skhep_testdata
+
+import uproot
+
+
+def test():
+    with uproot.open(skhep_testdata.data_path("string-example.root")) as file:
+        assert json.loads(file["FileSummaryRecord"]) == {
+            "LumiCounter.eventsByRun": {
+                "counts": {},
+                "empty": True,
+                "type": "LumiEventCounter",
+            },
+            "guid": "5FE9437E-D958-11EE-AB88-3CECEF1070AC",
+        }


### PR DESCRIPTION
~~Fixes #1159.~~ (That's a discussion.)

What do you think, @chrisburr? Is `std::string` truly exceptional, such that a special case is warranted, or is this the tip of an iceberg that should be handled in a more systematic way?

(If it's to be handled in a systematic way, I don't know when or by whom.)