### PR TITLE
ci: change pre-commit autoupdate to a monthly schedule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autoupdate_commit_msg: 'chore: update pre-commit hooks'
   autofix_commit_msg: 'style: pre-commit fixes'
+  autoupdate_schedule: monthly
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Almost every week there is a PR updating some pre-commit hook, and almost always they don't make any difference. I'm changing the autoupdate schedule so that it only runs monthly.

Henry convinced me to leave the dependabot updates on a weekly schedule since they don't trigger as often and are more important.