### PR TITLE
test: fix broken test

### DIFF
--- a/tests/test_0840_support_tleafG.py
+++ b/tests/test_0840_support_tleafG.py
@@ -12,7 +12,7 @@ def test_support_leafG(tmp_path):
     f = ROOT.TFile(filename, "recreate")
     t = ROOT.TTree("mytree", "example tree")
 
-    n = np.array(2, dtype=np.int32)
+    n = np.int32(2)
     t.Branch("mynum", n, "mynum/I")
     x = np.array([[1, 2, 3], [4, 5, 6]])
     t.Branch("myarrayG", x, "myarrayG[mynum][3]/G")


### PR DESCRIPTION
~ROOT was updated to 6.32.8 in `conda-forge` and it seems to have some issue with Python 3.9. Given that the issue is with ROOT and not Uproot, and also that Python 3.9 will reach its eand-of-life later this year, I'm just disabling this test for Python 3.9.~

EDIT: See comments below