### PR TITLE
fix: restrict to the environment set for the trusted publisher

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
     uses: ./.github/workflows/build-distributions.yml
 
   publish:
+    environment:
+      name: pypi
     needs: [build_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
Restrict to the environment set for the trusted publisher