### PR TITLE
perf: improve performance for read coalescing

### DIFF
--- a/src/uproot/source/coalesce.py
+++ b/src/uproot/source/coalesce.py
@@ -49,6 +49,7 @@ class RangeRequest:
 @dataclass
 class Cluster:
     ranges: list[RangeRequest]
+    _stop: int | None = None
 
     @property
     def start(self):
@@ -57,7 +58,13 @@ class Cluster:
 
     @property
     def stop(self):
-        return max(range.stop for range in self.ranges)
+        # Note: in order for this to work one has to use `append` for adding new ranges
+        return self._stop
+
+    def append(self, range):
+        if self._stop is None or range.stop > self._stop:
+            self._stop = range.stop
+        self.ranges.append(range)
 
     def __len__(self):
         return self.stop - self.start
@@ -88,7 +95,7 @@ def _merge_adjacent(ranges: list[RangeRequest], config: CoalesceConfig):
         if cluster.ranges and current_range.start - cluster.stop > config.max_range_gap:
             yield cluster
             cluster = Cluster([])
-        cluster.ranges.append(current_range)
+        cluster.append(current_range)
     if cluster.ranges:
         yield cluster
 


### PR DESCRIPTION
This fixes #1257 - the current read coalescing algorithm has a loop over ranges (to determine `Cluster.stop`) for every range added to a `Cluster` leading to a somewhat quadratic scaling. This can be fixed by having a private `_stop` attribute that is updated in an `append` method. The downside is that now `.append` has to be used to append new ranges to a `Cluster`. Since this is not really a user facing class i think that should be acceptable.

Using the example TTree from #1257 

```python
import uproot
import numpy as np

num_baskets = 1_000
num_per_basket = 1_000
num_branches = 50
with uproot.recreate("test.root") as f:
    for i_chunk in range(num_baskets):
        chunk = {f"branch{i}": np.random.rand(num_per_basket) for i in range(num_branches)}
        if "tree" in f:
            f["tree"].extend(chunk)
        else:
            f["tree"] = chunk
```

To be read via
```python
import uproot

def load(filename):
    with uproot.open({filename: "tree"}) as tree:
        return tree.arrays(library="np")
```

**Before** this PR i get on my laptop
```python
In [6]: %timeit -n1 -r2 __ = load("test.root")
1min 19s ± 3.2 s per loop (mean ± std. dev. of 2 runs, 1 loop each)
```

**After** the changes i get
```python
In [2]: %timeit __ = load("test.root")
4.62 s ± 90.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```