### PR TITLE
fix: update for NumPy 2.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,3 +92,27 @@ jobs:
       - name: Run pytest
         run: |
           python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|ssl|timeout|expired|connection|socket"
+
+  numpy2-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ['3.11']
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Pip install the package
+        run: python -m pip install 'numpy>2.0.0b1' .[test]
+
+      - name: Run pytest
+        run: |
+          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|ssl|timeout|expired|connection|socket"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -111,7 +111,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Pip install the package
-        run: python -m pip install 'numpy>2.0.0b1' .[test]
+        run: python -m pip install 'numpy>=2.0.0b1' .[test]
 
       - name: Run pytest
         run: |

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -80,7 +80,9 @@ def ensure_numpy(array, types=(numpy.bool_, numpy.integer, numpy.floating)):
 
     awkward = uproot.extras.awkward()
     with warnings.catch_warnings():
-        warnings.simplefilter("error", numpy.VisibleDeprecationWarning)
+        warnings.simplefilter(
+            "error", getattr(numpy, "exceptions", numpy).VisibleDeprecationWarning
+        )
         if isinstance(array, awkward.contents.Content):
             out = awkward.to_numpy(array)
         else:

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -106,7 +106,7 @@ class Numerical(uproot.interpretation.Interpretation):
 
                 start = stop
 
-        output = output.newbyteorder("=")
+        output = output.view(output.dtype.newbyteorder("="))
         self.hook_before_library_finalize(
             basket_arrays=basket_arrays,
             entry_start=entry_start,

--- a/src/uproot/source/cursor.py
+++ b/src/uproot/source/cursor.py
@@ -386,7 +386,7 @@ class Cursor:
             length_data = chunk.get(start, stop, self, context)
             length = numpy.frombuffer(length_data, dtype=self._u1).view(self._i4)[0]
         start = stop
-        stop = start + length
+        stop = start + int(length)
         if move:
             self._index = stop
         return uproot._util.tobytes(chunk.get(start, stop, self, context))

--- a/src/uproot/streamers.py
+++ b/src/uproot/streamers.py
@@ -1128,7 +1128,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
             uproot.const.kULong,
             uproot.const.kLong,
         ):
-            self._bases[0]._members["fSize"] = numpy.dtype(numpy.compat.long).itemsize
+            self._bases[0]._members["fSize"] = numpy.dtype(numpy.int64).itemsize
 
         elif self._bases[0]._members["fType"] in (
             uproot.const.kULong64,

--- a/tests/test_0692_fsspec_reading.py
+++ b/tests/test_0692_fsspec_reading.py
@@ -1,12 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-import pytest
-import uproot
-import uproot.source.fsspec
-import uproot.source.file
-import uproot.source.xrootd
-import uproot.source.s3
-
 from typing import BinaryIO
 import skhep_testdata
 import queue
@@ -14,6 +7,14 @@ import fsspec
 import requests
 import os
 import sys
+
+import pytest
+
+import uproot
+import uproot.source.fsspec
+import uproot.source.file
+import uproot.source.xrootd
+import uproot.source.s3
 
 is_windows = sys.platform.startswith("win")
 
@@ -243,7 +244,7 @@ def test_fsspec_chunks(http_server):
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
 
-        chunk_data_sum = {sum(chunk.raw_data) for chunk in chunks}
+        chunk_data_sum = {sum(map(int, chunk.raw_data)) for chunk in chunks}
         assert chunk_data_sum == {3967, 413, 10985}, "Chunk data does not match"
 
 

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -51,12 +51,19 @@ def test_fsspec_writing_local(tmp_path, scheme):
     "slash_prefix",
     [""] if is_windows else ["", "/"],
 )
-def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename):
-    uri = scheme + slash_prefix + os.path.join(tmp_path, "some", "path", filename)
-    with uproot.create(uri) as f:
-        f["tree"] = {"x": np.array([1, 2, 3])}
-    with uproot.open(uri) as f:
-        assert f["tree"]["x"].array().tolist() == [1, 2, 3]
+def test_fsspec_writing_local_uri(tmp_path, scheme, slash_prefix, filename, request):
+    os.chdir(tmp_path)
+
+    try:
+        uri = scheme + slash_prefix + os.path.join(tmp_path, "some", "path", filename)
+
+        with uproot.create(uri) as f:
+            f["tree"] = {"x": np.array([1, 2, 3])}
+        with uproot.open(uri) as f:
+            assert f["tree"]["x"].array().tolist() == [1, 2, 3]
+
+    finally:
+        os.chdir(request.config.invocation_params.dir)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_1070_pandas_dataframe_building_performance_fix.py
+++ b/tests/test_1070_pandas_dataframe_building_performance_fix.py
@@ -1,8 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
 
 import pytest
-import uproot
 import skhep_testdata
+
+import uproot
+
+pytest.importorskip("pandas")
 
 
 def test_pandas_performance_many_branches(tmp_path):

--- a/tests/test_1120_check_decompression_executor_pass_for_dask.py
+++ b/tests/test_1120_check_decompression_executor_pass_for_dask.py
@@ -1,8 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
 
 import pytest
-import uproot
 import skhep_testdata
+
+import uproot
+
+pytest.importorskip("pandas")
 
 
 def test_decompression_executor_for_dask():

--- a/tests/test_1189_dask_failing_on_duplicate_keys.py
+++ b/tests/test_1189_dask_failing_on_duplicate_keys.py
@@ -1,8 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
 
 import pytest
-import uproot
 import skhep_testdata
+
+import uproot
+
+pytest.importorskip("pandas")
 
 
 def test_dask_duplicated_keys():


### PR DESCRIPTION
Following on scikit-hep/awkward#3064, Uproot needs some fixes for NumPy 2.0 as well.

This fixes Uproot and adds new tests for NumPy 2.0 on all 3 platforms.