### PR TITLE
test: reinstate 'deflate', now that it works on MacOS

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -13,7 +13,6 @@ import itertools
 import numbers
 import os
 import re
-import sys
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -27,8 +26,6 @@ import packaging.version
 import uproot.source.chunk
 import uproot.source.fsspec
 import uproot.source.object
-
-macos = sys.platform == "darwin"
 
 
 def tobytes(array):

--- a/tests/test_0008_start_interpretation.py
+++ b/tests/test_0008_start_interpretation.py
@@ -49,8 +49,7 @@ def test_file_header(use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_file_header(use_deflate):
-    # FIXME: https://github.com/dcwatson/deflate/issues/42
-    if use_deflate and not uproot._util.macos:
+    if use_deflate:
         pytest.importorskip("deflate")
     uproot.ZLIB.use_deflate = use_deflate
     filename = skhep_testdata.data_path("uproot-Zmumu.root")

--- a/tests/test_0416_writing_compressed_data.py
+++ b/tests/test_0416_writing_compressed_data.py
@@ -34,8 +34,7 @@ def test_ZLIB(use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_deflate(use_deflate):
-    # FIXME: https://github.com/dcwatson/deflate/issues/42
-    if use_deflate and not uproot._util.macos:
+    if use_deflate:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -134,8 +133,7 @@ def test_histogram_ZLIB(tmp_path, use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_histogram_deflate(tmp_path, use_deflate):
-    # FIXME: https://github.com/dcwatson/deflate/issues/42
-    if use_deflate and not uproot._util.macos:
+    if use_deflate:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -593,8 +591,7 @@ def test_multicompression_5(tmp_path, use_isal):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_1_deflate(tmp_path, use_deflate):
-    # FIXME: https://github.com/dcwatson/deflate/issues/42
-    if use_deflate and not uproot._util.macos:
+    if use_deflate:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -628,8 +625,7 @@ def test_multicompression_1_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_2_deflate(tmp_path, use_deflate):
-    # FIXME: https://github.com/dcwatson/deflate/issues/42
-    if use_deflate and not uproot._util.macos:
+    if use_deflate:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -662,8 +658,7 @@ def test_multicompression_2_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_3_deflate(tmp_path, use_deflate):
-    # FIXME: https://github.com/dcwatson/deflate/issues/42
-    if use_deflate and not uproot._util.macos:
+    if use_deflate:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -697,8 +692,7 @@ def test_multicompression_3_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_4_deflate(tmp_path, use_deflate):
-    # FIXME: https://github.com/dcwatson/deflate/issues/42
-    if use_deflate and not uproot._util.macos:
+    if use_deflate:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:
@@ -730,8 +724,7 @@ def test_multicompression_4_deflate(tmp_path, use_deflate):
 
 @pytest.mark.parametrize("use_deflate", [False, True])
 def test_multicompression_5_deflate(tmp_path, use_deflate):
-    # FIXME: https://github.com/dcwatson/deflate/issues/42
-    if use_deflate and not uproot._util.macos:
+    if use_deflate:
         pytest.importorskip("deflate")
         uproot.ZLIB.library = "deflate"
     else:


### PR DESCRIPTION
Fixed by dcwatson/deflate#42 in deflate 0.6.1 (and the broken 0.6.0 has been yanked).

I tested it locally on my (M2) Mac; I expect it to breeze through the test suite, so I'll just enable auto-merge.

Thanks for the quick fix, @dcwatson!