### PR TITLE
fix: compress RNTuple column data

### DIFF
--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -964,7 +964,12 @@ class NTuple(CascadeNode):
             raw_data = col_data.reshape(-1).view("uint8")
             if col_data.dtype == numpy.dtype("bool"):
                 raw_data = numpy.packbits(raw_data, bitorder="little")
-            page_key = self.add_rblob(sink, raw_data, len(raw_data))
+            uncompressed_bytes = len(raw_data)
+            # Need better logic to specify per-column/field compression
+            raw_data = uproot.compression.compress(
+                raw_data, self._directory.freesegments.fileheader.compression
+            )
+            page_key = self.add_rblob(sink, raw_data, uncompressed_bytes)
             page_locator = NTuple_Locator(
                 len(raw_data), page_key.location + page_key.allocation
             )

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -1950,7 +1950,7 @@ class WritableNTuple:
         path (tuple of str): Path of directory names to this RNTuple.
         file (:doc:`uproot.writing.writable.WritableFile`): Handle to the file in
             which this RNTuple can be found.
-        cascading (:doc:`uproot.writing._cascadetree.NTuple`): The low-level
+        cascading (:doc:`uproot.writing._cascadentuple.NTuple`): The low-level
             directory object.
 
     Represents a writable ``RNTuple`` from a ROOT file.


### PR DESCRIPTION
RNTuple data was being stored fully uncompressed, which was pretty wasteful. This small PR makes it so that it is stored compressed with the compression setting from the file. It would be good to have the option of selecting compression settings in a more granular way (i.e. per field or column), but I'll have to think a bit more how to implement this since it would make more sense to specify it per column, but it would be a lot easier to specify it per field.