### PR TITLE
feat: Optional support to add c++ typenames to parameters in uproot.dask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,7 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 dev = [
   "boost_histogram>=0.13",
-  "dask-awkward>=2024.12.1",
-  "dask[dataframe] >=2022,<2025",
+  "dask-awkward>=2025.2.0",
   "dask[array,distributed]",
   "hist>=1.2",
   "pandas",

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1396,8 +1396,8 @@ def _get_ttree_form(
                     for key, value in ak_add_doc.items()
                 }
             )
-
-        content_form = content_form.copy(parameters=content_parameters)
+        if len(content_parameters.keys()) != 0:
+            content_form = content_form.copy(parameters=content_parameters)
         contents.append(content_form)
 
     if isinstance(ak_add_doc, bool):

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1390,7 +1390,12 @@ def _get_ttree_form(
             if ak_add_doc:
                 content_parameters["__doc__"] = branch.title
         elif isinstance(ak_add_doc, dict):
-            content_parameters.update({ key:branch.__getattribute__(value) for key,value in ak_add_doc.items() })
+            content_parameters.update(
+                {
+                    key: branch.__getattribute__(value)
+                    for key, value in ak_add_doc.items()
+                }
+            )
 
         content_form = content_form.copy(parameters=content_parameters)
         contents.append(content_form)
@@ -1398,9 +1403,11 @@ def _get_ttree_form(
     if isinstance(ak_add_doc, bool):
         parameters = {"__doc__": ttree.title} if ak_add_doc else None
     elif isinstance(ak_add_doc, dict):
-        parameters = {"__doc__": ttree.title} if "__doc__" in ak_add_doc.keys() else None
+        parameters = (
+            {"__doc__": ttree.title} if "__doc__" in ak_add_doc.keys() else None
+        )
     else:
-        parameters=None
+        parameters = None
 
     return awkward.forms.RecordForm(contents, common_keys, parameters=parameters)
 
@@ -1553,10 +1560,7 @@ which has {entry_stop} entries"""
                     partition_args.append((i, start, stop))
 
     base_form = _get_ttree_form(
-        awkward,
-        ttrees[0],
-        common_keys,
-        interp_options.get("ak_add_doc")
+        awkward, ttrees[0], common_keys, interp_options.get("ak_add_doc")
     )
 
     if len(partition_args) == 0:
@@ -1630,10 +1634,7 @@ def _get_dak_array_delay_open(
             ignore_duplicates=True,
         )
         base_form = _get_ttree_form(
-            awkward,
-            obj,
-            common_keys,
-            interp_options.get("ak_add_doc")
+            awkward, obj, common_keys, interp_options.get("ak_add_doc")
         )
 
     divisions = [0]

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -40,6 +40,7 @@ def dask(
     steps_per_file=unset,
     library="ak",
     ak_add_doc=False,
+    ak_add_typename=False,
     custom_classes=None,
     allow_missing=False,
     open_files=True,
@@ -89,6 +90,8 @@ def dask(
             ``NotImplementedError``.
         ak_add_doc (bool): If True and ``library="ak"``, add the TBranch ``title``
             to the Awkward ``__doc__`` parameter of the array.
+        ak_add_typename (bool): If True and ``library="ak"``, add the TBranch ``typename``
+            to the Awkward ``typename`` parameter of the array.
         custom_classes (None or dict): If a dict, override the classes from
             the :doc:`uproot.reading.ReadOnlyFile` or ``uproot.classes``.
         allow_missing (bool): If True, skip over any files that do not contain
@@ -236,7 +239,7 @@ def dask(
 
     filter_branch = uproot._util.regularize_filter(filter_branch)
 
-    interp_options = {"ak_add_doc": ak_add_doc}
+    interp_options = {"ak_add_doc": ak_add_doc, "ak_add_typename": ak_add_typename}
 
     if library.name == "np":
         if open_files:
@@ -491,6 +494,7 @@ class _UprootReadNumpy:
             entry_stop=stop,
             library="np",
             ak_add_doc=self.interp_options["ak_add_doc"],
+            ak_add_typename=self.interp_options["ak_add_typename"],
             decompression_executor=self.decompression_executor,
             interpretation_executor=self.interpretation_executor,
         )
@@ -555,6 +559,7 @@ which has {num_entries} entries"""
             entry_start=start,
             entry_stop=stop,
             ak_add_doc=self.interp_options["ak_add_doc"],
+            ak_add_typename=self.interp_options["ak_add_typename"],
             decompression_executor=self.decompression_executor,
             interpretation_executor=self.interpretation_executor,
         )
@@ -920,6 +925,7 @@ class TrivialFormMappingInfo(ImplementsFormMappingInfo):
             entry_start=start,
             entry_stop=stop,
             ak_add_doc=options["ak_add_doc"],
+            ak_add_typename=options["ak_add_typename"],
             decompression_executor=decompression_executor,
             interpretation_executor=interpretation_executor,
             how=tuple,
@@ -1378,13 +1384,17 @@ def _get_ttree_form(
     ttree,
     common_keys,
     ak_add_doc,
+    ak_add_typename,
 ):
     contents = []
     for key in common_keys:
         branch = ttree[key]
         content_form = branch.interpretation.awkward_form(ttree.file)
-        if ak_add_doc:
-            content_form = content_form.copy(parameters={"__doc__": branch.title})
+        if ak_add_doc or ak_add_typename:
+            content_parameters = {}
+            if ak_add_doc : content_parameters["__doc__"] = branch.title
+            if ak_add_typename : content_parameters["typename"] = branch.typename
+            content_form = content_form.copy(parameters=content_parameters)
         contents.append(content_form)
 
     parameters = {"__doc__": ttree.title} if ak_add_doc else None
@@ -1540,7 +1550,7 @@ which has {entry_stop} entries"""
                     partition_args.append((i, start, stop))
 
     base_form = _get_ttree_form(
-        awkward, ttrees[0], common_keys, interp_options.get("ak_add_doc")
+        awkward, ttrees[0], common_keys, interp_options.get("ak_add_doc"), interp_options.get("ak_add_typename")
     )
 
     if len(partition_args) == 0:
@@ -1614,7 +1624,7 @@ def _get_dak_array_delay_open(
             ignore_duplicates=True,
         )
         base_form = _get_ttree_form(
-            awkward, obj, common_keys, interp_options.get("ak_add_doc")
+            awkward, obj, common_keys, interp_options.get("ak_add_doc"), interp_options.get("ak_add_typename")
         )
 
     divisions = [0]

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1392,8 +1392,10 @@ def _get_ttree_form(
         content_form = branch.interpretation.awkward_form(ttree.file)
         if ak_add_doc or ak_add_typename:
             content_parameters = {}
-            if ak_add_doc : content_parameters["__doc__"] = branch.title
-            if ak_add_typename : content_parameters["typename"] = branch.typename
+            if ak_add_doc:
+                content_parameters["__doc__"] = branch.title
+            if ak_add_typename:
+                content_parameters["typename"] = branch.typename
             content_form = content_form.copy(parameters=content_parameters)
         contents.append(content_form)
 
@@ -1550,7 +1552,11 @@ which has {entry_stop} entries"""
                     partition_args.append((i, start, stop))
 
     base_form = _get_ttree_form(
-        awkward, ttrees[0], common_keys, interp_options.get("ak_add_doc"), interp_options.get("ak_add_typename")
+        awkward,
+        ttrees[0],
+        common_keys,
+        interp_options.get("ak_add_doc"),
+        interp_options.get("ak_add_typename"),
     )
 
     if len(partition_args) == 0:
@@ -1624,7 +1630,11 @@ def _get_dak_array_delay_open(
             ignore_duplicates=True,
         )
         base_form = _get_ttree_form(
-            awkward, obj, common_keys, interp_options.get("ak_add_doc"), interp_options.get("ak_add_typename")
+            awkward,
+            obj,
+            common_keys,
+            interp_options.get("ak_add_doc"),
+            interp_options.get("ak_add_typename"),
         )
 
     divisions = [0]

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -556,6 +556,7 @@ def _ak_add_doc_typename(array, hasbranches, ak_add_doc, ak_add_typename):
             array.layout.parameters["typename"] = hasbranches.typename
     return array
 
+
 class HasBranches(Mapping):
     """
     Abstract class of behaviors for anything that "has branches," namely
@@ -898,7 +899,10 @@ class HasBranches(Mapping):
         ]
 
         return _ak_add_doc_typename(
-            library.group(output, expression_context, how), self, ak_add_doc,  ak_add_typename
+            library.group(output, expression_context, how),
+            self,
+            ak_add_doc,
+            ak_add_typename,
         )
 
     def iterate(
@@ -1085,7 +1089,10 @@ class HasBranches(Mapping):
                                     )
 
                 arrays = {}
-                interp_options = {"ak_add_doc": ak_add_doc, "ak_add_typename": ak_add_typename}
+                interp_options = {
+                    "ak_add_doc": ak_add_doc,
+                    "ak_add_typename": ak_add_typename,
+                }
                 _ranges_or_baskets_to_arrays(
                     self,
                     ranges_or_baskets,
@@ -1107,7 +1114,7 @@ class HasBranches(Mapping):
                     library,
                     how,
                     ak_add_doc,
-                    ak_add_typename
+                    ak_add_typename,
                 )
 
                 output = language.compute_expressions(
@@ -3162,7 +3169,13 @@ def _ranges_or_baskets_to_arrays(
 
 
 def _fix_asgrouped(
-    arrays, expression_context, branchid_interpretation, library, how, ak_add_doc, ak_add_typename
+    arrays,
+    expression_context,
+    branchid_interpretation,
+    library,
+    how,
+    ak_add_doc,
+    ak_add_typename,
 ):
     index_start = 0
     for index_stop, (_, context) in enumerate(expression_context):
@@ -3182,7 +3195,10 @@ def _fix_asgrouped(
                     subcontext.append((subname, limited_context[subname]))
 
                 arrays[branch.cache_key] = _ak_add_doc_typename(
-                    library.group(subarrays, subcontext, how), branch, ak_add_doc, ak_add_typename
+                    library.group(subarrays, subcontext, how),
+                    branch,
+                    ak_add_doc,
+                    ak_add_typename,
                 )
 
                 index_start = index_stop

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -550,7 +550,12 @@ def _ak_add_doc(array, hasbranches, ak_add_doc):
             if ak_add_doc:
                 array.layout.parameters["__doc__"] = hasbranches.title
         elif isinstance(ak_add_doc, dict):
-            array.layout.parameters.update({ key:hasbranches.__getattribute__(value) for key,value in ak_add_doc.items() })
+            array.layout.parameters.update(
+                {
+                    key: hasbranches.__getattribute__(value)
+                    for key, value in ak_add_doc.items()
+                }
+            )
     return array
 
 
@@ -894,9 +899,7 @@ class HasBranches(Mapping):
         ]
 
         return _ak_add_doc(
-            library.group(output, expression_context, how),
-            self,
-            ak_add_doc
+            library.group(output, expression_context, how), self, ak_add_doc
         )
 
     def iterate(
@@ -3155,12 +3158,7 @@ def _ranges_or_baskets_to_arrays(
 
 
 def _fix_asgrouped(
-    arrays,
-    expression_context,
-    branchid_interpretation,
-    library,
-    how,
-    ak_add_doc
+    arrays, expression_context, branchid_interpretation, library, how, ak_add_doc
 ):
     index_start = 0
     for index_stop, (_, context) in enumerate(expression_context):
@@ -3180,9 +3178,7 @@ def _fix_asgrouped(
                     subcontext.append((subname, limited_context[subname]))
 
                 arrays[branch.cache_key] = _ak_add_doc(
-                    library.group(subarrays, subcontext, how),
-                    branch,
-                    ak_add_doc
+                    library.group(subarrays, subcontext, how), branch, ak_add_doc
                 )
 
                 index_start = index_stop

--- a/tests/test_1375_extend_ak_add_doc.py
+++ b/tests/test_1375_extend_ak_add_doc.py
@@ -1,0 +1,50 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import pytest
+import skhep_testdata
+
+import uproot
+
+file = skhep_testdata.data_path("nanoAOD_2015_CMS_Open_Data_ttbar.root")
+tree = "Events"
+
+to_test = {
+    "Electron_r9":{
+        "title":"R9 of the supercluster, calculated with full 5x5 region",
+        "typename":"float[]"
+    },
+    "luminosityBlock":{
+        "title":"luminosityBlock/i",
+        "typename":"uint32_t"
+    },
+    "Tau_jetIdx":{
+        "title":"index of the associated jet (-1 if none)",
+        "typename":"int32_t[]"
+    },
+}
+
+
+@pytest.mark.parametrize("file",[file])
+@pytest.mark.parametrize("tree",[tree])
+@pytest.mark.parametrize("open_files",[True,False])
+@pytest.mark.parametrize(
+    "ak_add_doc_value",
+    [
+        False,
+        True,
+        {"__doc__":"title"},
+        {"title":"title"},
+        {"typename":"typename"},
+        {"__doc__":"title","typename":"typename"}
+    ]
+)
+
+def test_extend_ak_add_doc(file, tree, open_files, ak_add_doc_value):
+
+    events = uproot.dask(file+":"+tree, open_files=open_files, ak_add_doc=ak_add_doc_value)
+    for branch_name in to_test.keys():
+        if isinstance(ak_add_doc_value, bool):
+            if ak_add_doc_value:
+                assert events[branch_name].form.parameters == {"__doc__":to_test[branch_name]["title"]}
+        if isinstance(ak_add_doc_value, dict):
+            assert events[branch_name].form.parameters == {key:to_test[branch_name][val] for key,val in ak_add_doc_value.items()}

--- a/tests/test_1375_extend_ak_add_doc.py
+++ b/tests/test_1375_extend_ak_add_doc.py
@@ -5,6 +5,9 @@ import skhep_testdata
 
 import uproot
 
+dask = pytest.importorskip("dask")
+dask_awkward = pytest.importorskip("dask_awkward")
+
 file = skhep_testdata.data_path("nanoAOD_2015_CMS_Open_Data_ttbar.root")
 tree = "Events"
 


### PR DESCRIPTION
### Optional support to add c++ typenames to parameters with ak_add_typename in uproot.dask
---

#### Necessity:

- Access to C++ typename info for each tree branch is essential in building COFFEA schema for files generated with EDM4HEP.

- Similar to how  `ak_add_doc`  is used to add the `__doc__` parameter to forms, `ak_add_typename` could be used to add  the C++ typename of the branch in parameters.

- This is an attempt to solve this feature request [#1369](https://github.com/scikit-hep/uproot5/issues/1369) posted by @ianna in response to the discussions among @jpivarski @ianna @davidlange6 and @prayagyadav

---

#### Outcome/Example/Expected output:

Bash:
```bash
wget https://github.com/prayagyadav/coffea/raw/refs/heads/test-typenames-swan/tests/samples/p8_ee_WW_ecm240_edm4hep.root
```
Python:
```python
file = "p8_ee_WW_ecm240_edm4hep.root"
tree = "events"
events = uproot.dask(file+":"+tree, open_files=False, ak_add_doc=True,  ak_add_typename=True)

events.Particle.form.parameters
```
Output:
``` 
{'__doc__': 'Particle_', 'typename': 'vector<edm4hep::MCParticleData>'}
```

[Here](https://colab.research.google.com/drive/1FsL_bjvGOtPtsdvRsPfbPR8lWhdrRiUJ?usp=sharing) is the live link to the notebook for the above example, where one can run these cells in real-time.

---
The bulk of the idea for these code changes was given by @davidlange6