### PR TITLE
fix: hide some subfields for variant and atomic fields

### DIFF
--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -1539,7 +1539,7 @@ class RField(uproot.behaviors.RNTuple.HasFields):
                 or self.parent.record.flags & uproot.const.RNTupleFieldFlags.REPETITIVE
                 or (
                     self.parent.record.struct_role == uproot.const.RNTupleFieldRole.LEAF
-                    and "std::atomic" in self.parent.record.type_name
+                    and self.record.field_name == "_0"
                 )
             )
             field = self

--- a/tests/test_1223_more_rntuple_types.py
+++ b/tests/test_1223_more_rntuple_types.py
@@ -85,6 +85,6 @@ def test_invalid_variant():
     with uproot.open(filename) as f:
         obj = f["ntuple"]
 
-        a = obj.arrays("variant.*")
+        a = obj["variant"].array()
 
-        assert a.variant.tolist() == [1, None, {"i": 2}]
+        assert a.tolist() == [1, None, {"i": 2}]

--- a/tests/test_1492_rntuple_hidden_keys.py
+++ b/tests/test_1492_rntuple_hidden_keys.py
@@ -1,0 +1,38 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+import os
+import uproot
+import pytest
+import skhep_testdata
+
+ak = pytest.importorskip("awkward")
+
+# There are other tests for hidden keys in test_1406_improved_rntuple_methods.py
+
+data = ak.Array(
+    {
+        "union_with_struct": [
+            {"x": {"a": 1, "b": 1}},
+            {"x": "two"},
+            {"x": {"a": 3, "b": 3}},
+            {"x": "four"},
+        ],
+    }
+)
+
+
+def test_struct_with_union(tmp_path):
+    filepath = os.path.join(tmp_path, "test.root")
+
+    with uproot.recreate(filepath) as file:
+        obj = file.mkrntuple("ntuple", data.layout.form)
+        obj.extend(data)
+
+    obj = uproot.open(filepath)["ntuple"]
+    assert len(obj.keys()) == 2
+
+
+def test_atomic():
+    filepath = skhep_testdata.data_path("test_atomic_bitset_rntuple_v1-0-0-0.root")
+    obj = uproot.open(filepath)["ntuple"]
+
+    assert len(obj["atomic_int"].keys()) == 0

--- a/tests/test_1492_rntuple_hidden_keys.py
+++ b/tests/test_1492_rntuple_hidden_keys.py
@@ -10,11 +10,19 @@ ak = pytest.importorskip("awkward")
 
 data = ak.Array(
     {
-        "union_with_struct": [
-            {"x": {"a": 1, "b": 1}},
-            {"x": "two"},
-            {"x": {"a": 3, "b": 3}},
-            {"x": "four"},
+        "union1": [
+            {"a": 1, "b": 1},
+            "two",
+            {"a": 3, "b": 3},
+            "four",
+            "five",
+        ],
+        "union2": [
+            {"a": 1, "b": 1},
+            {"a": 2, "b": 2, "c": 2},
+            {"a": 3, "b": 3},
+            {"a": 4, "b": 4, "c": 4},
+            "five",
         ],
     }
 )


### PR DESCRIPTION
This PR fixes a couple of things that I missed in #1469.

I made all subfields of variants hidden, since they cannot be accessed directly in a consistent way. Instead, the entire variant field needs to be read.

For example, with the example in the test
```python
data = ak.Array(
    {
        "union1": [
            {"a": 1, "b": 1},
            "two",
            {"a": 3, "b": 3},
            "four",
            "five",
        ],
        "union2": [
            {"a": 1, "b": 1},
            {"a": 2, "b": 2, "c": 2},
            {"a": 3, "b": 3},
            {"a": 4, "b": 4, "c": 4},
            "five",
        ],
    }
)
```
if one tried to do `rntuple["union1.a"]` one would get 2 elements, but it should be length 5 to be consistent. One could argue that in these cases we can just insert `None`s to make it the right shape, but I think the second example shows it's a bad idea in general. In that case, `rntuple["union2.a"]` would be have to include both types of structs, but they could have different types or meanings. So to avoid all these issues, we just forbid accessing them directly.

Additionally, I made the subfield of atomic fields hidden since they are equivalent to the parent field.