### PR TITLE
feat: better show method for RNTuples

### DIFF
--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -1532,6 +1532,7 @@ class HasFields(Mapping):
         recursive=True,
         max_width=80,
         stream=sys.stdout,
+        **kwargs,
     ):
         """
         Args:
@@ -1563,7 +1564,13 @@ class HasFields(Mapping):
             ├─ nested_list (std::vector<std::vector<std::int64_t>>)
             ├─ struct (MyStruct)
             │  ├─ x (std::int64_t)
-            └─└─ y (std::int64_t)
+            │  └─ y (std::int64_t)
+            └─ other_struct (OtherStruct)
+                ├─ a (SubStruct)
+                │  Description: The description of the subfield
+                │  ├─ x (std::int64_t)
+                │  └─ y (std::int64_t)
+                └─ b (std::int64_t)
         """
         elbow = "└─ "
         pipe = "│  "


### PR DESCRIPTION
This PR improves the show method on RNTuple so that it better shows the structure. This was inspired by UnROOT, which does a much better job of displaying the contents of an RNTuple.

This change breaks the api, but I think it's fine since `show` is something you would only use interactively and not in some existing script.

I still have to do some polishing and maybe add colors.