### PR TITLE
test: desable 'deflate' tests on MacOS; it fails on import

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -13,6 +13,7 @@ import itertools
 import numbers
 import os
 import re
+import sys
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -26,6 +27,8 @@ import packaging.version
 import uproot.source.chunk
 import uproot.source.fsspec
 import uproot.source.object
+
+macos = sys.platform == "darwin"
 
 
 def tobytes(array):

--- a/tests/test_0008_start_interpretation.py
+++ b/tests/test_0008_start_interpretation.py
@@ -49,7 +49,7 @@ def test_file_header(use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_file_header(use_deflate):
-    if use_deflate:
+    if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
     uproot.ZLIB.use_deflate = use_deflate
     filename = skhep_testdata.data_path("uproot-Zmumu.root")

--- a/tests/test_0008_start_interpretation.py
+++ b/tests/test_0008_start_interpretation.py
@@ -49,6 +49,7 @@ def test_file_header(use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_file_header(use_deflate):
+    # FIXME: https://github.com/dcwatson/deflate/issues/42
     if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
     uproot.ZLIB.use_deflate = use_deflate

--- a/tests/test_0416_writing_compressed_data.py
+++ b/tests/test_0416_writing_compressed_data.py
@@ -34,6 +34,7 @@ def test_ZLIB(use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_deflate(use_deflate):
+    # FIXME: https://github.com/dcwatson/deflate/issues/42
     if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
@@ -133,6 +134,7 @@ def test_histogram_ZLIB(tmp_path, use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_histogram_deflate(tmp_path, use_deflate):
+    # FIXME: https://github.com/dcwatson/deflate/issues/42
     if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
@@ -591,6 +593,7 @@ def test_multicompression_5(tmp_path, use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_1_deflate(tmp_path, use_deflate):
+    # FIXME: https://github.com/dcwatson/deflate/issues/42
     if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
@@ -625,6 +628,7 @@ def test_multicompression_1_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_2_deflate(tmp_path, use_deflate):
+    # FIXME: https://github.com/dcwatson/deflate/issues/42
     if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
@@ -658,6 +662,7 @@ def test_multicompression_2_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_3_deflate(tmp_path, use_deflate):
+    # FIXME: https://github.com/dcwatson/deflate/issues/42
     if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
@@ -692,6 +697,7 @@ def test_multicompression_3_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_4_deflate(tmp_path, use_deflate):
+    # FIXME: https://github.com/dcwatson/deflate/issues/42
     if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
@@ -724,6 +730,7 @@ def test_multicompression_4_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_5_deflate(tmp_path, use_deflate):
+    # FIXME: https://github.com/dcwatson/deflate/issues/42
     if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"

--- a/tests/test_0416_writing_compressed_data.py
+++ b/tests/test_0416_writing_compressed_data.py
@@ -34,7 +34,7 @@ def test_ZLIB(use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_deflate(use_deflate):
-    if use_deflate:
+    if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -133,7 +133,7 @@ def test_histogram_ZLIB(tmp_path, use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_histogram_deflate(tmp_path, use_deflate):
-    if use_deflate:
+    if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -591,7 +591,7 @@ def test_multicompression_5(tmp_path, use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_1_deflate(tmp_path, use_deflate):
-    if use_deflate:
+    if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -625,7 +625,7 @@ def test_multicompression_1_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_2_deflate(tmp_path, use_deflate):
-    if use_deflate:
+    if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -658,7 +658,7 @@ def test_multicompression_2_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_3_deflate(tmp_path, use_deflate):
-    if use_deflate:
+    if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -692,7 +692,7 @@ def test_multicompression_3_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_4_deflate(tmp_path, use_deflate):
-    if use_deflate:
+    if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -724,7 +724,7 @@ def test_multicompression_4_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_5_deflate(tmp_path, use_deflate):
-    if use_deflate:
+    if use_deflate and not uproot._util.macos:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:


### PR DESCRIPTION
Reported at https://github.com/dcwatson/deflate/issues/42.

Here's a build in `main` that was failing because of `deflate`

https://github.com/scikit-hep/uproot5/actions/runs/8959087137

This started sometime between April 25 and April 29, 2024.