### PR TITLE
chore(ci): switch to miniforge

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,11 +21,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
 
-    # Required for miniconda to activate conda
-    defaults:
-      run:
-        shell: bash -l {0}
-
     steps:
       - uses: actions/checkout@v4
 
@@ -34,14 +29,13 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          miniforge-version: latest
 
       - name: Install ROOT
         if: matrix.python-version == 3.8  &&  runner.os != 'macOS'  &&  runner.os != 'Windows'
         run: |
           conda env list
-          mamba install root
+          conda install root
           conda list
 
       - name: Install sshd for fsspec ssh tests
@@ -59,7 +53,7 @@ jobs:
         if: runner.os != 'macOS'  &&  runner.os != 'Windows'
         run: |
           conda env list
-          mamba install xrootd
+          conda install xrootd
           conda list
 
       - name: Pip install the package

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,6 +35,7 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
+          use-mamba: true
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"
@@ -43,7 +44,7 @@ jobs:
         if: matrix.python-version == 3.8  &&  runner.os != 'macOS'  &&  runner.os != 'Windows'
         run: |
           conda env list
-          conda install root
+          mamba install root
           conda list
 
       - name: Install sshd for fsspec ssh tests

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,11 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Required for miniconda to activate conda
-defaults:
-  run:
-    shell: bash -l {0}
-
 jobs:
   build:
     strategy:
@@ -25,6 +20,11 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
+
+    # Required for miniconda to activate conda
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,11 +37,7 @@ jobs:
           miniforge-version: latest
 
       - name: Check active Python version
-        shell: python
-        run: |
-          import sys
-          version = '.'.join(str(s) for s in sys.version_info[:2])
-          assert version == '${{ matrix.python-version }}', f'{version} incorrect!'
+        run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"
 
       - name: Install ROOT
         if: matrix.python-version == 3.8  &&  runner.os != 'macOS'  &&  runner.os != 'Windows'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Required for miniconda to activate conda
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,6 +36,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
 
+      - name: Check active Python version
+        shell: python
+        run: |
+          import sys
+          version = '.'.join(str(s) for s in sys.version_info[:2])
+          assert version == '${{ matrix.python-version }}', f'{version} incorrect!'
+
       - name: Install ROOT
         if: matrix.python-version == 3.8  &&  runner.os != 'macOS'  &&  runner.os != 'Windows'
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,7 @@ jobs:
         if: runner.os != 'macOS'  &&  runner.os != 'Windows'
         run: |
           conda env list
-          conda install xrootd
+          mamba install xrootd
           conda list
 
       - name: Pip install the package


### PR DESCRIPTION
Miniforge and Mambaforge are now equivalent, so the latter has been deprecated. There are a bunch of warning messages about this on CI runs, so this PR is mainly to clean those up. The rest of the warnings are out of our control, but I've seen that there's open PRs that will fix some of them.