### PR TITLE
fix: change expected xz/lzma module location on cramjam

### DIFF
--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -237,7 +237,7 @@ class LZMA(Compression, _DecompressLZMA):
 
     def compress(self, data: bytes) -> bytes:
         cramjam = uproot.extras.cramjam()
-        lzma = getattr(cramjam, "lzma", None) or getattr(
+        lzma = getattr(cramjam, "xz", None) or getattr(
             getattr(cramjam, "experimental", None), "lzma", None
         )
         if lzma is None:

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -190,7 +190,7 @@ class _DecompressLZMA:
 
     def decompress(self, data: bytes, uncompressed_bytes=None) -> bytes:
         cramjam = uproot.extras.cramjam()
-        lzma = getattr(cramjam, "lzma", None) or getattr(
+        lzma = getattr(cramjam, "xz", None) or getattr(
             getattr(cramjam, "experimental", None), "lzma", None
         )
         if lzma is None:


### PR DESCRIPTION
I've [pre-released v2.8.3-rc1](https://pypi.org/project/cramjam/2.8.3rc1/#files), which has the XZ/LZMA stuff now as `cramjam.xz`. 
Would rather not break things for you, so until releasing `2.8.3`, I think this change, or something like it, should happen here or >= 2.8.3 will look like it doesn't have xz/lzma support.


xref https://github.com/milesgranger/cramjam/issues/126