### PR TITLE
chore: better error message when writing TBaskets that are too large

### DIFF
--- a/src/uproot/const.py
+++ b/src/uproot/const.py
@@ -12,6 +12,8 @@ import numpy
 # determines when a file is "big"
 kStartBigFile = 2000000000
 
+kMaxTBasketBytes = numpy.iinfo(numpy.int32).max
+
 # used in unmarshaling
 kByteCountMask = numpy.int64(0x40000000)
 kByteCountVMask = numpy.int64(0x4000)

--- a/src/uproot/writing/_cascadetree.py
+++ b/src/uproot/writing/_cascadetree.py
@@ -1395,6 +1395,12 @@ class Tree:
         fObjlen = len(uncompressed_data)
         fNbytes = fKeylen + len(compressed_data)
 
+        if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
+            raise ValueError(
+                f"Numpy array data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
+                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket"
+            )
+
         parent_location = self._directory.key.location  # FIXME: is this correct?
 
         location = self._freesegments.allocate(fNbytes, dry_run=False)
@@ -1469,6 +1475,12 @@ class Tree:
 
         fObjlen = len(uncompressed_data)
         fNbytes = fKeylen + len(compressed_data)
+
+        if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
+            raise ValueError(
+                f"Jagged array data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
+                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket"
+            )
 
         parent_location = self._directory.key.location  # FIXME: is this correct?
 
@@ -1558,6 +1570,12 @@ class Tree:
 
         fObjlen = len(uncompressed_data)
         fNbytes = fKeylen + len(compressed_data)
+
+        if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
+            raise ValueError(
+                f"String data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
+                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket"
+            )
 
         parent_location = self._directory.key.location  # FIXME: is this correct?
 

--- a/src/uproot/writing/_cascadetree.py
+++ b/src/uproot/writing/_cascadetree.py
@@ -1395,7 +1395,7 @@ class Tree:
         fObjlen = len(uncompressed_data)
         fNbytes = fKeylen + len(compressed_data)
 
-        if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
+        if max(fObjlen, fNbytes) > uproot.const.kMaxTBasketBytes:
             raise ValueError(
                 f"Numpy array data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
                 f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket. "
@@ -1477,7 +1477,7 @@ class Tree:
         fObjlen = len(uncompressed_data)
         fNbytes = fKeylen + len(compressed_data)
 
-        if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
+        if max(fObjlen, fNbytes) > uproot.const.kMaxTBasketBytes:
             raise ValueError(
                 f"Jagged array data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
                 f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket. "
@@ -1573,7 +1573,7 @@ class Tree:
         fObjlen = len(uncompressed_data)
         fNbytes = fKeylen + len(compressed_data)
 
-        if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
+        if max(fObjlen, fNbytes) > uproot.const.kMaxTBasketBytes:
             raise ValueError(
                 f"String data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
                 f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket. "

--- a/src/uproot/writing/_cascadetree.py
+++ b/src/uproot/writing/_cascadetree.py
@@ -1398,7 +1398,8 @@ class Tree:
         if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
             raise ValueError(
                 f"Numpy array data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
-                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket"
+                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket. "
+                "Neither of these sizes can exceed 2 GiB."
             )
 
         parent_location = self._directory.key.location  # FIXME: is this correct?
@@ -1479,7 +1480,8 @@ class Tree:
         if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
             raise ValueError(
                 f"Jagged array data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
-                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket"
+                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket. "
+                "Neither of these sizes can exceed 2 GiB."
             )
 
         parent_location = self._directory.key.location  # FIXME: is this correct?
@@ -1574,7 +1576,8 @@ class Tree:
         if fObjlen > 2**31 - 1 or fNbytes > 2**31 - 1:
             raise ValueError(
                 f"String data of branch {branch_name} has an uncompressed size of {fObjlen} bytes "
-                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket"
+                f"and a compressed size of {fNbytes} bytes, which is too large to fit in a TBasket. "
+                "Neither of these sizes can exceed 2 GiB."
             )
 
         parent_location = self._directory.key.location  # FIXME: is this correct?


### PR DESCRIPTION
In #1135 there are some discussion about writing batches of data that are too big to fit in a TBasket. I added more detailed error messages so that it is clear what went wrong, since the way it currently crashes is not very informative.