### PR TITLE
fix: preserve structure of jagged subfields when accessing the arrays directly

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1543,7 +1543,7 @@ def _get_dak_array(
         entry_stop = ttree.num_entries
 
         if isinstance(ttree, HasFields):
-            akform = ttree.to_akform(filter_name=common_keys)
+            akform, _ = ttree.to_akform(filter_name=common_keys)
             ttree_step = _RNTuple_regularize_step_size(
                 ttree, akform, step_size, entry_start, entry_stop
             )
@@ -1593,7 +1593,7 @@ which has {entry_stop} entries"""
                     partition_args.append((i, start, stop))
 
     if isinstance(ttrees[0], HasFields):
-        base_form = ttrees[0].to_akform(filter_name=common_keys)
+        base_form = ttrees[0].to_akform(filter_name=common_keys)[0]
     else:
         base_form = _get_ttree_form(
             awkward, ttrees[0], common_keys, interp_options.get("ak_add_doc")

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -1637,14 +1637,18 @@ class RField(uproot.behaviors.RNTuple.HasFields):
         See also :ref:`uproot.behaviors.RNTuple.HasFields.arrays` to read
         multiple ``RFields`` into a group of arrays or an array-group.
         """
-        return self.arrays(
+        arrays = self.arrays(
             entry_start=entry_start,
             entry_stop=entry_stop,
             library=library,
             interpreter=interpreter,
             backend=backend,
             ak_add_doc=ak_add_doc,
-        )[self.name]
+        )
+        if self.name not in arrays.fields:
+            # Awkward keys for tuples don't include the initial underscore
+            return arrays[self.name[1:]]
+        return arrays[self.name]
 
 
 # No cupy version of numpy.insert() provided

--- a/tests/test_1406_improved_rntuple_methods.py
+++ b/tests/test_1406_improved_rntuple_methods.py
@@ -94,21 +94,22 @@ def test_to_akform(tmp_path):
 
     obj = uproot.open(filepath)["ntuple"]
 
-    akform = obj.to_akform()
+    akform, field_path = obj.to_akform()
     assert akform == data.layout.form
+    assert field_path is None
 
-    assert obj["struct1"].to_akform() == akform.select_columns("struct1")
-    assert obj["struct2"].to_akform() == akform.select_columns("struct2")
-    assert obj["struct3"].to_akform() == akform.select_columns("struct3")
-    assert obj["struct4"].to_akform() == akform.select_columns("struct4")
-    assert obj["struct5"].to_akform() == akform.select_columns("struct5")
+    assert obj["struct1"].to_akform() == (akform.select_columns("struct1"), ["struct1"])
+    assert obj["struct2"].to_akform() == (akform.select_columns("struct2"), ["struct2"])
+    assert obj["struct3"].to_akform() == (akform.select_columns("struct3"), ["struct3"])
+    assert obj["struct4"].to_akform() == (akform.select_columns("struct4"), ["struct4"])
+    assert obj["struct5"].to_akform() == (akform.select_columns("struct5"), ["struct5"])
 
-    assert obj["struct1"].to_akform(filter_name="x") == akform.select_columns(
+    assert obj["struct1"].to_akform(filter_name="x")[0] == akform.select_columns(
         ["struct1.x"]
     )
-    assert obj["struct3"].to_akform(filter_typename="double") == akform.select_columns(
-        ["struct3.t"]
-    )
+    assert obj["struct3"].to_akform(filter_typename="double")[
+        0
+    ] == akform.select_columns(["struct3.t"])
 
 
 def test_iterate_and_concatenate(tmp_path):
@@ -145,4 +146,4 @@ def test_array(tmp_path):
     obj = uproot.open(filepath)["ntuple"]
 
     assert obj["struct5._0"].array().tolist() == [1, 4]
-    # assert obj["struct6._0"].array().tolist() == [[1, 4], [7]] # TODO: Need to fix this
+    assert obj["struct6._0"].array().tolist() == [[1, 4], [7]]


### PR DESCRIPTION
As I described in #1475, when you try to use `array` on a subfield of a jagged array (and I think also of some regular arrays) you get flattened data that doesn't match the structure that you would expect. The issue was that the form being constructed was lacking information from the parent fields. I couldn't find a way to manipulate Awkward forms conveniently, so instead I switched `to_akform` to construct a larger form in case the field is a subfield of a collection, and return the relative path of the requested field. This way, once the actual Awkward array is constructed it is easy to zoom into the requested field back again.

Everything seems to be working now, but I'll add some tests to make sure that it works even in tricky cases.

Closes #1475