### PR TITLE
chore: move to using dependency-groups

### DIFF
--- a/.github/workflows/build-distributions.yml
+++ b/.github/workflows/build-distributions.yml
@@ -14,19 +14,4 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build sdist and wheel
-        run: pipx run build
-
-      - name: Check metadata
-        run: pipx run twine check --strict dist/*
-
-      - name: List contents of sdist
-        run: python -m tarfile --list dist/uproot-*.tar.gz
-
-      - name: List contents of wheel
-        run: python -m zipfile --list dist/uproot-*.whl
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: distribution-artifact
-          path: dist/*
+      - uses: hynek/build-and-inspect-python-package@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,6 +37,8 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
 
+      - uses: astral-sh/setup-uv@v5
+
       - name: Check active Python version
         run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"
 
@@ -66,7 +68,7 @@ jobs:
           micromamba list
 
       - name: Pip install the package
-        run: python -m pip install .[test,dev]
+        run: uv pip install --system -e. --group=dev
 
       - name: Run pytest
         run: |
@@ -93,7 +95,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
 
       - name: Pip install the package
-        run: uv pip install --system .[test,dev]
+        run: uv pip install --system -e. --group=dev
 
       - name: Run pytest
         run: |
@@ -116,12 +118,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: astral-sh/setup-uv@v5
+
       - name: Pip install the package
-        run: python -m pip install 'numpy<2' .[test]
+        run: |
+          uv venv
+          uv pip install -e. 'numpy<2' --group test
 
       - name: Run pytest
         run: |
-          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|ssl|timeout|expired|connection|socket"
+          uv run --no-sync pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|ssl|timeout|expired|connection|socket"
 
   pyodide-build:
     runs-on: ubuntu-latest
@@ -139,6 +145,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v5
 
       - name: Install pyodide-build
         run: python3 -m pip install pyodide-build==$PYODIDE_BUILD_VERSION
@@ -180,7 +188,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
-        run: pip install .[test-pyodide] pyodide-py==$PYODIDE_VERSION
+        run: uv pip install --system -e. --group=test-pyodide pyodide-py==$PYODIDE_VERSION
 
       - name: Run pytest
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: distribution-artifact
+          name: Packages
           path: dist
 
       - name: List distributions to be deployed

--- a/.github/workflows/upload-nightly-wheels.yml
+++ b/.github/workflows/upload-nightly-wheels.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: distribution-artifact
+          name: Packages
           path: dist
 
       - name: List wheel to be deployed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ This guide will help you get started with contributing.
    pip install awkward-pandas
    pip install pytest-timeout
    pip install fsspec-xrootd
+   pip install uv
 
    # Run local HTTP server (if needed for test data)
    python -m RangeHTTPServer
@@ -50,7 +51,7 @@ This guide will help you get started with contributing.
 
 4. **Install Uproot in editable mode**:
    ```bash
-   pip install -e ."[dev,test]"
+   uv pip install -e. --group=dev
    ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,42 @@ requires = [
   "hatch-vcs"
 ]
 
+[dependency-groups]
+dev = [
+  {include-group = "extra"},
+  {include-group = "test"}
+]
+extra = [
+  "boost_histogram>=0.13",
+  "dask-awkward>=2025.2.0",
+  "dask[array,distributed] !=2025.4.0",
+  "hist>=1.2",
+  "pandas",
+  "awkward-pandas"
+]
+test = [
+  "aiohttp",
+  "deflate",
+  "fsspec-xrootd>=0.5.0",
+  "isal",
+  "minio",
+  "paramiko",
+  "pytest-rerunfailures",
+  "rangehttpserver",
+  "requests",
+  "s3fs",
+  {include-group = "test-core"}
+]
+test-core = [
+  "pytest-timeout",
+  "pytest>=6",
+  "scikit-hep-testdata"
+]
+test-pyodide = [
+  "pytest-pyodide; python_version >='3.11'",
+  {include-group = "test-core"}
+]
+
 [lint.mccabe]
 max-complexity = 100
 
@@ -43,7 +79,7 @@ dependencies = [
   "numpy",
   "fsspec",
   "packaging",
-  "typing_extensions>=4.1.0; python_version < \"3.11\""
+  "typing_extensions>=4.1.0; python_version < '3.11'"
 ]
 description = "ROOT I/O in pure Python and NumPy."
 dynamic = [
@@ -55,37 +91,8 @@ readme = "README.md"
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-dev = [
-  "boost_histogram>=0.13",
-  "dask-awkward>=2025.2.0",
-  "dask[array,distributed]",
-  "hist>=1.2",
-  "pandas",
-  "awkward-pandas"
-]
 http = ["aiohttp"]
 s3 = ["s3fs"]
-test = [
-  "isal",
-  "deflate",
-  "minio",
-  "aiohttp",
-  "fsspec-xrootd>=0.5.0",
-  "s3fs",
-  "paramiko",
-  "pytest>=6",
-  "pytest-timeout",
-  "pytest-rerunfailures",
-  "requests",
-  "scikit-hep-testdata",
-  "rangehttpserver"
-]
-test-pyodide = [
-  "pytest>=6",
-  "pytest-pyodide",
-  "pytest-timeout",
-  "scikit-hep-testdata"
-]
 xrootd = ["fsspec-xrootd>=0.5.0"]
 
 [project.urls]


### PR DESCRIPTION
Using more uv (faster), switching to dependency groups. `uv run ...` now works.

Includes restriction on dask due to https://github.com/dask/dask/pull/11859.