### PR TITLE
chore: skip broken version of fsspec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ extra = [
 test = [
   "aiohttp",
   "deflate",
-  "fsspec-xrootd>=0.5.0",
+  "fsspec-xrootd>=0.5.0,!=2025.7.0",
   "isal",
   "minio",
   "paramiko",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ extra = [
 test = [
   "aiohttp",
   "deflate",
-  "fsspec-xrootd>=0.5.0,!=2025.7.0",
+  "fsspec-xrootd>=0.5.0",
   "isal",
   "minio",
   "paramiko",
@@ -81,7 +81,7 @@ dependencies = [
   "cramjam>=2.5.0",
   "xxhash",
   "numpy",
-  "fsspec",
+  "fsspec!=2025.7.0",
   "packaging",
   "typing_extensions>=4.1.0; python_version < '3.11'"
 ]


### PR DESCRIPTION
We need to skip the latest version of fsspec since they broke something. They already fixed it, but haven't made a new release. We need this so that the CI can pass on other PRs.