### PR TITLE
test: adjust for changes in example.com

### DIFF
--- a/tests/test_0001_source_class.py
+++ b/tests/test_0001_source_class.py
@@ -117,6 +117,7 @@ def test_memmap_fail(use_threads, tmp_path):
             ...
 
 
+@pytest.mark.skip(reason="example.com is responding with 200, rather than 206, now")
 @pytest.mark.parametrize("use_threads", [True, False])
 @pytest.mark.network
 def test_http(use_threads):
@@ -157,6 +158,7 @@ def test_colons_and_ports():
     ) == ("https://example.com:443/file.root", "object")
 
 
+@pytest.mark.skip(reason="example.com is responding with 200, rather than 206, now")
 @pytest.mark.parametrize("use_threads", [True, False], indirect=True)
 @pytest.mark.network
 def test_http_port(use_threads):


### PR DESCRIPTION
It returns 200, rather than 206, for our wrong-page examples now. There might be a good way to replace this test, but for now I'm disabling it. We have plenty of other tests that check the HTTP backend. (This test is from 0001, which tested HTTP without any ROOT files because it was written at a time when only the backend handlers existed.)