### PR TITLE
feat: support reading of custom-length RNTuple floats

### DIFF
--- a/src/uproot/const.py
+++ b/src/uproot/const.py
@@ -242,6 +242,10 @@ rntuple_delta_types = (
     rntuple_col_type_to_num_dict["splitindex32"],
     rntuple_col_type_to_num_dict["splitindex64"],
 )
+rntuple_custom_float_types = (
+    rntuple_col_type_to_num_dict["real32trunc"],
+    rntuple_col_type_to_num_dict["real32quant"],
+)
 
 
 class RNTupleLocatorType(IntEnum):


### PR DESCRIPTION
This PR implements the reading of `Real32Trunc` and `Real32Quant` fields, which have a variable number of bits in the ranges 10-31 and 1-32, respectively.

This already works, but I'll clean it up and add a test. I might also add support for suppressed columns in this PR. I'll update the title and description if I do so.