### PR TITLE
fix: RNTuple ug-fixing offset array concatenation, adding filter_name

### DIFF
--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -497,8 +497,10 @@ in file {self.file.file_path}"""
         arrays = [self.read_col_page(ncol, i) for i in cluster_range]
 
         # Check if column stores offset values for jagged arrays (splitindex64) (applies to cardinality cols too):
-        if dtype_byte == uproot.const.rntuple_col_type_to_num_dict["splitindex64"] or\
-           dtype_byte == uproot.const.rntuple_col_type_to_num_dict["splitindex32"]:
+        if (
+            dtype_byte == uproot.const.rntuple_col_type_to_num_dict["splitindex64"]
+            or dtype_byte == uproot.const.rntuple_col_type_to_num_dict["splitindex32"]
+        ):
             # Continue new cluster values from the last value of previous cluster.
 
             # Extract the last offset values:

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -506,7 +506,7 @@ in file {self.file.file_path}"""
                 arr[-1] for arr in arrays[:-1]
             ]  # First value always zero, therefore skip first arr.
             # Compute cumulative sum using itertools.accumulate:
-            last_offsets = [*list(accumulate(last_elements))]
+            last_offsets = list(accumulate(last_elements))
             # Add the offsets to each array
             for i in range(1, len(arrays)):
                 arrays[i] += last_offsets[i-1]

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -501,14 +501,13 @@ in file {self.file.file_path}"""
             dtype_byte == uproot.const.rntuple_col_type_to_num_dict["splitindex64"]
             or dtype_byte == uproot.const.rntuple_col_type_to_num_dict["splitindex32"]
         ):
-            # Continue new cluster values from the last value of previous cluster.
-
             # Extract the last offset values:
-            last_elements = [arr[-1] for arr in arrays[:-1]]
+            last_elements = [arr[-1] for arr in arrays[:-1]]  # First value always zero, therefore skip first arr.
             # Compute cumulative sum using itertools.accumulate:
-            last_offsets = [0, *list(accumulate(last_elements))]
+            last_offsets = [*list(accumulate(last_elements))]
             # Add the offsets to each array
-            arrays = [arr + offset for arr, offset in zip(arrays, last_offsets)]
+            for arr, offset in zip(arrays[1:], last_offsets):
+                arr += offset
             # Remove the first element from every sub-array except for the first one:
             arrays = [arrays[0]] + [arr[1:] for arr in arrays[1:]]
 

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 import struct
 from collections import defaultdict
+from itertools import accumulate
 
 import numpy
-from itertools import accumulate
 
 import uproot
 
@@ -62,14 +62,14 @@ class Model_ROOT_3a3a_Experimental_3a3a_RNTuple(uproot.model.Model):
         return keys
 
     def keys(
-            self,
-            *,
-            filter_name=None,
-            filter_typename=None,
-            filter_branch=None,
-            recursive=False,
-            full_paths=True,
-            ignore_duplicates=False,
+        self,
+        *,
+        filter_name=None,
+        filter_typename=None,
+        filter_branch=None,
+        recursive=False,
+        full_paths=True,
+        ignore_duplicates=False,
     ):
         if filter_name:
             # Return keys from the filter_name list:

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -509,7 +509,7 @@ in file {self.file.file_path}"""
             last_offsets = list(accumulate(last_elements))
             # Add the offsets to each array
             for i in range(1, len(arrays)):
-                arrays[i] += last_offsets[i-1]
+                arrays[i] += last_offsets[i - 1]
             # Remove the first element from every sub-array except for the first one:
             arrays = [arrays[0]] + [arr[1:] for arr in arrays[1:]]
 

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -502,7 +502,7 @@ in file {self.file.file_path}"""
             # Extract the last offset values:
             last_elements = [arr[-1] for arr in arrays[:-1]]
             # Compute cumulative sum using itertools.accumulate:
-            last_offsets = [0] + list(accumulate(last_elements))
+            last_offsets = [0, *list(accumulate(last_elements))]
             # Add the offsets to each array
             arrays = [arr + offset for arr, offset in zip(arrays, last_offsets)]
             # Remove the first element from every sub-array except for the first one:

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -508,8 +508,8 @@ in file {self.file.file_path}"""
             # Compute cumulative sum using itertools.accumulate:
             last_offsets = [*list(accumulate(last_elements))]
             # Add the offsets to each array
-            for arr, offset in zip(arrays[1:], last_offsets):
-                arr += offset
+            for i in range(1, len(arrays)):
+                arrays[i] += last_offsets[i-1]
             # Remove the first element from every sub-array except for the first one:
             arrays = [arrays[0]] + [arr[1:] for arr in arrays[1:]]
 

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -502,7 +502,9 @@ in file {self.file.file_path}"""
             or dtype_byte == uproot.const.rntuple_col_type_to_num_dict["splitindex32"]
         ):
             # Extract the last offset values:
-            last_elements = [arr[-1] for arr in arrays[:-1]]  # First value always zero, therefore skip first arr.
+            last_elements = [
+                arr[-1] for arr in arrays[:-1]
+            ]  # First value always zero, therefore skip first arr.
             # Compute cumulative sum using itertools.accumulate:
             last_offsets = [*list(accumulate(last_elements))]
             # Add the offsets to each array


### PR DESCRIPTION
Changes made in RNTuple model:

- Bug-fix: when reading arrays from more than one cluster, data was not identical to TTree. The reason for this was improper array concatenation in case of offset values. More information in here: https://gist.github.com/giedrius2020/c1ca87784779418ee3e938aaca31ff75 
- Added a function to filter wanted key values in `def keys()`
- Minimal change: changed existing "filter_names" variables to "filter_name", because that is how the variable was called in TTree model.