### PR TITLE
fix: missing attribute in __array__ method of STLVector

### DIFF
--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -1541,7 +1541,7 @@ class ROOTRVec(Container, Sequence):
             return False
 
     def __array__(self, *args, **kwargs):
-        return numpy.asarray(self._vector, *args, **kwargs)
+        return numpy.asarray(self._values, *args, **kwargs)
 
     def tolist(self):
         return [
@@ -1656,7 +1656,7 @@ class STLVector(Container, Sequence):
             return False
 
     def __array__(self, *args, **kwargs):
-        return numpy.asarray(self._vector, *args, **kwargs)
+        return numpy.asarray(self._values, *args, **kwargs)
 
     def tolist(self):
         return [


### PR DESCRIPTION
Commit [#cdaf9a7](cdaf9a7) adds an `__array__` method to STLVector in containers.py [L1544](https://github.com/scikit-hep/uproot5/blob/afca74c2af16641299abfbf91935e8010d601111/src/uproot/containers.py#L1544) and [L1659](https://github.com/scikit-hep/uproot5/blob/afca74c2af16641299abfbf91935e8010d601111/src/uproot/containers.py#L1659).

However, the method tries to return an attribute that does not exist. I think it should return `self._values` and not `self._vector`

```python
def __array__(self, *args, **kwargs):
    return numpy.asarray(self._vector, *args, **kwargs)
```
should be:
```python
def __array__(self, *args, **kwargs):
    return numpy.asarray(self._values, *args, **kwargs)
```