### PR TITLE
Allowing ATLAS-style file names for ROOT files

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -314,11 +314,18 @@ def file_object_path_split(urlpath: str) -> tuple[str, str | None]:
     separator = "::"
     parts = urlpath.split(separator)
     object_regex = re.compile(r"(.+\.root):(.*$)", re.IGNORECASE)
+    # Some files like "something.root.1" need to also be treated as ROOT files
+    object_regex_with_extra = re.compile(r"(.+\.root\.+[0-9]+):(.*$)", re.IGNORECASE)
     for i, part in enumerate(reversed(parts)):
         match = object_regex.match(part)
         if match:
             obj = re.sub(r"/+", "/", match.group(2).strip().lstrip("/")).rstrip("/")
             parts[-i - 1] = match.group(1)
+            break
+        match_with_extra = object_regex_with_extra.match(part)
+        if match_with_extra:
+            obj = re.sub(r"/+", "/", match_with_extra.group(2).strip().lstrip("/")).rstrip("/")
+            parts[-i - 1] = match_with_extra.group(1)
             break
 
     urlpath = separator.join(parts)


### PR DESCRIPTION
The ATLAS production system produces ROOT files with names like "something.root.1" (or "something.root.2" in case the job is the second attempt at producing the file, and so on). The suffix is always "." followed by an integer. In order to ensure that these files are also correctly treated by uproot when they're opened using the file:object style of calling open(), we need either a more general regex or an alternative regex pattern. Here I'm adding an alternative to be as specific as possible about what the alternative should be. There are other ways to solve this problem, but I don't think naming a bajillion files in our production system, or changing the behavior of PanDA, is going to be a viable solution, so better to parse things this way.

Very fundamentally, I don't quite understand why this regex is necessary. One could simply split on the colon and then try/except based on the first part being a file name and the second part being an object in that file. Since you look for the magic in the file anyway, I'm not sure what this function provides for you except perhaps tidier error messages, at the cost of this sort of difficulty in case file naming is abnormal (to be clear, I recognize that this file naming of PanDA's is really not nice, and ROOT itself has broken opening files on occasion because of it).