### PR TITLE
chore(ci): Disable RNTuple tests for now and unpin selenium version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ test = [
 ]
 test-pyodide = [
   "pytest>=6",
-  "selenium<=4.25.0",  # unpin once >4.26.0 is available
   "pytest-pyodide",
   "pytest-timeout",
   "scikit-hep-testdata"

--- a/tests-wasm/test_1272_basic_functionality.py
+++ b/tests-wasm/test_1272_basic_functionality.py
@@ -70,6 +70,7 @@ def test_write_ttree(selenium):
 
 
 # Taken from test_1191_rntuple_fixes.py
+@pytest.mark.skip(reason="Skipping until test files are available with RNTuple v1.0")
 @run_test_in_pyodide(test_file="test_ntuple_extension_columns.root")
 def test_read_rntuple(selenium):
     import uproot
@@ -95,6 +96,7 @@ def test_read_rntuple(selenium):
 
 
 # Taken from test_0034_generic_objects_in_ttrees.py
+@pytest.mark.skip(reason="Skipping until test files are available with RNTuple v1.0")
 @pytest.mark.network
 @run_test_in_pyodide(packages=["requests"])
 def test_read_ttree_http(selenium):
@@ -116,6 +118,7 @@ def test_read_ttree_http(selenium):
 
 
 # Taken from test_1191_rntuple_fixes.py
+@pytest.mark.skip(reason="Skipping until test files are available with RNTuple v1.0")
 @pytest.mark.network
 @run_test_in_pyodide(packages=["requests"])
 def test_read_rntuple_http(selenium):

--- a/tests/test_0013_rntuple_anchor.py
+++ b/tests/test_0013_rntuple_anchor.py
@@ -10,6 +10,10 @@ import skhep_testdata
 
 import uproot
 
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 def test():
     filename = skhep_testdata.data_path("uproot-ntpl001_staff.root")

--- a/tests/test_0630_rntuple_basics.py
+++ b/tests/test_0630_rntuple_basics.py
@@ -12,6 +12,10 @@ import uproot
 
 pytest.importorskip("awkward")
 
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 def test_flat():
     filename = skhep_testdata.data_path("test_ntuple_int_float.root")

--- a/tests/test_0662_rntuple_stl_containers.py
+++ b/tests/test_0662_rntuple_stl_containers.py
@@ -12,6 +12,10 @@ import uproot
 
 ak = pytest.importorskip("awkward")
 
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 def test_rntuple_stl_containers():
     filename = skhep_testdata.data_path("test_ntuple_stl_containers.root")

--- a/tests/test_0705_rntuple_writing_metadata.py
+++ b/tests/test_0705_rntuple_writing_metadata.py
@@ -13,6 +13,10 @@ import uproot
 
 ak = pytest.importorskip("awkward")
 
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 @pytest.mark.skip(
     reason="RNTuple writing is pending until specification 1.0.0 is released."

--- a/tests/test_0962_RNTuple_update.py
+++ b/tests/test_0962_RNTuple_update.py
@@ -6,6 +6,10 @@ import awkward as ak
 import skhep_testdata
 import numpy as np
 
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 def test_new_support_RNTuple_split_int32_reading():
     with uproot.open(skhep_testdata.data_path("test_ntuple_int_5e4.root")) as f:

--- a/tests/test_1191_rntuple_fixes.py
+++ b/tests/test_1191_rntuple_fixes.py
@@ -5,6 +5,10 @@ import skhep_testdata
 
 import uproot
 
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 def test_schema_extension():
     filename = skhep_testdata.data_path("test_ntuple_extension_columns.root")

--- a/tests/test_1223_more_rntuple_types.py
+++ b/tests/test_1223_more_rntuple_types.py
@@ -5,6 +5,10 @@ import skhep_testdata
 
 import uproot
 
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 def test_atomic():
     filename = skhep_testdata.data_path("test_ntuple_atomic_bitset.root")

--- a/tests/test_1250_rntuple_improvements.py
+++ b/tests/test_1250_rntuple_improvements.py
@@ -5,6 +5,10 @@ import skhep_testdata
 
 import uproot
 
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 def test_field_class():
     filename = skhep_testdata.data_path("DAOD_TRUTH3_RC2.root")

--- a/tests/test_1285_rntuple_multicluster_concatenation.py
+++ b/tests/test_1285_rntuple_multicluster_concatenation.py
@@ -5,6 +5,12 @@ import numpy as np
 
 import uproot
 
+import pytest
+
+pytest.skip(
+    "Skipping until test files are available with RNTuple v1.0", allow_module_level=True
+)
+
 
 def test_schema_extension():
     filename = skhep_testdata.data_path("test_ntuple_index_multicluster.root")


### PR DESCRIPTION
Next week is the planned release of version 1.0 of the RNTuple spec. So soon I'll be starting to delete old RNTuple test files from `scikit-hep-testdata` and generate new ones with the v1.0 spec. This will break the CI tests, so I'm disabling the RNTuple tests so that it doesn't affect other PRs.

I'm also unpinning the selenium version that was pinned in #1327 since they released a fixed version.