### PR TITLE
fix: 'AwkwardForth testing E' should use the last `fields`/`formats`, not first

### DIFF
--- a/src/uproot/streamers.py
+++ b/src/uproot/streamers.py
@@ -999,14 +999,14 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                 else:
                     # AwkwardForth testing E: test_0637's 01,02,05,08,09,11,12,13,15,16,29,35,39,45,46,47,49,50,56
                     read_members.append("        if forth_obj is not None:")
-                    for i in range(len(formats[0])):
+                    for i in range(len(formats[-1])):
                         read_members.extend(
                             [
                                 "           key = key_number ; key_number += 1",
                                 '           form_key = f"node{key}-data"',
-                                f'           nested_forth_stash = af.Node(f"node{{key}}", field_name={fields[0][i]!r}, form_details={{ "class": "NumpyArray", "primitive": "{af.struct_to_dtype_name[formats[0][i]]}", "inner_shape": [], "parameters": {{}}, "form_key": f"node{{key}}"}})',
-                                f'           nested_forth_stash.header_code.append(f"output {{form_key}} {af.struct_to_dtype_name[formats[0][i]]}\\n")',
-                                f'           nested_forth_stash.pre_code.append(f"stream !{formats[0][i]}-> {{form_key}}\\n")',
+                                f'           nested_forth_stash = af.Node(f"node{{key}}", field_name={fields[-1][i]!r}, form_details={{ "class": "NumpyArray", "primitive": "{af.struct_to_dtype_name[formats[-1][i]]}", "inner_shape": [], "parameters": {{}}, "form_key": f"node{{key}}"}})',
+                                f'           nested_forth_stash.header_code.append(f"output {{form_key}} {af.struct_to_dtype_name[formats[-1][i]]}\\n")',
+                                f'           nested_forth_stash.pre_code.append(f"stream !{formats[-1][i]}-> {{form_key}}\\n")',
                                 "           forth_obj.add_node(nested_forth_stash)",
                             ]
                         )

--- a/tests/test_1221_AwkwardForth_bug.py
+++ b/tests/test_1221_AwkwardForth_bug.py
@@ -1,0 +1,22 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import pytest
+import uproot
+import skhep_testdata
+
+
+def test():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-1221.root")) as file:
+        record = file["TrkAna"]["trkana"]["demtsh"].array()[-1, -1, -1]
+        assert record.tolist() == {
+            "wdot": -0.6311486959457397,
+            "dhit": True,
+            "poca": {
+                "fCoordinates": {
+                    "fX": -526.5504760742188,
+                    "fY": -195.0541534423828,
+                    "fZ": 1338.90771484375,
+                }
+            },
+            "dactive": True,
+        }


### PR DESCRIPTION
We've never before had a C++ class with members in the following pattern:

1. some basic type (int, float, bool...)
2. some not basic type (string, collection, class...)
3. more than one basic types

but it came up in #1221. It revealed a bug in which AwkwardForth statements are supposed to be generated from the last `fields`/`formats` list to be filled (these variables are both lists of lists), but the old code was looking at the first.

This was in the "AwkwardForth testing E" block, for the case in which there's more than just one `fields`/`formats`.

* If part 3 (above) has no more than one basic type, then we'd be in "AwkwardForth testing D", which was correct (`fields[-1][0]` and `formats[-1][0]`, with the `-1` in the first index).
* If there was no part 1 (above), then `fields[0] is fields[-1]` and `formats[0] is formats[-1]`, and it worked by accident.

All of the tests/test_0637_setup_tests_for_AwkwardForth.py tests are insensitive to the code change, so this case doesn't exist in our test suite. It would be great to get example files from #1221 and add them to our test suite.