### PR TITLE
fix: bug in PR #1189's 'ignore_duplicates' implementation

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1424,7 +1424,7 @@ class HasBranches(Mapping):
                     if filter_name is no_filter or _filter_name_deep(
                         filter_name, self, v
                     ):
-                        if ignore_duplicates and branch.name in keys_set:
+                        if ignore_duplicates and k2 in keys_set:
                             pass
                         else:
                             keys_set.add(k2)


### PR DESCRIPTION
The duplicate-checking should be checking against the full path, with slashes, not the `branch.name`. This passes the same tests as before (the Delphes file had no TBranches nested within TBranches), but it should fix CoffeaTeam/coffea#1080.