### PR TITLE
fix: uproot was exposed in one place to dask's _task_spec overhaul

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 dev = [
   "boost_histogram>=0.13",
-  "dask-awkward>=2023.12.1",
+  "dask-awkward>=2024.12.1",
   "dask[array,distributed]",
   "hist>=1.2",
   "pandas",

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -384,7 +384,7 @@ def _dask_array_from_map(
 ):
     dask = uproot.extras.dask()
     _dask_uses_tasks = hasattr(dask, "_task_spec")
-    
+
     da = uproot.extras.dask_array()
     if not callable(func):
         raise ValueError("`func` argument must be `callable`")
@@ -457,10 +457,12 @@ def _dask_array_from_map(
     }
 
     if _dask_uses_tasks:
-        blockwise_kwargs["task"] = dask._task_spec.Task(name, io_func, dask._task_spec.TaskRef(dask.blockwise.blockwise_token(0)))
+        blockwise_kwargs["task"] = dask._task_spec.Task(
+            name, io_func, dask._task_spec.TaskRef(dask.blockwise.blockwise_token(0))
+        )
     else:
         blockwise_kwargs["dsk"] = {name: (io_func, dask.blockwise.blockwise_token(0))}
-    
+
     dsk = dask.blockwise.Blockwise(**blockwise_kwargs)
 
     hlg = dask.highlevelgraph.HighLevelGraph.from_collections(name, dsk)


### PR DESCRIPTION
c.f. https://github.com/dask-contrib/dask-awkward/pull/556

There don't appear to be any other places where uproot directly accesses dask innards.