### PR TITLE
fix: adjust for Pandas changing its API again

### DIFF
--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -919,7 +919,12 @@ class Pandas(Library):
             )
 
         else:
-            index = arrays.index.arrays
+            # arrays.index.values before Pandas 0.24 and again now;
+            # arrays.index.arrays from Pandas 0.24 through some time ago.
+            if hasattr(arrays.index, "values"):
+                index = arrays.index.values
+            else:
+                index = arrays.index.arrays
             numpy.add(index, global_offset, out=index)
 
         return arrays

--- a/tests/test_1321_pandas_changed_api_again.py
+++ b/tests/test_1321_pandas_changed_api_again.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import pytest
+import skhep_testdata
+import uproot
+
+pytest.importorskip("pandas")
+
+
+def test():
+    assert (
+        len(
+            uproot.concatenate(
+                skhep_testdata.data_path("uproot-Zmumu.root"),
+                library="pd",
+                cut="Run > 148029",
+            )
+        )
+        == 1580
+    )


### PR DESCRIPTION
Before Uproot 5, we had

https://github.com/scikit-hep/uproot5/blob/b36a0229391c00e101fdbfd56925afa9e2bd2ebb/src/uproot/interpretation/library.py#L1131-L1134

to allow for different Pandas APIs before and after Pandas 0.24. But Pandas 0.24 is ancient, and I decided that we don't need to handle that anymore in #734 (which made a lot of changes, removing the explode-to-Pandas behavior).

But at some point in recent history, the attribute switched from `Index.arrays` back to `Index.values`. There's an `Index.array`, but it's a NumpyExtension, rather than a plain NumPy array, and `np.add` _might_ prefer the real NumPy array.