### PR TITLE
fix(ci): pin selenium version to fix pyodide tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ test = [
 ]
 test-pyodide = [
   "pytest>=6",
+  "selenium<=4.25.0",  # unpin once >4.26.0 is available
   "pytest-pyodide",
   "pytest-timeout",
   "scikit-hep-testdata"


### PR DESCRIPTION
There was a bug in the new Selenium version that is causing the Pyodide tests to fail (see #1326). I'm pinning Selenium to the previous version until they make a new release.