### PR TITLE
chore: add XRootD on macos

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,7 +59,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no localhost echo "ssh connection successful"
 
       - name: Install XRootD
-        if: runner.os != 'macOS' && runner.os != 'Windows'
+        if: runner.os != 'Windows'
         run: |
           conda env list
           mamba install xrootd


### PR DESCRIPTION
fixes https://github.com/scikit-hep/uproot5/issues/1384

XRootD is officially supported on the following platforms:

  RedHat Enterprise Linux 8 or later and their derivatives
  Debian 11 and Ubuntu 22.04 or later
  macOS 13 (Ventura) or later

Support for other operating systems is provided on a best-effort basis and by contributions from the community.
