### PR TITLE
fix: show untyped fields and make keys compatible with coffea

### DIFF
--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -195,7 +195,7 @@ class Model_ROOT_3a3a_RNTuple(uproot.model.Model):
         keys = []
         field_records = self.field_records
         for i, fr in enumerate(field_records):
-            if fr.parent_field_id == i and fr.type_name != "":
+            if fr.parent_field_id == i and not fr.field_name.startswith("_"):
                 keys.append(fr.field_name)
         return keys
 
@@ -219,7 +219,7 @@ class Model_ROOT_3a3a_RNTuple(uproot.model.Model):
         indices = []
         field_records = self.field_records
         for i, fr in enumerate(field_records):
-            if fr.parent_field_id == i and fr.type_name != "":
+            if fr.parent_field_id == i and not fr.field_name.startswith("_"):
                 indices.append(i)
         return indices
 
@@ -228,7 +228,7 @@ class Model_ROOT_3a3a_RNTuple(uproot.model.Model):
         d = {}
         field_records = self.field_records
         for i, fr in enumerate(field_records):
-            if fr.parent_field_id == i and fr.type_name != "":
+            if fr.parent_field_id == i and not fr.field_name.startswith("_"):
                 d[fr.field_name] = i
         return d
 
@@ -684,7 +684,7 @@ in file {self.file.file_path}"""
         for i in range(len(field_records)):
             if i not in seen:
                 ff = self.field_form(i, seen)
-                if field_records[i].type_name != "":
+                if not field_records[i].field_name.startswith("_"):
                     recordlist.append(ff)
 
         form = ak.forms.RecordForm(recordlist, topnames, form_key="toplevel")
@@ -1249,7 +1249,6 @@ class RNTupleField:
                 continue
             if (
                 fr.parent_field_id == self.index
-                and fr.type_name != ""
                 and not fr.field_name.startswith("_")
                 and not fr.field_name.startswith(":_")
             ):
@@ -1282,7 +1281,7 @@ class RNTupleField:
         indices = []
         field_records = self.ntuple.field_records
         for i, fr in enumerate(field_records):
-            if fr.parent_field_id == self.index and fr.type_name != "":
+            if fr.parent_field_id == self.index and not fr.field_name.startswith("_"):
                 indices.append(i)
         return indices
 
@@ -1291,7 +1290,7 @@ class RNTupleField:
         d = {}
         field_records = self.ntuple.field_records
         for i, fr in enumerate(field_records):
-            if fr.parent_field_id == self.index and fr.type_name != "":
+            if fr.parent_field_id == self.index and not fr.field_name.startswith("_"):
                 d[fr.field_name] = i
         return d
 

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -210,11 +210,8 @@ class Model_ROOT_3a3a_RNTuple(uproot.model.Model):
         full_paths=True,
         **_,  # For compatibility reasons we just ignore other kwargs
     ):
-        if filter_name:
-            # Return keys from the filter_name list:
-            return [key for key in self._keys if key in filter_name]
-        else:
-            return self._keys
+        filter_name = uproot._util.regularize_filter(filter_name)
+        return [key for key in self._keys if filter_name(key)]
 
     @property
     def _key_indices(self):
@@ -1268,11 +1265,8 @@ class RNTupleField:
         full_paths=True,
         **_,  # For compatibility reasons we just ignore other kwargs
     ):
-        if filter_name:
-            # Return keys from the filter_name list:
-            return [key for key in self._keys if key in filter_name]
-        else:
-            return self._keys
+        filter_name = uproot._util.regularize_filter(filter_name)
+        return [key for key in self._keys if filter_name(key)]
 
     @property
     def name(self):

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -199,14 +199,16 @@ class Model_ROOT_3a3a_RNTuple(uproot.model.Model):
                 keys.append(fr.field_name)
         return keys
 
+    # TODO: this is still missing a lot of functionality
     def keys(
         self,
         *,
         filter_name=None,
         filter_typename=None,
+        filter_field=None,
         recursive=False,
         full_paths=True,
-        # TODO: some arguments might be missing when compared with TTree. Solve when blocker is present in dask/coffea.
+        **_,  # For compatibility reasons we just ignore other kwargs
     ):
         if filter_name:
             # Return keys from the filter_name list:
@@ -1255,8 +1257,22 @@ class RNTupleField:
                 keys.append(fr.field_name)
         return keys
 
-    def keys(self):
-        return self._keys
+    # TODO: this is still missing a lot of functionality
+    def keys(
+        self,
+        *,
+        filter_name=None,
+        filter_typename=None,
+        filter_field=None,
+        recursive=False,
+        full_paths=True,
+        **_,  # For compatibility reasons we just ignore other kwargs
+    ):
+        if filter_name:
+            # Return keys from the filter_name list:
+            return [key for key in self._keys if key in filter_name]
+        else:
+            return self._keys
 
     @property
     def name(self):


### PR DESCRIPTION
I changed things so that untyped fields now show up in `keys`. Previously, I was ignoring those since I thought they would not be useful, but that's not true. Also, for now I still ignore fields whose name starts with `_`, but maybe I'll also change this later so that everything appears even though it might come with a lot of garbage.


I also changed the `keys` function so that it takes some arbitrary kwargs and simply ignores them. This fixes #1350, but it is a temporary solution, as coffea needs to switch to using the right kwargs once they fully move to using RNTuples.

The keys function is still missing most functionality, but in the interest of having coffea working, I'll leave that for a future PR.