### PR TITLE
ci: switch to micromamba

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
           use-mamba: true
-          mamba-version: 2.0.5 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
+          mamba-version: 2.0.4 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          conda-remove-defaults: true
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
           use-mamba: true
-          mamba-version: 2.0.6.rc3 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
+          mamba-version: 2.0.6 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,13 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Get micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          conda-remove-defaults: true
+          init-shell: bash
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"
@@ -43,9 +42,9 @@ jobs:
       - name: Install ROOT
         if: matrix.python-version == 3.9  &&  runner.os != 'macOS'  &&  runner.os != 'Windows'
         run: |
-          conda env list
-          conda install root
-          conda list
+          micromamba env list
+          micromamba install root
+          micromamba list
 
       - name: Install sshd for fsspec ssh tests
         if: runner.os != 'macOS' && runner.os != 'Windows'
@@ -61,9 +60,9 @@ jobs:
       - name: Install XRootD
         if: runner.os != 'Windows'
         run: |
-          conda env list
-          conda install xrootd
-          conda list
+          micromamba env list
+          micromamba install xrootd
+          micromamba list
 
       - name: Pip install the package
         run: python -m pip install .[test,dev]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
           use-mamba: true
-          mamba-version: 2.0.6 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
+          mamba-version: 2.0.7 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Get micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
+          environment-name: test-env
           init-shell: bash
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
           use-mamba: true
-          mamba-version: 2.0.4 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
+          mamba-version: 2.0.6.rc3 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,14 +41,14 @@ jobs:
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"
 
       - name: Install ROOT
-        if: matrix.python-version == 3.9  &&  runner.os != 'macOS'  &&  runner.os != 'Windows'
+        if: matrix.python-version == 3.9  &&  runner.os == 'Linux'
         run: |
           micromamba env list
           micromamba install root
           micromamba list
 
       - name: Install sshd for fsspec ssh tests
-        if: runner.os != 'macOS' && runner.os != 'Windows'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get install -y openssh-server
           sudo service ssh restart

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,6 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
           use-mamba: true
+          mamba-version: 2.0.5 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          miniforge-version: latest
-          use-mamba: true
-          mamba-version: 2.0.7 # FIXME: Unpin when conda-incubator/setup-miniconda#392 is fixed
 
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.python-version == 3.9  &&  runner.os != 'macOS'  &&  runner.os != 'Windows'
         run: |
           conda env list
-          mamba install root
+          conda install root
           conda list
 
       - name: Install sshd for fsspec ssh tests
@@ -60,7 +60,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           conda env list
-          mamba install xrootd
+          conda install xrootd
           conda list
 
       - name: Pip install the package


### PR DESCRIPTION
I'm pinning the Mamba version that the CI uses so that it stops being so unreliable. The issue was reported in conda-incubator/setup-miniconda#392 but it's been a while and it hasn't been fixed. The suggestion they have there is to pin the Mamba version, so that's what I'm doing. I'll run the tests a few times to make sure that this fix works and then I'll mark it as ready for review.

Closes #1391 