### PR TITLE
fix: Only dispatch requests to Source if we actually will use them

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -3096,8 +3096,6 @@ def _ranges_or_baskets_to_arrays(
         ):
             branchid_to_branch[cache_key]._awkward_check(interpretation)
 
-    hasbranches._file.source.chunks(ranges, notifications=notifications)
-
     def replace(ranges_or_baskets, original_index, basket):
         branch, basket_num, range_or_basket = ranges_or_baskets[original_index]
         ranges_or_baskets[original_index] = branch, basket_num, basket
@@ -3175,6 +3173,13 @@ def _ranges_or_baskets_to_arrays(
             notifications.put(sys.exc_info())
         else:
             notifications.put(None)
+
+    if len(arrays) == len(branchid_interpretation):
+        # all arrays are already in the cache
+        return
+
+    # Request all chunks and then poll notifications queue until we have all the arrays we expect
+    hasbranches._file.source.chunks(ranges, notifications=notifications)
 
     while len(arrays) < len(branchid_interpretation):
         obj = notifications.get()


### PR DESCRIPTION
The notifications queue in _ranges_or_baskets_to_arrays cannot be aware of chunk requests in flight because the queue only gets pushed to when we receive the returned chunk data. If we have the necessary array in cache, then we exit this function and fire-and-forget chunk requests causing extra network traffic, and more to the point, potential race conditions between receiving chunks and closing the file on teardown.

Fixes https://github.com/scikit-hep/coffea/issues/1331