### PR TITLE
fix: Remove spaces in `fParentName` and `fClassName` when matching streamer

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2140,6 +2140,10 @@ in file {self._file.file_path}"""
             fParentName = self.member("fParentName", none_if_missing=True)
             fClassName = self.member("fClassName", none_if_missing=True)
 
+            # Remove spaces
+            fParentName = fParentName.replace(" ", "") if fParentName else fParentName
+            fClassName = fClassName.replace(" ", "") if fClassName else fClassName
+
             if fParentName is not None and fParentName != "":
                 matches = self._file.streamers.get(fParentName)
 


### PR DESCRIPTION
Hi,
I found that when `uproot.behaviors.TBranch.TBranch` searching for streamer info object, the `fParentName` and `fClssName` may contain spaces sometimes, leaving `typename` and `interpretation` unknown.

For example, the `m_map_vec_obj.second` field in the [demo data](https://github.com/user-attachments/files/22710841/nested_stl.zip):

```python
>>> import uproot
>>> t = uproot.open("demo-data.root:my_tree")
>>> b = t["nested_stl/m_map_vec_obj"]
>>> b.show()
name                 | typename                       | interpretation                
---------------------+--------------------------------+-------------------------------
m_map_vec_obj        | map<int,vector<TSimpleObject>  | AsGroup(<TBranchElement 'm_map
m_map_vec_obj.first  | int32_t[]                      | AsJagged(AsDtype('>i4'))
m_map_vec_obj.second | unknown                        | <UnknownInterpretation 'non...
```

This is because the class's name of corresponding streamer-info object in `f.file.streamer` is `pair<int,vector<TSimpleObject>>`:

```python
>>> f.file.streamers["pair<int,vector<TSimpleObject>>"]
{1: <TStreamerInfo for pair<int,vector<TSimpleObject>> version 1 at 0x7761e5cc7aa0>}
```

while when `TBranch` search for streamer-info object, it uses `fParentName` and `fClassName`:

https://github.com/scikit-hep/uproot5/blob/65b4af60f506d2d47432aa31621761ef76e1ecea/src/uproot/behaviors/TBranch.py#L2137-L2144

which actually are `pair<int,vector<TSimpleObject> >` (with extra space between `>>`):

```python
>>> sb = b["m_map_vec_obj.second"]
>>> print(sb.member("fParentName"))
pair<int,vector<TSimpleObject> >
>>> print(sb.member("fClassName"))
pair<int,vector<TSimpleObject> >
```

So I remove spaces in `fParentName` and `fClassName` before searching for the streamer-info object.
