### PR TITLE
feat: all essential RNTuple writing functionality

### DIFF
--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -653,8 +653,9 @@ in file {self.file.file_path}"""
             # go find N in the rest, N is the # of fields in struct
             recordlist = [self.field_form(i, seen) for i in newids]
             namelist = [field_records[i].field_name for i in newids]
-            if all(name.startswith("_") for name in namelist):
-                namelist = None
+            # TODO: uncomment this once tuples are fixed
+            # if all(name.startswith("_") for name in namelist):
+            #     namelist = None
             return ak.forms.RecordForm(recordlist, namelist, form_key="whatever")
         elif structural_role == uproot.const.RNTupleFieldRole.VARIANT:
             keyname = self.col_form(this_id)

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import struct
 import sys
 from collections import defaultdict
-from itertools import accumulate
 
 import numpy
 import xxhash
@@ -776,10 +775,11 @@ in file {self.file.file_path}"""
         if dtype_byte in uproot.const.rntuple_delta_types:
             # Extract the last offset values:
             last_elements = [
-                (arr[-1] if len(arr) > 0 else 0) for arr in arrays[:-1]
+                (arr[-1] if len(arr) > 0 else numpy.zeros((), dtype=arr.dtype))
+                for arr in arrays[:-1]
             ]  # First value always zero, therefore skip first arr.
             # Compute cumulative sum using itertools.accumulate:
-            last_offsets = list(accumulate(last_elements))
+            last_offsets = numpy.cumsum(last_elements)
             # Add the offsets to each array
             for i in range(1, len(arrays)):
                 arrays[i] += last_offsets[i - 1]

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -743,10 +743,8 @@ in file {self.file.file_path}"""
             content = res.view(dtype)
 
         if isbit:
-            content = (
-                numpy.unpackbits(content.view(dtype=numpy.uint8))
-                .reshape(-1, 8)[:, ::-1]
-                .reshape(-1)
+            content = numpy.unpackbits(
+                content.view(dtype=numpy.uint8), bitorder="little"
             )
         elif dtype_str in ("real32trunc", "real32quant"):
             if nbits == 32:

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -775,7 +775,7 @@ in file {self.file.file_path}"""
         arrays = [self.read_col_page(ncol, i) for i in cluster_range]
 
         # Check if column stores offset values for jagged arrays (splitindex64) (applies to cardinality cols too):
-        if dtype_byte in uproot.const.rntuple_delta_types:
+        if dtype_byte in uproot.const.rntuple_index_types:
             # Extract the last offset values:
             last_elements = [
                 (arr[-1] if len(arr) > 0 else numpy.zeros((), dtype=arr.dtype))

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -653,6 +653,8 @@ in file {self.file.file_path}"""
             # go find N in the rest, N is the # of fields in struct
             recordlist = [self.field_form(i, seen) for i in newids]
             namelist = [field_records[i].field_name for i in newids]
+            if all(name.startswith("_") for name in namelist):
+                namelist = None
             return ak.forms.RecordForm(recordlist, namelist, form_key="whatever")
         elif structural_role == uproot.const.RNTupleFieldRole.VARIANT:
             keyname = self.col_form(this_id)

--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -818,7 +818,6 @@ class NTuple(CascadeNode):
         self._num_entries = 0
 
         self._column_counts = numpy.zeros(len(self._header._column_keys), dtype=int)
-        self._column_offsets = numpy.zeros(len(self._header._column_keys), dtype=int)
 
     def __repr__(self):
         return f"{type(self).__name__}({self._directory}, {self._header}, {self._footer}, {self._cluster_metadata}, {self._anchor}, {self._freesegments})"
@@ -878,11 +877,7 @@ class NTuple(CascadeNode):
         for idx, key in enumerate(self._header._column_keys):
             col_data = data_buffers[key]
             if "offsets" in key:
-                col_data = (
-                    col_data[1:] + self._column_offsets[idx]
-                )  # TODO: check if there is a better way to do this
-                if len(col_data) > 0:
-                    self._column_offsets[idx] = col_data[-1]
+                col_data = col_data[1:]
             col_len = len(col_data.reshape(-1))
             # TODO: when col_length is zero we can skip writing the page
             # but other things need to be adjusted

--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -46,28 +46,20 @@ from uproot.writing._cascade import CascadeLeaf, CascadeNode, Key, String
 _rntuple_string_length_format = struct.Struct("<I")
 
 _ak_primitive_to_typename_dict = {
-    "i64": "std::int64_t",
-    "i32": "std::int32_t",
-    # "switch": 3,
-    # "byte": 4,
+    "bool": "bool",
     "char": "char",
-    "bool": "bool",  # check
-    "float64": "double",
-    "float32": "float",
-    # "float16": 9,
-    "int64": "std::int64_t",
-    "int32": "std::int32_t",
-    "int16": "std::int16_t",
     "int8": "std::int8_t",
     "uint8": "std::uint8_t",
-    # "splitindex64": 14,
-    # "splitindex32": 15,
-    # "splitreal64": 16,
-    # "splitreal32": 17,
-    # "splitreal16": 18,
-    # "splitin64": 19,
-    # "splitint32": 20,
-    # "splitint16": 21,
+    "int16": "std::int16_t",
+    "uint16": "std::uint16_t",
+    "int32": "std::int32_t",
+    "uint32": "std::uint32_t",
+    "int64": "std::int64_t",
+    "uint64": "std::uint64_t",
+    "float32": "float",
+    "float64": "double",
+    "i32": "std::int32_t",  # index type
+    "i64": "std::int64_t",  # index type
 }
 _ak_primitive_to_num_dict = {
     "bool": 0x00,
@@ -80,7 +72,6 @@ _ak_primitive_to_num_dict = {
     "uint32": 0x08,
     "int64": 0x09,
     "uint64": 0x0A,
-    "float16": 0x0B,
     "float32": 0x0C,
     "float64": 0x0D,
     "i32": 0x0E,
@@ -819,9 +810,11 @@ class NTuple(CascadeNode):
                 )  # TODO: check if there is a better way to do this
                 self._column_offsets[idx] = col_data[-1]
             raw_data = col_data.view("uint8")
+            if col_data.dtype == numpy.dtype("bool"):
+                raw_data = numpy.packbits(raw_data, bitorder="little")
             page_key = self.add_rblob(sink, raw_data, len(raw_data), big=False)
             page_locator = NTuple_Locator(
-                len(raw_data), page_key.location + page_key.allocation  # probably wrong
+                len(raw_data), page_key.location + page_key.allocation
             )
             cluster_page_data.append(
                 [(page_locator, len(col_data), self._column_counts[idx])]

--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -398,6 +398,7 @@ class NTuple_Header(CascadeLeaf):
                 field_name="_0",
             )
         elif isinstance(akform, awkward.forms.RecordForm):
+            type_name = _cpp_typename(akform)
             field = NTuple_Field_Description(
                 0,
                 0,
@@ -405,7 +406,7 @@ class NTuple_Header(CascadeLeaf):
                 uproot.const.RNTupleFieldRole.RECORD,
                 0,
                 field_name,
-                "",
+                type_name,
                 "",
                 "",
             )

--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -113,6 +113,8 @@ def _cpp_typename(akform, subcall=False):
     elif isinstance(akform, awkward.forms.UnionForm):
         field_typenames = [_cpp_typename(t, subcall=True) for t in akform.contents]
         typename = f"std::variant<{','.join(field_typenames)}>"
+    elif isinstance(akform, awkward.forms.UnmaskedForm):
+        return _cpp_typename(akform.content, subcall=True)
     else:
         raise NotImplementedError(f"Form type {type(akform)} cannot be written yet")
     if not subcall and "UntypedRecord" in typename:
@@ -488,6 +490,13 @@ class NTuple_Header(CascadeLeaf):
                     field_name=subfield_name,
                     parent_fid=field_id,
                 )
+        elif isinstance(akform, awkward.forms.UnmaskedForm):
+            # Do nothing
+            self._build_field_col_records(
+                akform.content,
+                parent_fid=parent_fid,
+                field_name=field_name,
+            )
         else:
             raise NotImplementedError(f"Form type {type(akform)} cannot be written yet")
 

--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -81,9 +81,15 @@ _ak_primitive_to_num_dict = {
 
 
 def _cpp_typename(akform, subcall=False):
-    if isinstance(akform, awkward.forms.NumpyForm):
+    if isinstance(akform, awkward.forms.NumpyForm) and akform.inner_shape == ():
         ak_primitive = akform.primitive
         typename = _ak_primitive_to_typename_dict[ak_primitive]
+    elif isinstance(akform, awkward.forms.NumpyForm):
+        ak_primitive = akform.primitive
+        inner_shape = akform.inner_shape
+        typename = _ak_primitive_to_typename_dict[ak_primitive]
+        for arr_size in inner_shape[::-1]:
+            typename = f"std::array<{typename},{arr_size}>"
     elif isinstance(akform, awkward.forms.ListOffsetForm):
         content_typename = _cpp_typename(akform.content, subcall=True)
         typename = f"std::vector<{content_typename}>"

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -1347,20 +1347,30 @@ in file {self.file_path} in directory {self.path}"""
     def mkrntuple(
         self,
         name,
-        branch_types,
+        ak_form_or_data,
         title="",
     ):
         """
         Args:
             name (str): Name of the new RNTuple.
-            branch_types (dict or pairs of str \u2192 NumPy dtype/Awkward type): Name
-                and type specification for the TBranches.
+            ak_form_or_data (Awkward RecordForm or RecordArray): Name
+                and type specification for the fields. If a RecordForm is provided,
+                the RNTuple will be empty. If a RecordArray is provided, the RNTuple
+                will be initialized with the input data.
             title (str): Title for the new RNTuple.
 
         Creates an empty RNTuple in this directory.
         """
         if self._file.sink.closed:
             raise ValueError("cannot create a RNTuple in a closed file")
+
+        # TODO: Think of a better alternative to this
+        if isinstance(ak_form_or_data, uproot.extras.awkward().Array):
+            ntuple = self.mkrntuple(name, ak_form_or_data.layout.form, title)
+            ntuple.extend(ak_form_or_data)
+            return ntuple
+
+        # The rest assumes that ak_form_or_data is a RecordForm
 
         try:
             at = name.rindex("/")
@@ -1380,7 +1390,7 @@ in file {self.file_path} in directory {self.path}"""
                 directory._file.sink,
                 treename,
                 title,
-                branch_types,
+                ak_form_or_data,
             ),
         )
         directory._file._new_ntuple(ntuple)

--- a/tests/test_1356_basic_rntuple_writing.py
+++ b/tests/test_1356_basic_rntuple_writing.py
@@ -31,8 +31,6 @@ def test_flat_arrays(tmp_path):
 
 def test_flat_arrays_ROOT(tmp_path, capfd):
     ROOT = pytest.importorskip("ROOT")
-    if ROOT.gROOT.GetVersionInt() < 63500:
-        pytest.skip("ROOT version does not support RNTuple v1.0.0.0")
 
     filepath = os.path.join(tmp_path, "test.root")
 

--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -46,6 +46,10 @@ def test_writing_and_reading(tmp_path):
     filepath = os.path.join(tmp_path, "test.root")
 
     with uproot.recreate(filepath) as file:
+        obj = file.mkrntuple("ntuple", data)  # test inputting the data directly
+        obj.extend(data)
+
+    with uproot.recreate(filepath) as file:
         obj = file.mkrntuple("ntuple", data.layout.form)
         obj.extend(data)
         obj.extend(data)  # test multiple cluster groups
@@ -110,8 +114,16 @@ def test_writing_then_reading_with_ROOT(tmp_path, capfd):
     assert "* Field 8            : numpy_regular (std::array<std::int64_t,3>)" in out
     assert "* Field 9            : struct" in out
     assert "* Field 10           : struct_list" in out
-    assert "* Field 11           : tuple" in out
+    assert "* Field 11           : tuple (std::tuple<std::int64_t,std::int64_t>)" in out
     assert (
         "* Field 12           : tuple_list (std::vector<std::tuple<std::int64_t>>)"
+        in out
+    )
+    assert "* Field 13           : optional (std::optional<std::int64_t>)" in out
+    assert (
+        "* Field 14           : union (std::variant<std::int64_t,std::string>)" in out
+    )
+    assert (
+        "* Field 15           : optional_union (std::variant<std::optional<std::int64..."
         in out
     )

--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -35,6 +35,7 @@ data = ak.Array(
         ],
         "tuple": [(1, 2), (3, 4), (5, 6)],
         "tuple_list": [[(1,), (2,)], [(3,), (4,)], [(5,), (6,)]],
+        "optional": [1, None, 2],
     }
 )
 
@@ -53,9 +54,18 @@ def test_writing_and_reading(tmp_path):
     for f in data.fields:
         if "tuple" in f:
             # TODO: tuples are converted to records
-            continue
-        assert arrays[f][:3].tolist() == data[f].tolist()
-        assert arrays[f][3:].tolist() == data[f].tolist()
+            [tuple(t[f] for f in t.fields) for t in arrays[f][:3]] == data[f].tolist()
+            [tuple(t[f] for f in t.fields) for t in arrays[f][3:]] == data[f].tolist()
+        elif "optional" in f:
+            assert [t[0] if len(t) > 0 else None for t in arrays[f][:3]] == data[
+                f
+            ].tolist()
+            assert [t[0] if len(t) > 0 else None for t in arrays[f][3:]] == data[
+                f
+            ].tolist()
+        else:
+            assert arrays[f][:3].tolist() == data[f].tolist()
+            assert arrays[f][3:].tolist() == data[f].tolist()
 
 
 def test_writing_then_reading_with_ROOT(tmp_path, capfd):

--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -72,12 +72,25 @@ def test_writing_then_reading_with_ROOT(tmp_path, capfd):
     RT.PrintInfo()
     RT.Show(0)
     RT.Show(2)
+    RT.Show(4)
     out = capfd.readouterr().out
     assert "* N-Tuple : ntuple" in out
-    assert "* Entries : 3" in out
-    assert "* Field 1   : one (std::int64_t)" in out
-    assert "* Field 2   : two (double)" in out
-    assert '  "one": 1,' in out
-    assert '  "two": 1.1' in out
-    assert '  "one": 3' in out
-    assert '  "two": 3.3' in out
+    assert "* Entries : 6" in out
+    assert "* Field 1            : bool (bool)" in out
+    assert "* Field 2            : int (std::int64_t)" in out
+    assert "* Field 3            : float (double)" in out
+    assert "* Field 4            : jagged_list (std::vector<std::int64_t>)" in out
+    assert (
+        "* Field 5            : nested_list (std::vector<std::vector<std::int64_t>>)"
+        in out
+    )
+    assert "* Field 6            : string (std::string)" in out
+    assert "* Field 7            : regular (std::array<std::int64_t,3>)" in out
+    assert "* Field 8            : numpy_regular (std::array<std::int64_t,3>)" in out
+    assert "* Field 9            : struct" in out
+    assert "* Field 10           : struct_list" in out
+    assert "* Field 11           : tuple" in out
+    assert (
+        "* Field 12           : tuple_list (std::vector<std::tuple<std::int64_t>>)"
+        in out
+    )

--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -37,6 +37,7 @@ data = ak.Array(
         "tuple_list": [[(1,), (2,)], [(3,), (4,)], [(5,), (6,)]],
         "optional": [1, None, 2],
         "union": [1, 2, "three"],
+        "optional_union": [1, None, "three"],
     }
 )
 
@@ -57,13 +58,22 @@ def test_writing_and_reading(tmp_path):
             # TODO: tuples are converted to records
             [tuple(t[f] for f in t.fields) for t in arrays[f][:3]] == data[f].tolist()
             [tuple(t[f] for f in t.fields) for t in arrays[f][3:]] == data[f].tolist()
-        elif "optional" in f:
+        elif f == "optional":
             assert [t[0] if len(t) > 0 else None for t in arrays[f][:3]] == data[
                 f
             ].tolist()
             assert [t[0] if len(t) > 0 else None for t in arrays[f][3:]] == data[
                 f
             ].tolist()
+        elif f == "optional_union":
+            assert [
+                t if isinstance(t, str) else t[0] if len(t) > 0 else None
+                for t in arrays[f][:3]
+            ] == data[f].tolist()
+            assert [
+                t if isinstance(t, str) else t[0] if len(t) > 0 else None
+                for t in arrays[f][3:]
+            ] == data[f].tolist()
         else:
             assert arrays[f][:3].tolist() == data[f].tolist()
             assert arrays[f][3:].tolist() == data[f].tolist()

--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -36,6 +36,7 @@ data = ak.Array(
         "tuple": [(1, 2), (3, 4), (5, 6)],
         "tuple_list": [[(1,), (2,)], [(3,), (4,)], [(5,), (6,)]],
         "optional": [1, None, 2],
+        "union": [1, 2, "three"],
     }
 )
 

--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -21,6 +21,7 @@ data = ak.Array(
         "jagged_list": [[1], [2, 3], [4, 5, 6]],
         "nested_list": [[[1], []], [[2], [3, 3]], [[4, 5, 6]]],
         "string": ["one", "two", "three"],
+        "utf8_string": ["こんにちは", "⚛️💫🎆😀", "ǧ̸̛̫͍̰͖̟̈͛͑͆̆̌̃̉̅̄̔̈́̀̔͆̄͋̍͐͂̎͗̈́͒͘͝ͅö̴̮̝̪̬͎͚̜̖̜͖̞̤͕̙͂̀̀̊͛͑̈́͛͐͊͂͂̇͛̾̔͐͆͑͂̓̅̀͘͘͘̕͝͠͝͝ơ̶͍̙̻̾̈́̓̈́̀̅͑ḑ̷͚̠̹̗͉͙̞͇͕̼̲̥͉̯̞͕̲̻̞͗̓̃̊̅͗͊͊́̑̈́̎͋̇̓͛̅͜͜͠͝ͅb̷̢̢̨̨̛̛̘̠̞̰̺̘̰̖̺̞̱͇̰̙̲̱̪͕͎͉̖̞͇̹̮͙͋̀͑͂̈́̇͛̐͊̀̇͆̓̋̀̿̋̂̅̀̌̑̓̽͊̂͑̈̇̚͜͝y̶̗͇̠̞͚̦̮̦͈̹̥̋̓̓̈́̐̆̀̄̋̂̀̇͋̎̚͜͝ȩ̷̢̡͇̮̩̹̥̬̰͎͔̬̩̰̯͍̲͎̭͉̬̣̻̖͍̥̟̪͕̫̟̋̔̀͆̑̈́̐̃͐͌̍͒̔̈́̃̈́̐̔̾͊̿̓͆͑̚͜͝͝͝ͅ"],
         "regular": ak.Array(
             ak.contents.RegularArray(
                 ak.contents.NumpyArray([1, 2, 3, 4, 5, 6, 7, 8, 9]), 3
@@ -110,20 +111,21 @@ def test_writing_then_reading_with_ROOT(tmp_path, capfd):
         in out
     )
     assert "* Field 6            : string (std::string)" in out
-    assert "* Field 7            : regular (std::array<std::int64_t,3>)" in out
-    assert "* Field 8            : numpy_regular (std::array<std::int64_t,3>)" in out
-    assert "* Field 9            : struct" in out
-    assert "* Field 10           : struct_list" in out
-    assert "* Field 11           : tuple (std::tuple<std::int64_t,std::int64_t>)" in out
+    assert "* Field 7            : utf8_string (std::string)" in out
+    assert "* Field 8            : regular (std::array<std::int64_t,3>)" in out
+    assert "* Field 9            : numpy_regular (std::array<std::int64_t,3>)" in out
+    assert "* Field 10           : struct" in out
+    assert "* Field 11           : struct_list" in out
+    assert "* Field 12           : tuple (std::tuple<std::int64_t,std::int64_t>)" in out
     assert (
-        "* Field 12           : tuple_list (std::vector<std::tuple<std::int64_t>>)"
+        "* Field 13           : tuple_list (std::vector<std::tuple<std::int64_t>>)"
         in out
     )
-    assert "* Field 13           : optional (std::optional<std::int64_t>)" in out
+    assert "* Field 14           : optional (std::optional<std::int64_t>)" in out
     assert (
-        "* Field 14           : union (std::variant<std::int64_t,std::string>)" in out
+        "* Field 15           : union (std::variant<std::int64_t,std::string>)" in out
     )
     assert (
-        "* Field 15           : optional_union (std::variant<std::optional<std::int64..."
+        "* Field 16           : optional_union (std::variant<std::optional<std::int64..."
         in out
     )

--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -1,0 +1,83 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import json
+import os
+import queue
+import sys
+
+import numpy
+import pytest
+import skhep_testdata
+
+import uproot
+
+ak = pytest.importorskip("awkward")
+
+data = ak.Array(
+    {
+        "bool": [True, False, True],
+        "int": [1, 2, 3],
+        "float": [1.1, 2.2, 3.3],
+        "jagged_list": [[1], [2, 3], [4, 5, 6]],
+        "nested_list": [[[1], []], [[2], [3, 3]], [[4, 5, 6]]],
+        "string": ["one", "two", "three"],
+        "regular": ak.Array(
+            ak.contents.RegularArray(
+                ak.contents.NumpyArray([1, 2, 3, 4, 5, 6, 7, 8, 9]), 3
+            )
+        ),
+        "numpy_regular": numpy.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+        "struct": [{"x": 1, "y": 2}, {"x": 3, "y": 4}, {"x": 5, "y": 6}],
+        "struct_list": [
+            [{"x": 1}, {"x": 2}],
+            [{"x": 3}, {"x": 4}],
+            [{"x": 5}, {"x": 6}],
+        ],
+        "tuple": [(1, 2), (3, 4), (5, 6)],
+        "tuple_list": [[(1,), (2,)], [(3,), (4,)], [(5,), (6,)]],
+    }
+)
+
+
+def test_writing_and_reading(tmp_path):
+    filepath = os.path.join(tmp_path, "test.root")
+
+    with uproot.recreate(filepath) as file:
+        obj = file.mkrntuple("ntuple", data.layout.form)
+        obj.extend(data)
+        obj.extend(data)  # test multiple cluster groups
+
+    obj = uproot.open(filepath)["ntuple"]
+    arrays = obj.arrays()
+
+    for f in data.fields:
+        if "tuple" in f:
+            # TODO: tuples are converted to records
+            continue
+        assert arrays[f][:3].tolist() == data[f].tolist()
+        assert arrays[f][3:].tolist() == data[f].tolist()
+
+
+def test_writing_then_reading_with_ROOT(tmp_path, capfd):
+    ROOT = pytest.importorskip("ROOT")
+
+    filepath = os.path.join(tmp_path, "test.root")
+
+    with uproot.recreate(filepath) as file:
+        obj = file.mkrntuple("ntuple", data.layout.form)
+        obj.extend(data)
+        obj.extend(data)  # test multiple cluster groups
+
+    RT = ROOT.Experimental.RNTupleReader.Open("ntuple", filepath)
+    RT.PrintInfo()
+    RT.Show(0)
+    RT.Show(2)
+    out = capfd.readouterr().out
+    assert "* N-Tuple : ntuple" in out
+    assert "* Entries : 3" in out
+    assert "* Field 1   : one (std::int64_t)" in out
+    assert "* Field 2   : two (double)" in out
+    assert '  "one": 1,' in out
+    assert '  "two": 1.1' in out
+    assert '  "one": 3' in out
+    assert '  "two": 3.3' in out


### PR DESCRIPTION
This PR extend the writing functionality for RNTuples quite a bit. It adds the following:

- Lists of booleans
- Lists of strings
- Jagged arrays (including nested jagged arrays)
- Rectangular arrays
- Structs
- Lists of structs
- Optional types
- Union types