### PR TITLE
fix: don't let uproot.update mess up the TFile fVersion

### DIFF
--- a/src/uproot/writing/_cascade.py
+++ b/src/uproot/writing/_cascade.py
@@ -2159,8 +2159,10 @@ class FileHeader(CascadeLeaf):
                 uuid_bytes,
             ) = uproot.reading._file_header_fields_big.unpack(raw_bytes)
             assert units == 8
+            outversion = version - 1000000
         else:
             assert units == 4
+            outversion = version
 
         assert begin >= uproot.reading._file_header_fields_small.size
         assert free_location >= 0
@@ -2183,7 +2185,7 @@ class FileHeader(CascadeLeaf):
             info_num_bytes,
             uuid.UUID(bytes=uuid_bytes),
         )
-        out._version = version - 1000000
+        out._version = outversion
         out._begin = begin
         return out
 

--- a/tests/test_1212_dont_let_update_mess_up_file_version.py
+++ b/tests/test_1212_dont_let_update_mess_up_file_version.py
@@ -1,0 +1,18 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import os
+
+import uproot
+
+
+def test(tmp_path):
+    filename = os.path.join(tmp_path, "whatever.root")
+
+    with uproot.recreate(filename) as file:
+        file["one"] = "one"
+
+    with uproot.update(filename) as file:
+        file["two"] = "two"
+
+    with uproot.open(filename) as file:
+        assert file.file.fVersion == uproot.writing._cascade.FileHeader.class_version


### PR DESCRIPTION
When `uproot.update` was reading in a file, it used to unconditionally subtract 1000000 from the `TFile::fVersion` that it read:

https://github.com/scikit-hep/uproot5/blob/e9440995e0e6649bf8ea8634185d758602179a55/src/uproot/writing/_cascade.py#L2175-L2188

The offset of 1000000 is how ROOT distinguishes between files with (some) 64-bit seek positions and files that are all 32-bit. Uproot's `FileHeader.version` holds the real version number, without the offset, and puts the offset back in if needed:

https://github.com/scikit-hep/uproot5/blob/e9440995e0e6649bf8ea8634185d758602179a55/src/uproot/writing/_cascade.py#L2093-L2100

But it was _unconditionally_ subtracting 1000000 from the files it read, even if the file was fully 32-bit, as most are (because it only starts to matter for files bigger than 4 GB). So `uproot.update` was messing up a metadata field of most of the files it touched. (I can see how this mistake was made: I must have thought the line that subtracts 1000000 was still inside the `if version >= 1000000:` block, just above.)

Uproot doesn't do anything with the `TFile::fVersion`, other than use it as a 64-bit indicator, and I suppose we haven't been updating large enough files for this to be noticed. However, the version number that it wrote was nonsensical, a number near -937600.

ROOT doesn't do much with these numbers, either, but it does more than Uproot. This bug was discovered because ROOT was shifting into a mode in which it was handling files as though they were older than ROOT 3. (The last version of ROOT 2.x was in [September of the year 2000](https://web.archive.org/web/20020526135430/http://root.cern.ch/).) That fallback code did not work for TLeafL and TLeafO (among the TLeaf subclasses that I tested; TLeafD, TLeafI, and TLeafS were fine), and that makes sense because TLeafL and TLeafO were added [in 2003](https://github.com/root-project/root/commit/57b449dd4de933b67af1a7ba8986225cebdaea56) and [in 2005](https://github.com/root-project/root/commit/f8504accfb58185b79ef8fa874691eb78ad8097d), respectively (the others are older, and that's why they're fine).

------------------

For @zbilodea: files made with this correction can be read from ROOT with no warnings.

```python
>>> import uproot
>>> f = uproot.recreate("one-tree.root")
>>> import numpy as np
>>> f["tree1"] = {"branch": np.array([1, 2, 3])}
>>> f["tree2"] = {"branch": np.array([1, 2, 3])}
```

```console
% cp one-tree.root two-trees.root
```

```python
>>> import uproot
>>> f = uproot.update("one-tree.root")
>>> del f["tree2"]
```

```c++
root [0] auto f = new TFile("one-tree.root")
(TFile *) 0x5e75fab86820
root [1] TTree *t
(TTree *) nullptr
root [2] f->GetObject("tree1", t);
```

```c++
root [0] auto f = new TFile("two-trees.root")
(TFile *) 0x55e5977bc500
root [1] TTree *t
(TTree *) nullptr
root [2] f->GetObject("tree1", t);
```

You were correct in your observation that the TStreamerInfo for the TLeafL class and the bytes of the TLeafL instance were identical between the file that worked without errors and the file that didn't. The "hinge" came from `uproot.update` setting a bad version number and sending ROOT into this pre-version 3 mode: it didn't read the (correct) TStreamerInfo, and because TLeafL was not designed before ROOT version 3, it generated an incorrect TStreamerInfo instead of reading the one in the file. That's also why it didn't matter whether you used the high-level `del` or the low-level `FreeSegments.release`: either way, `uproot.update` set the `TFile::fVersion` to a nonsensical value.

I'll merge this PR into `main` right away; when you merge `main` into your PR, it should fix the TLeafL error.

------------------------

This bug would have affected any files modified by `uproot.update`, any process that adds or removes an object, because any modification of the `TFree` record (map of unused space within the file) would overwrite the `FileHeader` to indicate that the `TFree` record might have moved. As long as these files were smaller than 4 GB, Uproot would not have noticed, but it could have influenced ROOT in subtle ways, as shown above.