### PR TITLE
chore: declare support for Python 3.12 and switch to testing NumPy < 2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|ssl|timeout|expired|connection|socket"
 
-  numpy2-build:
+  numpy1-build:
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +111,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Pip install the package
-        run: python -m pip install 'numpy>=2.0.0b1' .[test]
+        run: python -m pip install 'numpy<2' .[test]
 
       - name: Run pytest
         run: |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/uproot.svg)](https://pypi.org/project/uproot)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/uproot)](https://github.com/conda-forge/uproot-feedstock)
-[![Python 3.7‒3.11](https://img.shields.io/badge/python-3.7%E2%80%923.11-blue)](https://www.python.org)
+[![Python 3.7‒3.12](https://img.shields.io/badge/python-3.7%E2%80%923.12-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Continuous integration tests](https://github.com/scikit-hep/uproot5/actions/workflows/build-test.yml/badge.svg)](https://github.com/scikit-hep/uproot5/actions)
 


### PR DESCRIPTION
We've been testing against Python 3.12 for a long time now (since #980), but somehow forgot to declare that we support this version in the metadata.

Also, since NumPy 2 has been released, we should switch to testing for its absence, rather than its presence, so that both NumPy 1 and NumPy 2 are included in at least one test.