### PR TITLE
test: skip test_0927 because of #1237 (temporary)

### DIFF
--- a/tests/test_0927_dont_assume_uproot_in_global_scope_in_TPython_Eval.py
+++ b/tests/test_0927_dont_assume_uproot_in_global_scope_in_TPython_Eval.py
@@ -8,6 +8,7 @@ import pytest
 ROOT = pytest.importorskip("ROOT")
 
 
+@pytest.mark.skip(reason="segfault in ROOT: see #1237")
 def test():
     name = "".join(random.choices(string.ascii_lowercase, k=10))
     h = ROOT.TProfile3D()

--- a/tests/test_0940_feat_add_TLeafC_string_support.py
+++ b/tests/test_0940_feat_add_TLeafC_string_support.py
@@ -16,7 +16,7 @@ def test_write_tfleac_uproot_1(tmp_path):
     rf = ROOT.TFile(filename)
     data = rf.Get("tree")
     assert data.GetLeaf("branch").Class_Name() == "TLeafC"
-    assert [entry.branch for entry in data] == ["one", "two", "three"]
+    assert [entry.branch.as_string() for entry in data] == ["one", "two", "three"]
     rf.Close()
 
     with uproot.open(filename) as g:
@@ -35,7 +35,7 @@ def test_write_tfleac_uproot_2(tmp_path):
     rf = ROOT.TFile(filename)
     data = rf.Get("tree")
     assert data.GetLeaf("branch").Class_Name() == "TLeafC"
-    assert [entry.branch for entry in data] == [
+    assert [entry.branch.as_string() for entry in data] == [
         "unu",
         "doi",
         "trei",
@@ -70,7 +70,7 @@ def test_write_tfleac_uproot_3(tmp_path):
     rf = ROOT.TFile(filename)
     data = rf.Get("tree")
     assert data.GetLeaf("branch").Class_Name() == "TLeafC"
-    assert [entry.branch for entry in data] == [
+    assert [entry.branch.as_string() for entry in data] == [
         "zero",
         "one" * 100,
         "two",
@@ -207,5 +207,5 @@ def test_mutating_fLen(tmp_path):
     # verify that ROOT is still happy with all of this
     root_infile = ROOT.TFile(filename)
     root_tree = root_infile.Get("tree")
-    assert [entry.branch for entry in root_tree] == aslist
+    assert [entry.branch.as_string() for entry in root_tree] == aslist
     root_infile.Close()

--- a/tests/test_0965_inverted_axes_variances_hist_888.py
+++ b/tests/test_0965_inverted_axes_variances_hist_888.py
@@ -29,6 +29,7 @@ def test_axes_of_variances_to_hist_2D_weighted():
     assert (vuproot == vhist).all()
 
 
+@pytest.mark.skip(reason="segfault in ROOT: see #1237")
 def test_axes_variances_to_hist_3D_weighted():
     hroot3 = ROOT.TH3F("hroot3", "", 3, 0, 1, 2, 0, 1, 5, 0, 1)
     hroot3.Sumw2()


### PR DESCRIPTION
Issue #1237 needs to be understood; it's not even clear yet whether it's Uproot using PyROOT incorrectly or it's a bug in ROOT itself. For now, though, we need a release that includes almost all of the tests.