### PR TITLE
ci: pin Chrome version for Pyodide tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -175,8 +175,8 @@ jobs:
         uses: pyodide/pyodide-actions/install-browser@v2
         with:
           runner: selenium
-          browser: node
-          browser-version: 20
+          browser: chrome
+          browser-version: 1446681
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
@@ -184,7 +184,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest -vv --dist-dir=./pyodide-dist/ --runner=selenium --runtime=node tests-wasm
+          pytest -vv --dist-dir=./pyodide-dist/ --runner=selenium --runtime=chrome tests-wasm
 
   pass:
     if: always()

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           runner: selenium
           browser: chrome
-          browser-version: 137.0.7125
+          browser-version: 1446681
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -127,8 +127,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      PYODIDE_VERSION: 0.27.3
-      PYODIDE_BUILD_VERSION: 0.29.3
+      PYODIDE_VERSION: 0.27.5
+      PYODIDE_BUILD_VERSION: 0.30.0
       AWKWARD_VERSION: v2.7.4
 
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest -vv --dist-dir=./pyodide-dist/ --runner=selenium --runtime=chrome tests-wasm
+          pytest -vv --dist-dir=./pyodide-dist/ --runner=selenium --runtime=node tests-wasm
 
   pass:
     if: always()

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           runner: selenium
           browser: chrome
-          browser-version: latest
+          browser-version: 137.0.7125
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -175,8 +175,8 @@ jobs:
         uses: pyodide/pyodide-actions/install-browser@v2
         with:
           runner: selenium
-          browser: chrome
-          browser-version: 1446681
+          browser: node
+          browser-version: 20
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies

--- a/tests-wasm/utils.py
+++ b/tests-wasm/utils.py
@@ -10,10 +10,23 @@ import pytest
 import skhep_testdata
 
 try:
+    import pytest_pyodide
     from pytest_pyodide import run_in_pyodide
     from pytest_pyodide.decorator import copy_files_to_pyodide
 except ImportError:
     pytest.skip("Pyodide is not available", allow_module_level=True)
+
+# Disable CORS so that we can fetch files for http tests
+# Currently, this can only be done for Chrome
+selenium_config = pytest_pyodide.config.get_global_config()
+selenium_config.set_flags(
+    "chrome",
+    [
+        *selenium_config.get_flags("chrome"),
+        "--disable-web-security",
+        "--disable-site-isolation-trials",
+    ],
+)
 
 
 # copy skhep_testdata files to testdata directory (needed for @copy_files_to_pyodide)

--- a/tests-wasm/utils.py
+++ b/tests-wasm/utils.py
@@ -10,23 +10,10 @@ import pytest
 import skhep_testdata
 
 try:
-    import pytest_pyodide
     from pytest_pyodide import run_in_pyodide
     from pytest_pyodide.decorator import copy_files_to_pyodide
 except ImportError:
     pytest.skip("Pyodide is not available", allow_module_level=True)
-
-# Disable CORS so that we can fetch files for http tests
-# Currently, this can only be done for Chrome
-selenium_config = pytest_pyodide.config.get_global_config()
-selenium_config.set_flags(
-    "chrome",
-    [
-        *selenium_config.get_flags("chrome"),
-        "--disable-web-security",
-        "--disable-site-isolation-trials",
-    ],
-)
 
 
 # copy skhep_testdata files to testdata directory (needed for @copy_files_to_pyodide)


### PR DESCRIPTION
I'm updating the version of Pyodide that the CI uses to see if it fixes the issue we started to see in #1420.