### PR TITLE
feat: enable manual column optimization with dask-awkward

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1086,6 +1086,9 @@ class UprootReadMixin:
         keys = self.necessary_columns(report=report, state=state)
         return self.project_keys(keys)
 
+    def project_manually(self: T, columns: frozenset[str]) -> T:
+        return self.project_keys(columns)
+
     def necessary_columns(
         self, *, report: TypeTracerReport, state: dict
     ) -> frozenset[str]:


### PR DESCRIPTION
Enables https://github.com/dask-contrib/dask-awkward/pull/565 for `uproot.dask`.

Example:
```python
import uproot
import dask_awkward as dak


# foo.root has 3 branches: "A", "B", "C"
array = uproot.dask({"foo.root": "tree_name"})

# get dask key in graph:
key, _ = next(iter(array.dask.keys()))

# manual column optimization for "A" and "C"
needs = {key: ["A", "C"]}
optimized_array = dak.manual.optimize_columns(array, needs)

# this only loads "A" & "C" from disk in a single read call (`tree.arrays([...])`), 
# it doesn't load "B", and avoids typetracing entirely (it's already optimized...)
concrete_array = optimized_array.compute()
```
`key` corresponds to the key of the `from-uproot` IO layer. `needs` can have multiple keys that point to various projectable IO-layers.