### PR TITLE
test: disable test that uses UNL file

### DIFF
--- a/tests/test_1146_split_ranges_for_large_files_over_http.py
+++ b/tests/test_1146_split_ranges_for_large_files_over_http.py
@@ -1,8 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
 
+import pytest
 import uproot
 
 
+@pytest.mark.skip(
+    reason="The server started requiring authentication to access the file."
+)
 def test_split_ranges_if_large_file_in_http():
     fname = (
         "https://xrootd-local.unl.edu:1094//store/user/AGC/nanoAOD/TT_TuneCUETP8M1_13TeV"


### PR DESCRIPTION
The UNL server started requiring authentication to access [this file](https://xrootd-local.unl.edu:1094//store/user/AGC/nanoAOD/TT_TuneCUETP8M1_13TeV-powheg-pythia8/cmsopendata2015_ttbar_19980_PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext3-v1_00000_0000.root"), so the test is timing out.

Maybe this was just an accidental change in the configuration, but I'm not sure who to contact so I disabled the test for now.