### PR TITLE
chore(deps): add xxhash dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 dependencies = [
   "awkward>=2.4.6",
   "cramjam>=2.5.0",
+  "xxhash",
   "numpy",
   "fsspec",
   "packaging",
@@ -67,7 +68,6 @@ s3 = ["s3fs"]
 test = [
   "isal",
   "deflate",
-  "xxhash",
   "minio",
   "aiohttp",
   "fsspec-xrootd",


### PR DESCRIPTION
`xxhash` is currently a strict dependency for reading RNTuples (see #1271). We could simply remove the line that uses `xxhash` to verify checksums, but given that it is now available in Pyodide and it will unquestionably be needed for writing RNTuples, then it makes sense to add it as a dependency now.

Once this is merged, I will also start using it more extensively for RNTuple reading.

Closes #1271.