### PR TITLE
fix: issue with empty big_endian array

### DIFF
--- a/src/uproot/writing/_cascadetree.py
+++ b/src/uproot/writing/_cascadetree.py
@@ -735,7 +735,7 @@ class Tree:
                             )
                         )
                     tofill.append((branch_name, datum["compression"], big_endian, None))
-                    if datum["kind"] == "counter":
+                    if datum["kind"] == "counter" and big_endian.size > 0:
                         datum["tleaf_maximum_value"] = max(
                             big_endian.max(), datum["tleaf_maximum_value"]
                         )


### PR DESCRIPTION
Fixes problem with 0-length arrays and writing, e.g.:

```python
import uproot

events = uproot.dask({"coffea/tests/samples/nano_dy.root": "Events"})

uproot.dask_write(
  events[events.nJet > 10],  # cuts away all events
  destination="skimtest/",
  prefix="nano_dy/skimmed",
  compute=True,
)
```