### PR TITLE
fix: support accessing RNTuple fields by full path

### DIFF
--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -2098,14 +2098,20 @@ class ReadOnlyDirectory(Mapping):
                             last = step
                             step = step[item]
 
-                    elif isinstance(step, uproot.behaviors.TBranch.HasBranches):
+                    elif isinstance(
+                        step,
+                        (
+                            uproot.behaviors.TBranch.HasBranches,
+                            uproot.behaviors.RNTuple.HasFields,
+                        ),
+                    ):
                         return step["/".join(items[i:])]
 
                     else:
                         raise uproot.KeyInFileError(
                             where,
                             because="/".join(items[:i])
-                            + " is not a TDirectory, TTree, or TBranch",
+                            + " is not a TDirectory, TTree, TBranch, RNTuple, or RField",
                             keys=[key.fName for key in last._keys],
                             file_path=self._file.file_path,
                         )

--- a/tests/test_1250_rntuple_improvements.py
+++ b/tests/test_1250_rntuple_improvements.py
@@ -12,12 +12,20 @@ def test_field_class():
         obj = f["ntuple"]
         my_struct = obj["my_struct"]
         assert len(my_struct) == 2
+        assert my_struct is f["ntuple/my_struct"]
+        assert my_struct is f["ntuple"]["my_struct"]
 
         sub_struct = my_struct["sub_struct"]
         assert len(my_struct) == 2
+        assert sub_struct is f["ntuple/my_struct/sub_struct"]
+        assert sub_struct is f["ntuple"]["my_struct"]["sub_struct"]
 
         sub_sub_struct = sub_struct["sub_sub_struct"]
         assert len(sub_sub_struct) == 2
+        assert sub_sub_struct is f["ntuple/my_struct/sub_struct/sub_sub_struct"]
+        assert (
+            sub_sub_struct is f["ntuple"]["my_struct"]["sub_struct"]["sub_sub_struct"]
+        )
 
         v = sub_sub_struct["v"]
         assert len(v) == 1


### PR DESCRIPTION
This PR makes it possible to access RNTuple fields directly from the file by specifying the full path.

This is needed to make Uproot Browser work with RNTuples (more easily). @henryiii 