### PR TITLE
perf: if first whole TBasket has inconclusive AwkwardForth

### DIFF
--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -512,6 +512,27 @@ input stream
 
             start = stop
 
+        # If *some* of the baskets are Awkward and *some* are not,
+        # convert the ones that are not, individually.
+        if any(
+            uproot._util.from_module(x, "awkward") for x in basket_arrays.values()
+        ) and isinstance(
+            library,
+            (
+                uproot.interpretation.library.Awkward,
+                uproot.interpretation.library.Pandas,
+            ),
+        ):
+            awkward = uproot.extras.awkward()
+            for k, v in basket_arrays.items():
+                if not uproot._util.from_module(v, "awkward"):
+                    form = json.loads(self.awkward_form(branch.file).to_json())
+                    basket_arrays[k] = (
+                        uproot.interpretation.library._object_to_awkward_array(
+                            awkward, form, v
+                        )
+                    )
+
         if len(basket_arrays) == 0:
             output = numpy.array([], dtype=self.numpy_dtype)
 


### PR DESCRIPTION
@nikoladze found a performance bug: if the first whole TBasket has inconclusive AwkwardForth, the code (before this PR) concatenated everything and ran the whole array through a generic iterable → Awkward Array transformation. The problem is that almost all of the data had been an Awkward Array already, all but the one TBasket with inconclusive AwkwardForth.

This PR adds an extra check for this case. If the list of basket-arrays is only partially Awkward, it converts the non-Awkward ones to Awkward individually so that the concatenated array doesn't have to be passed through the unnecessary generic iterable → Awkward Array transformation.

(There aren't any tests for this because it's based on private data.)