### PR TITLE
fix: add new Executor arguments to ImplementsFormMappingInfo protocol

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -5,6 +5,7 @@ import math
 import socket
 import time
 from collections.abc import Callable, Iterable, Mapping
+from concurrent.futures import Executor
 
 from uproot.source.chunk import SourcePerformanceCounters
 
@@ -835,6 +836,8 @@ class ImplementsFormMappingInfo(Protocol):
         keys: frozenset[str],
         start: int,
         stop: int,
+        decompression_executor: Executor,
+        interpretation_executor: Executor,
         options: Any,
     ) -> Mapping[str, AwkArray]: ...
 


### PR DESCRIPTION
This is a follow-up to https://github.com/scikit-hep/uproot5/pull/1120#issuecomment-1982305217, which added arguments to some internal classes in Dask, but didn't update the protocols that described those internal classes.