### PR TITLE
perf: faster reading of files with many branches

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -17,6 +17,7 @@ import re
 import sys
 import threading
 from collections.abc import Iterable, Mapping, MutableMapping
+from keyword import iskeyword
 
 import numpy
 
@@ -2923,7 +2924,7 @@ def _regularize_expressions(
             ):
                 branchname_expression = (
                     branchname
-                    if branchname.isalnum()
+                    if branchname.isidentifier() and not iskeyword(branchname)
                     else language.getter_of(branchname)
                 )
                 _regularize_expression(

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2923,7 +2923,7 @@ def _regularize_expressions(
             ):
                 _regularize_expression(
                     hasbranches,
-                    language.getter_of(branchname),
+                    branchname,
                     keys,
                     aliases,
                     language,

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1965,7 +1965,9 @@ class TBranch(HasBranches):
         """
         if self._cache_key is None:
             sep = ":" if isinstance(self._parent, uproot.behaviors.TTree.TTree) else "/"
-            self._cache_key = f"{self.parent.cache_key}{sep}{self.name}({self.index})"
+            self._cache_key = (
+                f"{self.parent.cache_key}{sep}{self.name}({self.member('fOffset')})"
+            )
         return self._cache_key
 
     @property

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1978,6 +1978,7 @@ class TBranch(HasBranches):
         non-recursive index is always unique.
         """
         if not hasattr(self, "_index"):
+            # cache index of all branches of the parent to avoid repeating this loop for other branches
             for i, branch in enumerate(self.parent.branches):
                 branch._index = i
         return self._index

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1965,9 +1965,7 @@ class TBranch(HasBranches):
         """
         if self._cache_key is None:
             sep = ":" if isinstance(self._parent, uproot.behaviors.TTree.TTree) else "/"
-            self._cache_key = (
-                f"{self.parent.cache_key}{sep}{self.name}({self.member('fOffset')})"
-            )
+            self._cache_key = f"{self.parent.cache_key}{sep}{self.name}({self.index})"
         return self._cache_key
 
     @property
@@ -1979,11 +1977,10 @@ class TBranch(HasBranches):
         :ref:`uproot.behaviors.TBranch.TBranch.name` is not unique: the
         non-recursive index is always unique.
         """
-        for i, branch in enumerate(self.parent.branches):
-            if branch is self:
-                return i
-        else:
-            raise AssertionError
+        if not hasattr(self, "_index"):
+            for i, branch in enumerate(self.parent.branches):
+                branch._index = i
+        return self._index
 
     @property
     def interpretation(self):

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2923,9 +2923,14 @@ def _regularize_expressions(
                     uproot.interpretation.grouped.AsGrouped,
                 ),
             ):
+                branchname_expression = (
+                    branchname
+                    if branchname.isalnum()
+                    else language.getter_of(branchname)
+                )
                 _regularize_expression(
                     hasbranches,
-                    branchname,
+                    branchname_expression,
                     keys,
                     aliases,
                     language,


### PR DESCRIPTION
This PR fixes #1442 (at least partially). It's not clear to me why this getter is needed, but it has a huge performance cost, so I switched to using the branch names directly.

This change gives it a huge boost in performance for trees with many branches, although it is still significantly slower than Uproot3.

For comparison, I generated a file with 1000 branches, as done in #1442 and the output of
```python
%timeit uproot.open("test.root:df").arrays(library="pd")
```
went from
```
3.07 s ± 46.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
to
```
353 ms ± 7.82 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

@ianna do you know why this getter could have been needed in the first place? All the tests seem to pass, so I'm not sure why it was needed.