### PR TITLE
test: is the leading slash breaking Windows tests?

### DIFF
--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -49,7 +49,7 @@ def test_fsspec_writing_local(tmp_path, scheme):
 )
 @pytest.mark.parametrize(
     "slash_prefix",
-    ["", ("\\" if is_windows else "/")],
+    [""] if is_windows else ["", "/"],
 )
 def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
     uri = scheme + slash_prefix + os.path.join(tmp_path, "some", "path", filename)

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -46,7 +46,7 @@ def test_fsspec_writing_local(tmp_path, scheme):
 )
 @pytest.mark.parametrize(
     "slash_prefix",
-    ["", "/"],
+    [""],
 )
 def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
     uri = scheme + slash_prefix + os.path.join(tmp_path, "some", "path", filename)

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -4,10 +4,13 @@ import pytest
 import uproot
 import uproot.source.fsspec
 
+import sys
 import os
 import pathlib
 import fsspec
 import numpy as np
+
+is_windows = sys.platform.startswith("win")
 
 
 def test_fsspec_writing_no_integration(tmp_path):
@@ -46,7 +49,7 @@ def test_fsspec_writing_local(tmp_path, scheme):
 )
 @pytest.mark.parametrize(
     "slash_prefix",
-    [""],
+    ["", ("\\" if is_windows else "/")],
 )
 def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
     uri = scheme + slash_prefix + os.path.join(tmp_path, "some", "path", filename)


### PR DESCRIPTION
I'll try removing the slash, putting it back in, and if that's it, I'll exclude it on Windows.

It's making paths like

```
/C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\test_fsspec_writing_local_uri_24\some\path\my%E2%80%92file.root
```

which at some point become `D:/C:`. Right about here:

```
C:\Users\runneradmin\miniconda3\envs\test\lib\site-packages\uproot\sink\file.py:53: in __init__
    self._truncate_file(urlpath_or_file_like, **storage_options)
        self       = <uproot.sink.file.FileSink object at 0x00000295EDA4AFD0>
        storage_options = {}
        urlpath_or_file_like = '/C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\test_fsspec_writing_local_uri_24\\some\\path\\my%E2%80%92file.root'
C:\Users\runneradmin\miniconda3\envs\test\lib\site-packages\uproot\sink\file.py:80: in _truncate_file
    fs.mkdirs(parent_directory, exist_ok=True)
        cls        = <class 'uproot.sink.file.FileSink'>
        fs         = <fsspec.implementations.local.LocalFileSystem object at 0x00000295DEE2BC70>
        local_path = 'D:/C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_fsspec_writing_local_uri_24/some/path/my%E2%80%92file.root'
        parent_directory = 'D:/C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_fsspec_writing_local_uri_24/some/path'
        storage_options = {}
        urlpath    = '/C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\test_fsspec_writing_local_uri_24\\some\\path\\my%E2%80%92file.root'
```

The `local_path` returned by

https://github.com/scikit-hep/uproot5/blob/2d34ce4d7e30d16df19a0e3dfce447978577a0f9/src/uproot/sink/file.py#L78

has `D:/C:`, and apparently that didn't happen before. Was there a recent change, @martindurant? (It looks like it might have been wrong before, correct now, and this Uproot test has to catch up.)

