### PR TITLE
fix: support RNTuples with multiple cluster groups

### DIFF
--- a/tests/test_1159_rntuple_cluster_groups.py
+++ b/tests/test_1159_rntuple_cluster_groups.py
@@ -1,0 +1,27 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+def test_multiple_cluster_groups():
+    filename = skhep_testdata.data_path(
+        "test_multiple_cluster_groups_rntuple_v1-0-0-0.root"
+    )
+    with uproot.open(filename) as f:
+        obj = f["ntuple"]
+
+        assert len(obj.footer.cluster_group_records) == 3
+
+        assert obj.footer.cluster_group_records[0].num_clusters == 5
+        assert obj.footer.cluster_group_records[1].num_clusters == 4
+        assert obj.footer.cluster_group_records[2].num_clusters == 3
+
+        assert obj.num_entries == 1000
+
+        arrays = obj.arrays()
+
+        assert arrays.one.tolist() == list(range(1000))
+        assert arrays.int_vector.tolist() == [[i, i + 1] for i in range(1000)]

--- a/tests/test_1191_rntuple_fixes.py
+++ b/tests/test_1191_rntuple_fixes.py
@@ -11,9 +11,7 @@ def test_schema_extension():
     with uproot.open(filename) as f:
         obj = f["ntuple"]
 
-        assert len(obj.page_list_envelopes.pagelinklist[0]) < len(
-            obj.page_list_envelopes.pagelinklist[1]
-        )
+        assert len(obj.page_link_list[0]) < len(obj.page_link_list[1])
 
         assert len(obj.column_records) > len(obj.header.column_records)
         assert len(obj.column_records) == 4

--- a/tests/test_1347_rntuple_floats_suppressed_cols.py
+++ b/tests/test_1347_rntuple_floats_suppressed_cols.py
@@ -156,11 +156,11 @@ def test_multiple_representations():
     with uproot.open(filename) as f:
         obj = f["ntuple"]
 
-        assert len(obj.page_list_envelopes.pagelinklist) == 3
+        assert len(obj.page_link_list) == 3
         # The zeroth representation is active in clusters 0 and 2, but not in cluster 1
-        assert not obj.page_list_envelopes.pagelinklist[0][0].suppressed
-        assert obj.page_list_envelopes.pagelinklist[1][0].suppressed
-        assert not obj.page_list_envelopes.pagelinklist[2][0].suppressed
+        assert not obj.page_link_list[0][0].suppressed
+        assert obj.page_link_list[1][0].suppressed
+        assert not obj.page_link_list[2][0].suppressed
 
         arrays = obj.arrays()
 


### PR DESCRIPTION
This PR fixes #1357. Now multiple cluster groups are handled correctly. Internally, it just groups all clusters together into a single group. I couldn't think of any reasons to keep track of different groups, but we can implement that later if necessary.