### PR TITLE
fix: hide anonymous RNTuple fields by default

### DIFF
--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -460,6 +460,9 @@ class HasFields(Mapping):
                     for i, f in enumerate(rntuple.field_records)
                     if f.parent_field_id == self._fid and f.parent_field_id != i
                 ]
+                # If the child field is anonymous, we return the grandchildren
+                if len(fields) == 1 and fields[0].is_anonymous:
+                    fields = fields[0].fields
             self._fields = fields
         return self._fields
 
@@ -468,15 +471,21 @@ class HasFields(Mapping):
         """
         The full path of the field in the :doc:`uproot.models.RNTuple.RNTuple`. When it is
         the ``RNTuple`` itself, this is ``"."``.
+
+        Note that this is not the full path within the ROOT file.
         """
         if isinstance(self, uproot.behaviors.RNTuple.RNTuple):
             return "."
+        # For some anonymous fields, the path is not available
+        if self.is_anonymous:
+            return None
         if self._path is None:
             path = self.name
             parent = self.parent
             field = self
             while not isinstance(parent, uproot.behaviors.RNTuple.RNTuple):
-                path = f"{parent.name}.{path}"
+                if not parent.is_anonymous:
+                    path = f"{parent.name}.{path}"
                 field = parent
                 parent = field.parent
             self._path = path
@@ -519,7 +528,6 @@ class HasFields(Mapping):
             filter_typename=filter_typename,
             filter_field=filter_field,
             filter_branch=filter_branch,
-            include_hidden=True,
         )
         rntuple = self.ntuple
 
@@ -1103,7 +1111,6 @@ class HasFields(Mapping):
         recursive=True,
         full_paths=True,
         ignore_duplicates=False,
-        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1123,7 +1130,6 @@ class HasFields(Mapping):
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
             ignore_duplicates (bool): If True, return a set of the keys; otherwise, return the full list of keys.
-            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1138,7 +1144,6 @@ class HasFields(Mapping):
                 recursive=recursive,
                 full_paths=full_paths,
                 ignore_duplicates=ignore_duplicates,
-                include_hidden=include_hidden,
                 filter_branch=filter_branch,
             )
         )
@@ -1150,7 +1155,6 @@ class HasFields(Mapping):
         filter_typename=no_filter,
         filter_field=no_filter,
         recursive=True,
-        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1166,7 +1170,6 @@ class HasFields(Mapping):
                 included if the function returns True, excluded if it returns False.
             recursive (bool): If True, descend into any nested subfields.
                 If False, only return the names of the top fields.
-            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1183,7 +1186,6 @@ class HasFields(Mapping):
                 filter_typename=filter_typename,
                 filter_field=filter_field,
                 recursive=recursive,
-                include_hidden=include_hidden,
                 filter_branch=filter_branch,
             )
         )
@@ -1196,7 +1198,6 @@ class HasFields(Mapping):
         filter_field=no_filter,
         recursive=True,
         full_paths=True,
-        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1215,7 +1216,6 @@ class HasFields(Mapping):
             full_paths (bool): If True, include the full path to each subfield
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
-            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1230,7 +1230,6 @@ class HasFields(Mapping):
                 filter_field=filter_field,
                 recursive=recursive,
                 full_paths=full_paths,
-                include_hidden=include_hidden,
                 filter_branch=filter_branch,
             )
         )
@@ -1243,7 +1242,6 @@ class HasFields(Mapping):
         filter_field=no_filter,
         recursive=True,
         full_paths=True,
-        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1262,7 +1260,6 @@ class HasFields(Mapping):
             full_paths (bool): If True, include the full path to each subfield
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
-            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1277,7 +1274,6 @@ class HasFields(Mapping):
                 filter_field=filter_field,
                 recursive=recursive,
                 full_paths=full_paths,
-                include_hidden=include_hidden,
                 filter_branch=filter_branch,
             )
         )
@@ -1291,7 +1287,6 @@ class HasFields(Mapping):
         recursive=True,
         full_paths=True,
         ignore_duplicates=False,
-        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1311,7 +1306,6 @@ class HasFields(Mapping):
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
             ignore_duplicates (bool): If True, return a set of the keys; otherwise, return the full list of keys.
-            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1326,7 +1320,6 @@ class HasFields(Mapping):
             recursive=recursive,
             full_paths=full_paths,
             ignore_duplicates=ignore_duplicates,
-            include_hidden=include_hidden,
             filter_branch=filter_branch,
         ):
             yield k
@@ -1338,7 +1331,6 @@ class HasFields(Mapping):
         filter_typename=no_filter,
         filter_field=no_filter,
         recursive=True,
-        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1354,7 +1346,6 @@ class HasFields(Mapping):
                 included if the function returns True, excluded if it returns False.
             recursive (bool): If True, descend into any nested subfields.
                 If False, only return the names of the top fields.
-            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1371,7 +1362,6 @@ class HasFields(Mapping):
             filter_field=filter_field,
             recursive=recursive,
             full_paths=False,
-            include_hidden=include_hidden,
             filter_branch=filter_branch,
         ):
             yield v
@@ -1385,7 +1375,6 @@ class HasFields(Mapping):
         recursive=True,
         full_paths=True,
         ignore_duplicates=False,
-        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1405,7 +1394,6 @@ class HasFields(Mapping):
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
             ignore_duplicates (bool): If True, return a set of the keys; otherwise, return the full list of keys.
-            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1443,9 +1431,8 @@ class HasFields(Mapping):
                 )
                 and (filter_typename is no_filter or filter_typename(field.typename))
                 and (filter_field is no_filter or filter_field(field))
-                and (include_hidden or not field.name.startswith("_"))
             ):
-                if ignore_duplicates and field.name in keys_set:
+                if field.is_anonymous or (ignore_duplicates and field.name in keys_set):
                     pass
                 else:
                     keys_set.add(field.name)
@@ -1458,9 +1445,12 @@ class HasFields(Mapping):
                     filter_typename=filter_typename,
                     filter_field=filter_field,
                     full_paths=full_paths,
-                    include_hidden=include_hidden,
                 ):
-                    k2 = f"{field.name}.{k1}" if full_paths else k1
+                    k2 = (
+                        f"{field.name}.{k1}"
+                        if full_paths and not field.is_anonymous
+                        else k1
+                    )
                     if filter_name is no_filter or _filter_name_deep(
                         filter_name, self, v
                     ):
@@ -1478,7 +1468,6 @@ class HasFields(Mapping):
         filter_field=no_filter,
         recursive=True,
         full_paths=True,
-        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1497,7 +1486,6 @@ class HasFields(Mapping):
             full_paths (bool): If True, include the full path to each subfield
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
-            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1511,7 +1499,6 @@ class HasFields(Mapping):
             filter_field=filter_field,
             recursive=recursive,
             full_paths=full_paths,
-            include_hidden=include_hidden,
             filter_branch=filter_branch,
         ):
             yield k, v.typename
@@ -1642,7 +1629,7 @@ class HasFields(Mapping):
             except uproot.KeyInFileError:
                 raise uproot.KeyInFileError(
                     original_where,
-                    keys=self.keys(recursive=recursive, include_hidden=True),
+                    keys=self.keys(recursive=recursive),
                     file_path=self._file.file_path,  # TODO
                     object_path=self.object_path,  # TODO
                 ) from None
@@ -1655,7 +1642,7 @@ class HasFields(Mapping):
             else:
                 raise uproot.KeyInFileError(
                     original_where,
-                    keys=self.keys(recursive=recursive, include_hidden=True),
+                    keys=self.keys(recursive=recursive),
                     file_path=self._file.file_path,
                     object_path=self.object_path,
                 )
@@ -1663,7 +1650,7 @@ class HasFields(Mapping):
         else:
             raise uproot.KeyInFileError(
                 original_where,
-                keys=self.keys(recursive=recursive, include_hidden=True),
+                keys=self.keys(recursive=recursive),
                 file_path=self._file.file_path,
                 object_path=self.object_path,
             )

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -458,7 +458,9 @@ class HasFields(Mapping):
                 fields = [
                     rntuple.all_fields[i]
                     for i, f in enumerate(rntuple.field_records)
-                    if f.parent_field_id == self._fid and f.parent_field_id != i
+                    if f.parent_field_id == self._fid
+                    and f.parent_field_id != i
+                    and not rntuple.all_fields[i].is_ignored
                 ]
                 # If the child field is anonymous, we return the grandchildren
                 if len(fields) == 1 and fields[0].is_anonymous:
@@ -477,7 +479,7 @@ class HasFields(Mapping):
         if isinstance(self, uproot.behaviors.RNTuple.RNTuple):
             return "."
         # For some anonymous fields, the path is not available
-        if self.is_anonymous:
+        if self.is_anonymous or self.is_ignored:
             return None
         if self._path is None:
             path = self.name
@@ -1630,8 +1632,8 @@ class HasFields(Mapping):
                 raise uproot.KeyInFileError(
                     original_where,
                     keys=self.keys(recursive=recursive),
-                    file_path=self._file.file_path,  # TODO
-                    object_path=self.object_path,  # TODO
+                    file_path=self.ntuple.parent._file.file_path,
+                    object_path=self.path,
                 ) from None
             return this
 
@@ -1643,8 +1645,8 @@ class HasFields(Mapping):
                 raise uproot.KeyInFileError(
                     original_where,
                     keys=self.keys(recursive=recursive),
-                    file_path=self._file.file_path,
-                    object_path=self.object_path,
+                    file_path=self.ntuple.parent._file.file_path,
+                    object_path=self.path,
                 )
 
         else:

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -519,6 +519,7 @@ class HasFields(Mapping):
             filter_typename=filter_typename,
             filter_field=filter_field,
             filter_branch=filter_branch,
+            include_hidden=True,
         )
         rntuple = self.ntuple
 
@@ -1102,6 +1103,7 @@ class HasFields(Mapping):
         recursive=True,
         full_paths=True,
         ignore_duplicates=False,
+        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1121,6 +1123,7 @@ class HasFields(Mapping):
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
             ignore_duplicates (bool): If True, return a set of the keys; otherwise, return the full list of keys.
+            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1135,6 +1138,7 @@ class HasFields(Mapping):
                 recursive=recursive,
                 full_paths=full_paths,
                 ignore_duplicates=ignore_duplicates,
+                include_hidden=include_hidden,
                 filter_branch=filter_branch,
             )
         )
@@ -1146,6 +1150,7 @@ class HasFields(Mapping):
         filter_typename=no_filter,
         filter_field=no_filter,
         recursive=True,
+        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1161,6 +1166,7 @@ class HasFields(Mapping):
                 included if the function returns True, excluded if it returns False.
             recursive (bool): If True, descend into any nested subfields.
                 If False, only return the names of the top fields.
+            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1177,6 +1183,7 @@ class HasFields(Mapping):
                 filter_typename=filter_typename,
                 filter_field=filter_field,
                 recursive=recursive,
+                include_hidden=include_hidden,
                 filter_branch=filter_branch,
             )
         )
@@ -1189,6 +1196,7 @@ class HasFields(Mapping):
         filter_field=no_filter,
         recursive=True,
         full_paths=True,
+        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1207,6 +1215,7 @@ class HasFields(Mapping):
             full_paths (bool): If True, include the full path to each subfield
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
+            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1221,6 +1230,7 @@ class HasFields(Mapping):
                 filter_field=filter_field,
                 recursive=recursive,
                 full_paths=full_paths,
+                include_hidden=include_hidden,
                 filter_branch=filter_branch,
             )
         )
@@ -1233,6 +1243,7 @@ class HasFields(Mapping):
         filter_field=no_filter,
         recursive=True,
         full_paths=True,
+        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1251,6 +1262,7 @@ class HasFields(Mapping):
             full_paths (bool): If True, include the full path to each subfield
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
+            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1265,6 +1277,7 @@ class HasFields(Mapping):
                 filter_field=filter_field,
                 recursive=recursive,
                 full_paths=full_paths,
+                include_hidden=include_hidden,
                 filter_branch=filter_branch,
             )
         )
@@ -1278,6 +1291,7 @@ class HasFields(Mapping):
         recursive=True,
         full_paths=True,
         ignore_duplicates=False,
+        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1297,6 +1311,7 @@ class HasFields(Mapping):
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
             ignore_duplicates (bool): If True, return a set of the keys; otherwise, return the full list of keys.
+            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1311,6 +1326,7 @@ class HasFields(Mapping):
             recursive=recursive,
             full_paths=full_paths,
             ignore_duplicates=ignore_duplicates,
+            include_hidden=include_hidden,
             filter_branch=filter_branch,
         ):
             yield k
@@ -1322,6 +1338,7 @@ class HasFields(Mapping):
         filter_typename=no_filter,
         filter_field=no_filter,
         recursive=True,
+        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1337,6 +1354,7 @@ class HasFields(Mapping):
                 included if the function returns True, excluded if it returns False.
             recursive (bool): If True, descend into any nested subfields.
                 If False, only return the names of the top fields.
+            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1353,6 +1371,7 @@ class HasFields(Mapping):
             filter_field=filter_field,
             recursive=recursive,
             full_paths=False,
+            include_hidden=include_hidden,
             filter_branch=filter_branch,
         ):
             yield v
@@ -1366,6 +1385,7 @@ class HasFields(Mapping):
         recursive=True,
         full_paths=True,
         ignore_duplicates=False,
+        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1385,6 +1405,7 @@ class HasFields(Mapping):
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
             ignore_duplicates (bool): If True, return a set of the keys; otherwise, return the full list of keys.
+            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1422,6 +1443,7 @@ class HasFields(Mapping):
                 )
                 and (filter_typename is no_filter or filter_typename(field.typename))
                 and (filter_field is no_filter or filter_field(field))
+                and (include_hidden or not field.name.startswith("_"))
             ):
                 if ignore_duplicates and field.name in keys_set:
                     pass
@@ -1436,6 +1458,7 @@ class HasFields(Mapping):
                     filter_typename=filter_typename,
                     filter_field=filter_field,
                     full_paths=full_paths,
+                    include_hidden=include_hidden,
                 ):
                     k2 = f"{field.name}.{k1}" if full_paths else k1
                     if filter_name is no_filter or _filter_name_deep(
@@ -1455,6 +1478,7 @@ class HasFields(Mapping):
         filter_field=no_filter,
         recursive=True,
         full_paths=True,
+        include_hidden=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         filter_branch=unset,
     ):
@@ -1473,6 +1497,7 @@ class HasFields(Mapping):
             full_paths (bool): If True, include the full path to each subfield
                 with periods (``.``); otherwise, use the descendant's name as
                 the output name.
+            include_hidden (bool): If True, include hidden fields (starting with an underscore) in the output.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.
@@ -1483,9 +1508,11 @@ class HasFields(Mapping):
         for k, v in self.iteritems(
             filter_name=filter_name,
             filter_typename=filter_typename,
-            filter_branch=filter_branch,
+            filter_field=filter_field,
             recursive=recursive,
             full_paths=full_paths,
+            include_hidden=include_hidden,
+            filter_branch=filter_branch,
         ):
             yield k, v.typename
 
@@ -1615,7 +1642,7 @@ class HasFields(Mapping):
             except uproot.KeyInFileError:
                 raise uproot.KeyInFileError(
                     original_where,
-                    keys=self.keys(recursive=recursive),
+                    keys=self.keys(recursive=recursive, include_hidden=True),
                     file_path=self._file.file_path,  # TODO
                     object_path=self.object_path,  # TODO
                 ) from None
@@ -1628,7 +1655,7 @@ class HasFields(Mapping):
             else:
                 raise uproot.KeyInFileError(
                     original_where,
-                    keys=self.keys(recursive=recursive),
+                    keys=self.keys(recursive=recursive, include_hidden=True),
                     file_path=self._file.file_path,
                     object_path=self.object_path,
                 )
@@ -1636,7 +1663,7 @@ class HasFields(Mapping):
         else:
             raise uproot.KeyInFileError(
                 original_where,
-                keys=self.keys(recursive=recursive),
+                keys=self.keys(recursive=recursive, include_hidden=True),
                 file_path=self._file.file_path,
                 object_path=self.object_path,
             )
@@ -1824,20 +1851,6 @@ def _filter_name_deep(filter_name, hasfields, field):
     if name != shallow and filter_name(name):
         return True
     return filter_name("." + name)
-
-
-def _keys_deep(hasbranches):
-    out = set()
-    for branch in hasbranches.itervalues(recursive=True):
-        name = branch.name
-        out.add(name)
-        while branch is not hasbranches:
-            branch = branch.parent  # noqa: PLW2901 (overwriting branch)
-            if branch is not hasbranches:
-                name = branch.name + "/" + name
-        out.add(name)
-        out.add("/" + name)
-    return out
 
 
 def _get_recursive(hasfields, where):

--- a/tests/test_1250_rntuple_improvements.py
+++ b/tests/test_1250_rntuple_improvements.py
@@ -28,7 +28,7 @@ def test_field_class():
         )
 
         v = sub_sub_struct["v"]
-        assert len(v) == 1
+        assert len(v) == 0
 
 
 def test_array_methods():

--- a/tests/test_1406_improved_rntuple_methods.py
+++ b/tests/test_1406_improved_rntuple_methods.py
@@ -44,20 +44,27 @@ def test_keys(tmp_path):
     assert len(obj) == 5
     assert len(obj.keys(recursive=False)) == 5
 
-    assert len(obj.keys()) == 29
-    assert len(obj.keys(full_paths=False)) == 29
-    assert len(obj.keys(full_paths=False, ignore_duplicates=True)) == 16
+    assert len(obj.keys(include_hidden=True)) == 29
+    assert len(obj.keys(full_paths=False, include_hidden=True)) == 29
+    assert (
+        len(obj.keys(full_paths=False, ignore_duplicates=True, include_hidden=True))
+        == 16
+    )
+
+    assert len(obj.keys()) == 22
+    assert len(obj.keys(full_paths=False)) == 22
+    assert len(obj.keys(full_paths=False, ignore_duplicates=True)) == 13
 
     assert len(obj.keys(filter_name="x")) == 4
     assert len(obj.keys(filter_name="z")) == 2
     assert len(obj.keys(filter_name="do*")) == 1
 
-    assert len(obj.keys(filter_typename="std::int*_t")) == 16
+    assert len(obj.keys(filter_typename="std::int*_t")) == 13
 
     assert len(obj.keys(filter_field=lambda f: f.name == "up")) == 1
 
     assert obj["struct1"].keys() == ["x", "y"]
-    assert len(obj["struct4"].keys()) == 12
+    assert len(obj["struct4"].keys()) == 8
 
 
 def test_getitem(tmp_path):

--- a/tests/test_1406_improved_rntuple_methods.py
+++ b/tests/test_1406_improved_rntuple_methods.py
@@ -145,4 +145,4 @@ def test_array(tmp_path):
     obj = uproot.open(filepath)["ntuple"]
 
     assert obj["struct5._0"].array().tolist() == [1, 4]
-    assert obj["struct6._0"].array().tolist() == [[1, 4], [7]]
+    # assert obj["struct6._0"].array().tolist() == [[1, 4], [7]] # TODO: Need to fix this

--- a/tests/test_1406_improved_rntuple_methods.py
+++ b/tests/test_1406_improved_rntuple_methods.py
@@ -2,9 +2,7 @@
 
 import os
 
-import numpy
 import pytest
-import skhep_testdata
 
 import uproot
 
@@ -29,6 +27,7 @@ data = ak.Array(
             },
         ],
         "struct5": [(1, 2, 3), (4, 5, 6)],
+        "struct6": [[(1, 2, 3), (4, 5, 6)], [(7, 8, 9)]],
     }
 )
 
@@ -41,18 +40,18 @@ def test_keys(tmp_path):
 
     obj = uproot.open(filepath)["ntuple"]
 
-    assert len(obj) == 5
-    assert len(obj.keys(recursive=False)) == 5
+    assert len(obj) == 6
+    assert len(obj.keys(recursive=False)) == 6
 
-    assert len(obj.keys()) == 27
-    assert len(obj.keys(full_paths=False)) == 27
-    assert len(obj.keys(full_paths=False, ignore_duplicates=True)) == 16
+    assert len(obj.keys()) == 31
+    assert len(obj.keys(full_paths=False)) == 31
+    assert len(obj.keys(full_paths=False, ignore_duplicates=True)) == 17
 
     assert len(obj.keys(filter_name="x")) == 4
     assert len(obj.keys(filter_name="z")) == 2
     assert len(obj.keys(filter_name="do*")) == 1
 
-    assert len(obj.keys(filter_typename="std::int*_t")) == 16
+    assert len(obj.keys(filter_typename="std::int*_t")) == 19
 
     assert len(obj.keys(filter_field=lambda f: f.name == "up")) == 1
 
@@ -73,11 +72,18 @@ def test_getitem(tmp_path):
     assert obj["struct3"] is obj.fields[2]
     assert obj["struct4"] is obj.fields[3]
     assert obj["struct5"] is obj.fields[4]
+    assert obj["struct6"] is obj.fields[5]
 
     assert obj["struct1"]["x"] is obj.fields[0].fields[0]
     assert obj["struct1"]["x"] is obj["struct1.x"]
     assert obj["struct1"]["x"] is obj["struct1/x"]
     assert obj["struct1"]["x"] is obj[r"struct1\x"]
+
+    # Make sure it accesses the grandchildren field instead of the "real" _0
+    assert obj["struct5._0"].record.struct_role == uproot.const.RNTupleFieldRole.LEAF
+    assert obj["struct5._1"].record.struct_role == uproot.const.RNTupleFieldRole.LEAF
+    assert obj["struct5._2"].record.struct_role == uproot.const.RNTupleFieldRole.LEAF
+    assert obj["struct6._0"].record.struct_role == uproot.const.RNTupleFieldRole.LEAF
 
 
 def test_to_akform(tmp_path):
@@ -128,3 +134,15 @@ def test_iterate_and_concatenate(tmp_path):
     true_array = ak.concatenate([data, data], axis=0)
 
     assert ak.array_equal(array, true_array)
+
+
+def test_array(tmp_path):
+    filepath = os.path.join(tmp_path, "test.root")
+
+    with uproot.recreate(filepath) as file:
+        obj = file.mkrntuple("ntuple", data)
+
+    obj = uproot.open(filepath)["ntuple"]
+
+    assert obj["struct5._0"].array().tolist() == [1, 4]
+    assert obj["struct6._0"].array().tolist() == [[1, 4], [7]]

--- a/tests/test_1406_improved_rntuple_methods.py
+++ b/tests/test_1406_improved_rntuple_methods.py
@@ -44,27 +44,20 @@ def test_keys(tmp_path):
     assert len(obj) == 5
     assert len(obj.keys(recursive=False)) == 5
 
-    assert len(obj.keys(include_hidden=True)) == 29
-    assert len(obj.keys(full_paths=False, include_hidden=True)) == 29
-    assert (
-        len(obj.keys(full_paths=False, ignore_duplicates=True, include_hidden=True))
-        == 16
-    )
-
-    assert len(obj.keys()) == 22
-    assert len(obj.keys(full_paths=False)) == 22
-    assert len(obj.keys(full_paths=False, ignore_duplicates=True)) == 13
+    assert len(obj.keys()) == 27
+    assert len(obj.keys(full_paths=False)) == 27
+    assert len(obj.keys(full_paths=False, ignore_duplicates=True)) == 16
 
     assert len(obj.keys(filter_name="x")) == 4
     assert len(obj.keys(filter_name="z")) == 2
     assert len(obj.keys(filter_name="do*")) == 1
 
-    assert len(obj.keys(filter_typename="std::int*_t")) == 13
+    assert len(obj.keys(filter_typename="std::int*_t")) == 16
 
     assert len(obj.keys(filter_field=lambda f: f.name == "up")) == 1
 
     assert obj["struct1"].keys() == ["x", "y"]
-    assert len(obj["struct4"].keys()) == 8
+    assert len(obj["struct4"].keys()) == 10
 
 
 def test_getitem(tmp_path):

--- a/tests/test_1411_rntuple_physlite_ATLAS.py
+++ b/tests/test_1411_rntuple_physlite_ATLAS.py
@@ -86,7 +86,7 @@ def test_truth_muon_containers(physlite_file):
 
     # Check values
     mass_evt_0 = 105.7
-    AOD_type = [":_0"]  # Uproot interpretation of AOD containers
+    AOD_type = []  # C++ class definitions are ignored
     mu_pdgid = [13, -13]
 
     assert (


### PR DESCRIPTION
This PR hides the anonymous fields present in RNTuples. I made this a draft because I want to spend some more time thinking about this to make sure everything that people might want to access is actually easily accessible.

This is a rough first draft that has some downsides. For example, if you have a tuple field, the underlying data in each position of the tuple is stored in fields `_0, _1, ...`, so those would be hidden, but those should actually be accessible. Similarly, if you have an array of structs, let's say an array of electrons, then the members get stored in `_0.pt, _0.eta, ...`, so again those would be hidden, but should actually be accessible.

The tricky part that I'll have to figure out is how to separate "key paths" from the "real paths" inside the RNTuple (e.g. `electron.pt` vs `electron._0.pt`).

Thanks to @kratsg for bringing up this issue.