### PR TITLE
fix: resolve issues with ROOT 6.36+

### DIFF
--- a/src/uproot/pyroot.py
+++ b/src/uproot/pyroot.py
@@ -100,17 +100,18 @@ public:
 };
 
 char* _uproot_TMessage_reallocate(char* buffer, size_t newsize, size_t oldsize) {
-    _Uproot_buffer_sizer* ptr = reinterpret_cast<_Uproot_buffer_sizer*>(
-        (void*)TPython::Eval("__import__('uproot').pyroot.pyroot_to_buffer.sizer")
-    );
+    std::any pyptr;
+    TPython::Exec("pyptr = __import__('uproot').pyroot.pyroot_to_buffer.sizer", &pyptr);
+    _Uproot_buffer_sizer* ptr = std::any_cast<_Uproot_buffer_sizer*>(pyptr);
     ptr->buffer = reinterpret_cast<size_t>(buffer);
     ptr->newsize = newsize;
     ptr->oldsize = oldsize;
 
     TPython::Exec("__import__('uproot').pyroot.pyroot_to_buffer.reallocate()");
 
-    TPyReturn out = TPython::Eval("__import__('uproot').pyroot.pyroot_to_buffer.buffer.ctypes.data");
-    return reinterpret_cast<char*>((size_t)out);
+    std::any out;
+    TPython::Exec("out = __import__('uproot').pyroot.pyroot_to_buffer.buffer.ctypes.data", &out);
+    return std::any_cast<char*>(out);
 }
 
 void _uproot_TMessage_SetBuffer(TMessage& message, void* buffer, UInt_t newsize) {

--- a/tests/test_0705_rntuple_writing_metadata.py
+++ b/tests/test_0705_rntuple_writing_metadata.py
@@ -73,7 +73,7 @@ def test_writable(tmp_path):
 
 def test_ROOT(tmp_path, capfd):
     ROOT = pytest.importorskip("ROOT")
-    if ROOT.gROOT.GetVersionInt() < 63500:
+    if ROOT.gROOT.GetVersionInt() < 63400:
         pytest.skip("ROOT version does not support RNTuple v1.0.0.0")
 
     filepath = os.path.join(tmp_path, "test.root")
@@ -87,7 +87,10 @@ def test_ROOT(tmp_path, capfd):
             ["one", "two"],
         )
         file.mkrntuple("ntuple", akform)
-    RT = ROOT.Experimental.RNTupleReader.Open("ntuple", filepath)
+    if ROOT.gROOT.GetVersionInt() < 63600:
+        RT = ROOT.Experimental.RNTupleReader.Open("ntuple", filepath)
+    else:
+        RT = ROOT.RNTupleReader.Open("ntuple", filepath)
     RT.PrintInfo()
     out = capfd.readouterr().out
     assert "* Field 1   : one (double)" in out

--- a/tests/test_1356_basic_rntuple_writing.py
+++ b/tests/test_1356_basic_rntuple_writing.py
@@ -31,6 +31,8 @@ def test_flat_arrays(tmp_path):
 
 def test_flat_arrays_ROOT(tmp_path, capfd):
     ROOT = pytest.importorskip("ROOT")
+    if ROOT.gROOT.GetVersionInt() < 63400:
+        pytest.skip("ROOT version does not support RNTuple v1.0.0.0")
 
     filepath = os.path.join(tmp_path, "test.root")
 
@@ -39,7 +41,10 @@ def test_flat_arrays_ROOT(tmp_path, capfd):
         obj = file.mkrntuple("ntuple", data.layout.form)
         obj.extend(data)
 
-    RT = ROOT.Experimental.RNTupleReader.Open("ntuple", filepath)
+    if ROOT.gROOT.GetVersionInt() < 63600:
+        RT = ROOT.Experimental.RNTupleReader.Open("ntuple", filepath)
+    else:
+        RT = ROOT.RNTupleReader.Open("ntuple", filepath)
     RT.PrintInfo()
     RT.Show(0)
     RT.Show(2)

--- a/tests/test_1395_rntuple_writing_lists_and_structs.py
+++ b/tests/test_1395_rntuple_writing_lists_and_structs.py
@@ -94,6 +94,8 @@ def test_writing_and_reading(tmp_path):
 
 def test_writing_then_reading_with_ROOT(tmp_path, capfd):
     ROOT = pytest.importorskip("ROOT")
+    if ROOT.gROOT.GetVersionInt() < 63400:
+        pytest.skip("ROOT version does not support RNTuple v1.0.0.0")
 
     filepath = os.path.join(tmp_path, "test.root")
 
@@ -102,7 +104,10 @@ def test_writing_then_reading_with_ROOT(tmp_path, capfd):
         obj.extend(data)
         obj.extend(data)  # test multiple cluster groups
 
-    RT = ROOT.Experimental.RNTupleReader.Open("ntuple", filepath)
+    if ROOT.gROOT.GetVersionInt() < 63600:
+        RT = ROOT.Experimental.RNTupleReader.Open("ntuple", filepath)
+    else:
+        RT = ROOT.RNTupleReader.Open("ntuple", filepath)
     RT.PrintInfo()
     RT.Show(0)
     RT.Show(2)


### PR DESCRIPTION
There `TPython::Eval` api was deprecated in ROOT 6.34 and removed in 6.36, so we have to switch to `TPython::Exec`.

The CI doesn't test with ROOT 6.36, but it works for me locally with 6.37.

Closes #1460