### PR TITLE
fix: add support for new RNTuple switches

### DIFF
--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -480,9 +480,15 @@ in file {self.file.file_path}"""
         pagelist = linklist[ncol]
         dtype_byte = self.column_records[ncol].type
         dtype_str = uproot.const.rntuple_col_num_to_dtype_dict[dtype_byte]
-        dtype = numpy.dtype("bool") if dtype_str == "bit" else numpy.dtype(dtype_str)
-
         total_len = numpy.sum([desc.num_elements for desc in pagelist], dtype=int)
+        if dtype_str == "switch":
+            # switches are read as 3 int32
+            dtype = numpy.dtype("int32")
+            total_len *= 3
+        else:
+            dtype = (
+                numpy.dtype("bool") if dtype_str == "bit" else numpy.dtype(dtype_str)
+            )
         res = numpy.empty(total_len, dtype)
         split = 14 <= dtype_byte <= 21 or 26 <= dtype_byte <= 28
         zigzag = 26 <= dtype_byte <= 28
@@ -493,6 +499,8 @@ in file {self.file.file_path}"""
         cumsum = 0
         for page_desc in pagelist:
             n_elements = page_desc.num_elements
+            if dtype_str == "switch":
+                n_elements *= 3
             tracker_end = tracker + n_elements
             self.read_pagedesc(
                 res[tracker:tracker_end], page_desc, dtype_str, dtype, nbits, split
@@ -568,8 +576,11 @@ in file {self.file.file_path}"""
 
 # Supporting function and classes
 def _split_switch_bits(content):
-    kindex = numpy.bitwise_and(content, numpy.int64(0x00000000000FFFFF))
-    tags = (content >> 44).astype("int8") - 1
+    tags = content[2::3].astype(numpy.dtype("int8")) - 1
+    kindex = numpy.empty(len(content) * 2 // 3, numpy.dtype("int32"))
+    kindex[::2] = content[::3]
+    kindex[1::2] = content[1::3]
+    kindex = kindex.view(numpy.dtype("int64"))
     return kindex, tags
 
 

--- a/tests/test_0662_rntuple_stl_containers.py
+++ b/tests/test_0662_rntuple_stl_containers.py
@@ -13,9 +13,6 @@ import uproot
 ak = pytest.importorskip("awkward")
 
 
-@pytest.mark.skip(
-    reason="FIXME: skipping test_ntuple_stl_containers.root until #928 is fixed"
-)
 def test_rntuple_stl_containers():
     filename = skhep_testdata.data_path("test_ntuple_stl_containers.root")
     with uproot.open(filename) as f:

--- a/tests/test_1191_rntuple_fixes.py
+++ b/tests/test_1191_rntuple_fixes.py
@@ -57,6 +57,9 @@ def test_empty_page_list():
         assert data[0] == 0
 
 
+@pytest.mark.skip(
+    reason="The file takes too long to download (about 5 seconds). Need to find a smaller test file."
+)
 def test_multiple_page_lists():
     url = "http://root.cern/files/tutorials/ntpl004_dimuon_v1rc2.root"
     with uproot.open(f"simplecache::{url}") as f:

--- a/tests/test_1191_rntuple_fixes.py
+++ b/tests/test_1191_rntuple_fixes.py
@@ -1,5 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
 
+import pytest
 import skhep_testdata
 
 import uproot


### PR DESCRIPTION
This PR fixes reading RNTuple switch data, which is now 96 bits as opposed to 64 bits. These are used to encode `std::variant` types. I re-enabled a test for them, which I didn't realize was being skipped.

Also, as a minor thing, I disabled another RNTuple test because the test file takes a relatively long file to download, and sometimes the server seems to get stuck.