### PR TITLE
feat: support writing ListArrays to RNTuples

### DIFF
--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -39,6 +39,11 @@ data = ak.Array(
         "optional": [1, None, 2],
         "union": [1, 2, "three"],
         "optional_union": [1, None, "three"],
+        "list_array": ak.contents.ListArray(
+            ak.index.Index([1, 0, 3]),
+            ak.index.Index([1, 2, 4]),
+            ak.contents.NumpyArray([0, 1, 2, 3, 4, 5]),
+        ),
     }
 )
 
@@ -125,3 +130,4 @@ def test_writing_then_reading_with_ROOT(tmp_path, capfd):
         "* Field 16           : optional_union (std::variant<std::optional<std::int64..."
         in out
     )
+    assert "* Field 17           : list_array (std::vector<std::int64_t>)" in out


### PR DESCRIPTION
This PR adds support for writing `ListArray`s to RNTuples. RNTuples have an analogue for this, so they are converted to `ListOffsetArray`s before writing them.

There are still some array types that can't be written, but each of them requires special handling since again there are no analogues in RNTuple. I'll continue to add them over time.