### PR TITLE
docs: Uproot only supports Pythons 3.8 through 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/uproot.svg)](https://pypi.org/project/uproot)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/uproot)](https://github.com/conda-forge/uproot-feedstock)
-[![Python 3.7‒3.12](https://img.shields.io/badge/python-3.7%E2%80%923.12-blue)](https://www.python.org)
+[![Python 3.8‒3.12](https://img.shields.io/badge/python-3.8%E2%80%923.12-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Continuous integration tests](https://github.com/scikit-hep/uproot5/actions/workflows/build-test.yml/badge.svg)](https://github.com/scikit-hep/uproot5/actions)
 


### PR DESCRIPTION
Okay, so I'm leaving this as manual because the automated version doesn't show a range—it lists every Python version separately. This would make the badge too big, and I don't want the badges to use so much space. They're carefully arranged in two rows just to keep them from being overwhelming.

![](https://media.licdn.com/dms/image/v2/C5612AQGL9qoPMFZMYw/article-cover_image-shrink_600_2000/article-cover_image-shrink_600_2000/0/1520093949131?e=2147483647&v=beta&t=C8cPdu3LFOSwRe4VzeIHUUeg4rvRkuW9LIwQj6vVVAQ)