### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,10 @@ jobs:
     needs: [build_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
 
     steps:
       - uses: actions/download-artifact@v4
@@ -30,6 +34,11 @@ jobs:
 
       - name: List distributions to be deployed
         run: ls -lha dist/
+
+      - name: Generate artifact attestation for sdist and wheel
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: dist/uproot-*
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds