### PR TITLE
fix: test to check that we can write via xrootd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ test = [
   "deflate",
   "minio",
   "aiohttp",
-  "fsspec-xrootd",
+  "fsspec-xrootd>=0.5.0",
   "s3fs",
   "paramiko",
   "pytest>=6",
@@ -86,7 +86,7 @@ test-pyodide = [
   "pytest-timeout",
   "scikit-hep-testdata"
 ]
-xrootd = ["fsspec-xrootd"]
+xrootd = ["fsspec-xrootd>=0.5.0"]
 
 [project.urls]
 Download = "https://github.com/scikit-hep/uproot5/releases"

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import fsspec
 import numpy as np
+import awkward as ak
 
 is_windows = sys.platform.startswith("win")
 
@@ -218,3 +219,16 @@ def test_fsspec_writing_memory(tmp_path, scheme):
 
     with uproot.open(uri) as f:
         assert f["tree"]["x"].array().tolist() == [1, 2, 3]
+
+
+def test_write_fsspec_xrootd(xrootd_server):
+    remote_path, _ = xrootd_server
+    filename = "file.root"
+    remote_file_path = os.path.join(remote_path, filename)
+    array = ak.Array({"x":[1,2,3], "y":[4,5,6]})
+    file = uproot.recreate(remote_file_path)
+    file["tree"] = array
+    file.close()
+    with uproot.open(remote_file_path) as f:
+        assert f["tree"]["x"].array().tolist() == [1, 2, 3]
+        assert f["tree"]["y"].array().tolist() == [4, 5, 6]

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -221,7 +221,7 @@ def test_fsspec_writing_memory(tmp_path, scheme):
         assert f["tree"]["x"].array().tolist() == [1, 2, 3]
 
 
-def test_write_fsspec_xrootd(xrootd_server):
+def test_write_append_fsspec_xrootd(xrootd_server):
     remote_path, _ = xrootd_server
     filename = "file.root"
     remote_file_path = os.path.join(remote_path, filename)
@@ -229,6 +229,12 @@ def test_write_fsspec_xrootd(xrootd_server):
     file = uproot.recreate(remote_file_path)
     file["tree"] = array
     file.close()
+    array2 = ak.Array({"x":[1,2,3,4], "y":[4,5,6,7]})
+    file = uproot.update(remote_file_path)
+    file["other_tree"] = array2
+    file.close()
     with uproot.open(remote_file_path) as f:
         assert f["tree"]["x"].array().tolist() == [1, 2, 3]
         assert f["tree"]["y"].array().tolist() == [4, 5, 6]
+        assert f["other_tree"]["x"].array().tolist() == [1, 2, 3, 4]
+        assert f["other_tree"]["y"].array().tolist() == [4, 5, 6, 7]

--- a/tests/test_0692_fsspec_writing.py
+++ b/tests/test_0692_fsspec_writing.py
@@ -225,11 +225,11 @@ def test_write_append_fsspec_xrootd(xrootd_server):
     remote_path, _ = xrootd_server
     filename = "file.root"
     remote_file_path = os.path.join(remote_path, filename)
-    array = ak.Array({"x":[1,2,3], "y":[4,5,6]})
+    array = ak.Array({"x": [1, 2, 3], "y": [4, 5, 6]})
     file = uproot.recreate(remote_file_path)
     file["tree"] = array
     file.close()
-    array2 = ak.Array({"x":[1,2,3,4], "y":[4,5,6,7]})
+    array2 = ak.Array({"x": [1, 2, 3, 4], "y": [4, 5, 6, 7]})
     file = uproot.update(remote_file_path)
     file["other_tree"] = array2
     file.close()


### PR DESCRIPTION
This PR introduces a test to check that we can correctly write via XRootD (see https://github.com/scikit-hep/uproot5/issues/1252).
This test fails with current fsspec-xrootd, but it succeeds when running with the changes introduced in https://github.com/scikit-hep/fsspec-xrootd/pull/76.
We can thus decide to either merge it now but skip the test, or wait until https://github.com/scikit-hep/fsspec-xrootd/pull/76 is merged (and a new version released) and then merge it.