### PR TITLE
chore(deps): unconstrain Dask dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
 extra = [
   "boost_histogram>=0.13",
   "dask-awkward>=2025.2.0",
-  "dask[array,distributed] !=2025.4.0",
+  "dask[array,distributed]",
   "hist>=1.2",
   "pandas",
   "awkward-pandas"


### PR DESCRIPTION
The version of Dask was constrained in #1427 since we thought that they introduced a bug. However, the issue seems to be with the interface between `dask-awkward` and `dask`, so they are taking care of it on that side (see https://github.com/dask-contrib/dask-awkward/pull/588).