### PR TITLE
fix: safer branch title access

### DIFF
--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -460,7 +460,7 @@ def _awkward_json_to_array(awkward, form, array):
 
 def _awkward_add_doc(awkward, array, branch, ak_add_doc):
     if ak_add_doc:
-        return awkward.with_parameter(array, "__doc__", branch.title)
+        return awkward.with_parameter(array, "__doc__", getattr(branch, "title", ""))
     else:
         return array
 


### PR DESCRIPTION
This happens when writing a length-0 coffea NanoEvents array with uproot and then reading it again (reported on coffea Mattermost channel). uproot wants to add the branch title as the `__doc__` parameter to the awkward array, but fails if it isn't present. This PR looses this requirement a bit and adds an empty string instead of a failure.