### PR TITLE
fix: use trusted publishers for publishing releases to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,4 +42,4 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.pypi_password }}
+          print-hash: true


### PR DESCRIPTION
fixes #1226 