### PR TITLE
feat: use numcodecs as an optional backend for LZMA, ZSTD, ZLIB 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ test = [
   "deflate",
   "fsspec-xrootd>=0.5.0",
   "isal",
+  "numcodecs",
   "paramiko",
   "pytest-rerunfailures",
   "rangehttpserver",

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -273,7 +273,7 @@ class LZMA(Compression, _DecompressLZMA):
             out = codec.encode(data)
             out = b"".join(out) if isinstance(out, list) else bytes(out)
             return out
-        
+
         except ModuleNotFoundError:
             # Failure due to numcodecs not installed = fall back to cramjam/stdlib
             pass

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -196,10 +196,9 @@ class _DecompressLZMA:
             codec = numcodecs.LZMA()
             decoded = codec.decode(data)
 
-            if isinstance(decoded, list):
-                decoded = b"".join(decoded)
-            else:
-                decoded = bytes(decoded)
+            decoded = (
+                b"".join(decoded) if isinstance(decoded, list) else bytes(decoded)
+            )
 
             # numcodecs does not gaurentee outpute size ( must validate )
             if uncompressed_bytes is not None and len(decoded) != uncompressed_bytes:
@@ -363,10 +362,9 @@ class _DecompressZSTD:
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
 
-            if isinstance(decoded, list):
-                decoded = b"".join(decoded)
-            else:
-                decoded = bytes(decoded)
+            decoded = ( 
+                b"".join(decoded) if isinstance(decoded, list) else bytes(decoded)
+            )
 
             # numcodecs does NOT guarantee outpute size (must validate)
             if len(decoded) != uncompressed_bytes:

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -195,7 +195,12 @@ class _DecompressLZMA:
 
             codec = numcodecs.LZMA()
             decoded = codec.decode(data)
-            decoded = bytes(decoded)
+
+            if isinstance(decoded, list) : 
+                decoded = b"".join(decoded)
+            else : 
+                decoded = bytes(decoded)
+
             # numcodecs does not gaurentee outpute size ( must validate )
             if uncompressed_bytes is not None and len(decoded) != uncompressed_bytes:
                 raise ValueError("numcodecs LZMA produced incorrect output size")
@@ -357,7 +362,11 @@ class _DecompressZSTD:
 
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
-            decoded = bytes(decoded)
+            
+            if isinstance(decoded, list) : 
+                decoded = b"".join(decoded)
+            else : 
+                decoded = bytes(decoded)
 
             # numcodecs does NOT guarantee outpute size (must validate)
             if len(decoded) != uncompressed_bytes:

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -195,7 +195,7 @@ class _DecompressLZMA:
 
             codec = numcodecs.LZMA()
             decoded = codec.decode(data)
-
+            decoded = bytes(decoded)
             # numcodecs does not gaurentee outpute size ( must validate )
             if uncompressed_bytes is not None and len(decoded) != uncompressed_bytes:
                 raise ValueError("numcodecs LZMA produced incorrect output size")
@@ -268,8 +268,8 @@ class LZMA(Compression, _DecompressLZMA):
             import numcodecs
 
             codec = numcodecs.LZMA()
-            return codec.encode(data)
-
+            out = codec.encode(data)
+            return bytes(out)
         except ImportError:
             # Failure due to numcodecs not installed = fall back to cramjam/stdlib
             pass
@@ -356,6 +356,7 @@ class _DecompressZSTD:
 
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
+            decode = bytes(decoded)
 
             # numcodecs does NOT guarantee outpute size (must validate)
             if len(decoded) != uncompressed_bytes:
@@ -418,7 +419,8 @@ class ZSTD(Compression, _DecompressZSTD):
             import numcodecs
 
             codec = numcodecs.Zstd(level=self._level)
-            return codec.encode(data)
+            out = codec.encode(data)
+            return bytes(out)
 
         except ImportError:
             # Failure due to numcodecs not installed = Fall back

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -196,9 +196,7 @@ class _DecompressLZMA:
             codec = numcodecs.LZMA()
             decoded = codec.decode(data)
 
-            decoded = (
-                b"".join(decoded) if isinstance(decoded, list) else bytes(decoded)
-            )
+            decoded = b"".join(decoded) if isinstance(decoded, list) else bytes(decoded)
 
             # numcodecs does not gaurentee outpute size ( must validate )
             if uncompressed_bytes is not None and len(decoded) != uncompressed_bytes:
@@ -362,9 +360,7 @@ class _DecompressZSTD:
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
 
-            decoded = ( 
-                b"".join(decoded) if isinstance(decoded, list) else bytes(decoded)
-            )
+            decoded = b"".join(decoded) if isinstance(decoded, list) else bytes(decoded)
 
             # numcodecs does NOT guarantee outpute size (must validate)
             if len(decoded) != uncompressed_bytes:

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -280,12 +280,13 @@ class LZMA(Compression, _DecompressLZMA):
             getattr(cramjam, "experimental", None), "lzma", None
         )
         if lzma is not None:
-            return lzma.compress(data, preset=self._level)
-
+            out = lzma.compress(data, preset=self._level)
+            return bytes(memoryview(out))
         # Fallback : stdlib lzma
         import lzma as _stdlib_lzma
 
-        return _stdlib_lzma.compress(data, preset=self._level)
+        out = _stdlib_lzma.compress(data, preset=self._level)
+        return bytes(memoryview(out))
 
 
 class _DecompressLZ4:
@@ -433,8 +434,9 @@ class ZSTD(Compression, _DecompressZSTD):
         if zstd is None:
             raise RuntimeError("ZSTD compression requires ramjam or numcodecs")
 
-        return zstd.compress(data, level=self._level)
-
+        out = zstd.compress(data, level=self._level)
+        return bytes(memoryview(out))
+    
 
 algorithm_codes = {
     uproot.const.kZLIB: ZLIB,

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -94,7 +94,7 @@ class _DecompressZLIB:
             raise ValueError(
                 "zlib decompression requires the number of uncompressed bytes"
             )
-        
+
         if self.library == "zlib":
             import zlib
 
@@ -621,10 +621,8 @@ def compress(data: bytes, compression: Compression) -> bytes:
     format (bytes, memoryview, or NumPy array) it was provided.
     """
 
-    def _normalize_bytes(x):
-        if isinstance(x, list):
-            return b"".join(x)
-        return x
+    if compression is None or compression.level == 0:
+        return data
 
     out = []
     next = data

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -196,9 +196,9 @@ class _DecompressLZMA:
             codec = numcodecs.LZMA()
             decoded = codec.decode(data)
 
-            if isinstance(decoded, list) : 
+            if isinstance(decoded, list):
                 decoded = b"".join(decoded)
-            else : 
+            else:
                 decoded = bytes(decoded)
 
             # numcodecs does not gaurentee outpute size ( must validate )
@@ -362,10 +362,10 @@ class _DecompressZSTD:
 
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
-            
-            if isinstance(decoded, list) : 
+
+            if isinstance(decoded, list):
                 decoded = b"".join(decoded)
-            else : 
+            else:
                 decoded = bytes(decoded)
 
             # numcodecs does NOT guarantee outpute size (must validate)

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -191,7 +191,7 @@ class _DecompressLZMA:
     def decompress(self, data: bytes, uncompressed_bytes=None) -> bytes:
         # Try numcodecs
         try:
-            import numcodecs
+            numcodecs = uproot.extras.numcodecs()
 
             codec = numcodecs.LZMA()
             decoded = codec.decode(data)
@@ -204,7 +204,7 @@ class _DecompressLZMA:
 
             return decoded
 
-        except ImportError:
+        except ModuleNotFoundError:
             # Failure due to numcodecs not being installed = fall back to cramjam/stdlib
             pass
 
@@ -267,12 +267,14 @@ class LZMA(Compression, _DecompressLZMA):
     def compress(self, data: bytes) -> bytes:
         # Try numcodecs
         try:
-            import numcodecs
+            numcodecs = uproot.extras.numcodecs()
 
             codec = numcodecs.LZMA()
             out = codec.encode(data)
-            return bytes(memoryview(out))
-        except ImportError:
+            out = b"".join(out) if isinstance(out, list) else bytes(out)
+            return out
+        
+        except ModuleNotFoundError:
             # Failure due to numcodecs not installed = fall back to cramjam/stdlib
             pass
 
@@ -355,7 +357,7 @@ class _DecompressZSTD:
 
         # Try numcodecs
         try:
-            import numcodecs
+            numcodecs = uproot.extras.numcodecs()
 
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
@@ -368,7 +370,7 @@ class _DecompressZSTD:
 
             return decoded
 
-        except ImportError:
+        except ModuleNotFoundError:
             # Failure due to numcodecs not being installed = fall back
             pass
         except ValueError:
@@ -420,13 +422,14 @@ class ZSTD(Compression, _DecompressZSTD):
     def compress(self, data: bytes) -> bytes:
         # Try numcodecs :
         try:
-            import numcodecs
+            numcodecs = uproot.extras.numcodecs()
 
             codec = numcodecs.Zstd(level=self._level)
             out = codec.encode(data)
-            return bytes(memoryview(out))
+            out = b"".join(out) if isinstance(out, list) else bytes(out)
+            return out
 
-        except ImportError:
+        except ModuleNotFoundError:
             # Failure due to numcodecs not installed = Fall back
             pass
 

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -269,7 +269,7 @@ class LZMA(Compression, _DecompressLZMA):
 
             codec = numcodecs.LZMA()
             out = codec.encode(data)
-            return bytes(out)
+            return bytes(memoryview(out))
         except ImportError:
             # Failure due to numcodecs not installed = fall back to cramjam/stdlib
             pass
@@ -420,7 +420,7 @@ class ZSTD(Compression, _DecompressZSTD):
 
             codec = numcodecs.Zstd(level=self._level)
             out = codec.encode(data)
-            return bytes(out)
+            return bytes(memoryview(out))
 
         except ImportError:
             # Failure due to numcodecs not installed = Fall back

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -637,8 +637,13 @@ def compress(data: bytes, compression: Compression) -> bytes:
     output would be larger than the input, the input is returned instead, in whatever
     format (bytes, memoryview, or NumPy array) it was provided.
     """
+    def _normalize_bytes(x) : 
+        if isinstance(x, list) : 
+            return b"".join(x)
+        return x 
+    
     if compression is None or compression.level == 0:
-        return data
+        return _normalize_bytes(data)
 
     out = []
     next = data
@@ -671,6 +676,7 @@ def compress(data: bytes, compression: Compression) -> bytes:
         out.append(compressed)
 
     out = b"".join(out)
+    data = _normalize_bytes(data)
 
     if len(out) < len(data):
         return out

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -189,30 +189,28 @@ class _DecompressLZMA:
     _method = b"\x00"
 
     def decompress(self, data: bytes, uncompressed_bytes=None) -> bytes:
-        # Try numcodecs 
-        try : 
+        # Try numcodecs
+        try:
             import numcodecs
 
             codec = numcodecs.LZMA()
             decoded = codec.decode(data)
 
             # numcodecs does not gaurentee outpute size ( must validate )
-            if uncompressed_bytes is not None and len(decoded)!=uncompressed_bytes : 
-                raise ValueError ( 
-                    "numcodecs LZMA produced incorrect output size"
-                )
-            
-            return decoded 
-        
-        except ImportError: 
-            # Failure due to numcodecs not being installed = fall back to cramjam/stdlib 
-            pass 
-        
-        except ValueError : 
+            if uncompressed_bytes is not None and len(decoded) != uncompressed_bytes:
+                raise ValueError("numcodecs LZMA produced incorrect output size")
+
+            return decoded
+
+        except ImportError:
+            # Failure due to numcodecs not being installed = fall back to cramjam/stdlib
+            pass
+
+        except ValueError:
             # Failure due to output-size validation failed = fall back to cramjam/stdlib
             pass
 
-        # Fallback : Try cramjam(preferred) or stdlib 
+        # Fallback : Try cramjam(preferred) or stdlib
         cramjam = uproot.extras.cramjam()
         lzma = getattr(cramjam, "xz", None) or getattr(
             getattr(cramjam, "experimental", None), "lzma", None
@@ -224,12 +222,12 @@ class _DecompressLZMA:
 
             return lzma.decompress(data)
 
-        # Known output size path is required 
-        if uncompressed_bytes is None : 
+        # Known output size path is required
+        if uncompressed_bytes is None:
             raise ValueError(
                 "lzma decompression requires the number of uncompressed bytes"
             )
-        
+
         return lzma.decompress(data, output_len=uncompressed_bytes)
 
 
@@ -266,17 +264,17 @@ class LZMA(Compression, _DecompressLZMA):
 
     def compress(self, data: bytes) -> bytes:
         # Try numcodecs
-        try : 
+        try:
             import numcodecs
 
             codec = numcodecs.LZMA()
             return codec.encode(data)
-        
-        except ImportError : 
-            # Failure due to numcodecs not installed = fall back to cramjam/stdlib
-            pass 
 
-        # Fallbac : Try cramjam 
+        except ImportError:
+            # Failure due to numcodecs not installed = fall back to cramjam/stdlib
+            pass
+
+        # Fallbac : Try cramjam
         cramjam = uproot.extras.cramjam()
         lzma = getattr(cramjam, "xz", None) or getattr(
             getattr(cramjam, "experimental", None), "lzma", None
@@ -284,9 +282,11 @@ class LZMA(Compression, _DecompressLZMA):
         if lzma is not None:
             return lzma.compress(data, preset=self._level)
 
-        # Fallback : stdlib lzma 
-        import lzma as _stdlib_lzma 
+        # Fallback : stdlib lzma
+        import lzma as _stdlib_lzma
+
         return _stdlib_lzma.compress(data, preset=self._level)
+
 
 class _DecompressLZ4:
     name = "LZ4"
@@ -344,43 +344,39 @@ class _DecompressZSTD:
     _method = b"\x01"
 
     def decompress(self, data: bytes, uncompressed_bytes=None) -> bytes:
-        # ROOT requires exact output size 
+        # ROOT requires exact output size
         if uncompressed_bytes is None:
             raise ValueError(
                 "zstd block decompression requires the number of uncompressed bytes"
             )
-        
-        # Try numcodecs 
-        try : 
+
+        # Try numcodecs
+        try:
             import numcodecs
 
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
 
-            #numcodecs does NOT guarantee outpute size (must validate)
-            if len(decoded)!=uncompressed_bytes : 
-                raise ValueError(
-                    "numcodecs ZSSTD produced incorrect output size"
-                )
-            
+            # numcodecs does NOT guarantee outpute size (must validate)
+            if len(decoded) != uncompressed_bytes:
+                raise ValueError("numcodecs ZSSTD produced incorrect output size")
+
             return decoded
-        
-        except ImportError : 
-            # Failure due to numcodecs not being installed = fall back 
-            pass 
-        except ValueError : 
+
+        except ImportError:
+            # Failure due to numcodecs not being installed = fall back
+            pass
+        except ValueError:
             # Failusre due to size mismatch = fall back to strict backend
-            pass 
+            pass
 
         # Fallback : cramjam
         cramjam = uproot.extras.cramjam()
-        zstd = getattr(cramjam,"zstd", None) 
+        zstd = getattr(cramjam, "zstd", None)
 
-        if zstd is None : 
-            raise RuntimeError ( 
-                "ZSTD decompression requires cramjam or numcodecs"
-            )
-        
+        if zstd is None:
+            raise RuntimeError("ZSTD decompression requires cramjam or numcodecs")
+
         return zstd.decompress(data, output_len=uncompressed_bytes)
 
 
@@ -417,26 +413,24 @@ class ZSTD(Compression, _DecompressZSTD):
         self._level = int(value)
 
     def compress(self, data: bytes) -> bytes:
-        # Try numcodecs : 
-        try : 
+        # Try numcodecs :
+        try:
             import numcodecs
 
-            codec = numcodecs.Zstd(level = self._level)
+            codec = numcodecs.Zstd(level=self._level)
             return codec.encode(data)
-        
-        except ImportError : 
+
+        except ImportError:
             # Failure due to numcodecs not installed = Fall back
-            pass 
+            pass
 
         # Fallback : cramjam
-        cramjam = uproot.extras.cramjam() 
+        cramjam = uproot.extras.cramjam()
         zstd = getattr(cramjam, "zstd", None)
 
-        if zstd is None : 
-            raise RuntimeError(
-                "ZSTD compression requires ramjam or numcodecs"
-            )
-        
+        if zstd is None:
+            raise RuntimeError("ZSTD compression requires ramjam or numcodecs")
+
         return zstd.compress(data, level=self._level)
 
 

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -436,7 +436,7 @@ class ZSTD(Compression, _DecompressZSTD):
 
         out = zstd.compress(data, level=self._level)
         return bytes(memoryview(out))
-    
+
 
 algorithm_codes = {
     uproot.const.kZLIB: ZLIB,

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -103,11 +103,11 @@ class _DecompressZLIB:
 
                 if len(decoded) != uncompressed_bytes:
                     raise ValueError("numcodecs ZLIB produced incorrect output size")
-            
+
                 return decoded
-        
+
             except ModuleNotFoundError:
-                #Failure due to numcodecs not installed = fall back to stdlib/isal/defalte
+                # Failure due to numcodecs not installed = fall back to stdlib/isal/defalte
                 pass
 
         elif self.library == "zlib":
@@ -175,12 +175,12 @@ class ZLIB(Compression, _DecompressZLIB):
                 numcodecs = uproot.extras.numcodecs()
                 codec = numcodecs.Zlib(level=self._level)
                 out = codec.encode(data)
-            
+
                 return out
             except ModuleNotFoundError:
                 # Failure due to numcodecs not installed = fall back to stdlib/isal/stdil
                 pass
-        
+
         elif self.library == "zlib":
             import zlib
 

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -356,7 +356,7 @@ class _DecompressZSTD:
 
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
-            decode = bytes(decoded)
+            decoded = bytes(decoded)
 
             # numcodecs does NOT guarantee outpute size (must validate)
             if len(decoded) != uncompressed_bytes:

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -637,11 +637,12 @@ def compress(data: bytes, compression: Compression) -> bytes:
     output would be larger than the input, the input is returned instead, in whatever
     format (bytes, memoryview, or NumPy array) it was provided.
     """
-    def _normalize_bytes(x) : 
-        if isinstance(x, list) : 
+
+    def _normalize_bytes(x):
+        if isinstance(x, list):
             return b"".join(x)
-        return x 
-    
+        return x
+
     if compression is None or compression.level == 0:
         return _normalize_bytes(data)
 

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -196,20 +196,14 @@ class _DecompressLZMA:
             codec = numcodecs.LZMA()
             decoded = codec.decode(data)
 
-            decoded = b"".join(decoded) if isinstance(decoded, list) else bytes(decoded)
-
             # numcodecs does not gaurentee outpute size ( must validate )
             if uncompressed_bytes is not None and len(decoded) != uncompressed_bytes:
                 raise ValueError("numcodecs LZMA produced incorrect output size")
 
-            return decoded
+            return bytes(decoded)
 
         except ModuleNotFoundError:
             # Failure due to numcodecs not being installed = fall back to cramjam/stdlib
-            pass
-
-        except ValueError:
-            # Failure due to output-size validation failed = fall back to cramjam/stdlib
             pass
 
         # Fallback : Try cramjam(preferred) or stdlib
@@ -271,8 +265,7 @@ class LZMA(Compression, _DecompressLZMA):
 
             codec = numcodecs.LZMA()
             out = codec.encode(data)
-            out = b"".join(out) if isinstance(out, list) else bytes(out)
-            return out
+            return bytes(out)
 
         except ModuleNotFoundError:
             # Failure due to numcodecs not installed = fall back to cramjam/stdlib
@@ -285,12 +278,12 @@ class LZMA(Compression, _DecompressLZMA):
         )
         if lzma is not None:
             out = lzma.compress(data, preset=self._level)
-            return bytes(memoryview(out))
+            return bytes((out))
         # Fallback : stdlib lzma
         import lzma as _stdlib_lzma
 
         out = _stdlib_lzma.compress(data, preset=self._level)
-        return bytes(memoryview(out))
+        return bytes((out))
 
 
 class _DecompressLZ4:
@@ -362,21 +355,16 @@ class _DecompressZSTD:
             codec = numcodecs.Zstd()
             decoded = codec.decode(data)
 
-            decoded = b"".join(decoded) if isinstance(decoded, list) else bytes(decoded)
-
             # numcodecs does NOT guarantee outpute size (must validate)
             if len(decoded) != uncompressed_bytes:
                 raise ValueError("numcodecs ZSSTD produced incorrect output size")
 
-            return decoded
+            return bytes(decoded)
 
         except ModuleNotFoundError:
             # Failure due to numcodecs not being installed = fall back
             pass
-        except ValueError:
-            # Failusre due to size mismatch = fall back to strict backend
-            pass
-
+       
         # Fallback : cramjam
         cramjam = uproot.extras.cramjam()
         zstd = getattr(cramjam, "zstd", None)
@@ -426,8 +414,7 @@ class ZSTD(Compression, _DecompressZSTD):
 
             codec = numcodecs.Zstd(level=self._level)
             out = codec.encode(data)
-            out = b"".join(out) if isinstance(out, list) else bytes(out)
-            return out
+            return bytes(out)
 
         except ModuleNotFoundError:
             # Failure due to numcodecs not installed = Fall back
@@ -441,7 +428,7 @@ class ZSTD(Compression, _DecompressZSTD):
             raise RuntimeError("ZSTD compression requires ramjam or numcodecs")
 
         out = zstd.compress(data, level=self._level)
-        return bytes(memoryview(out))
+        return bytes((out))
 
 
 algorithm_codes = {

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -278,12 +278,12 @@ class LZMA(Compression, _DecompressLZMA):
         )
         if lzma is not None:
             out = lzma.compress(data, preset=self._level)
-            return bytes((out))
+            return bytes(out)
         # Fallback : stdlib lzma
         import lzma as _stdlib_lzma
 
         out = _stdlib_lzma.compress(data, preset=self._level)
-        return bytes((out))
+        return bytes(out)
 
 
 class _DecompressLZ4:
@@ -364,7 +364,7 @@ class _DecompressZSTD:
         except ModuleNotFoundError:
             # Failure due to numcodecs not being installed = fall back
             pass
-       
+
         # Fallback : cramjam
         cramjam = uproot.extras.cramjam()
         zstd = getattr(cramjam, "zstd", None)
@@ -428,7 +428,7 @@ class ZSTD(Compression, _DecompressZSTD):
             raise RuntimeError("ZSTD compression requires ramjam or numcodecs")
 
         out = zstd.compress(data, level=self._level)
-        return bytes((out))
+        return bytes(out)
 
 
 algorithm_codes = {

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -187,6 +187,23 @@ or
     conda install cramjam""") from err
     else:
         return cramjam
+    
+def numcodecs() : 
+    """
+    Imports and returns ``numcodecs``.
+    """
+    try : 
+        import numcodecs
+    except ModuleNotFoundError as err : 
+        raise ModuleNotFoundError("""install the `numcodecs` package with:
+
+    pip install numcodecs
+                                
+or 
+            
+    conda install numcodecs""") from err
+    else:
+        return numcodecs
 
 
 def xxhash():

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -187,20 +187,21 @@ or
     conda install cramjam""") from err
     else:
         return cramjam
-    
-def numcodecs() : 
+
+
+def numcodecs():
     """
     Imports and returns ``numcodecs``.
     """
-    try : 
+    try:
         import numcodecs
-    except ModuleNotFoundError as err : 
+    except ModuleNotFoundError as err:
         raise ModuleNotFoundError("""install the `numcodecs` package with:
 
     pip install numcodecs
-                                
-or 
-            
+
+or
+
     conda install numcodecs""") from err
     else:
         return numcodecs


### PR DESCRIPTION
This PR is towards evaluating numcodecs as an alternative backend for compression in uproot, as discussed in #1568. 

It introduces numcodecs as an optional backend for LZMA and ZSTD compression and decompression within compression.py, while preserving existing interfaces, error handling and fallback behavior. The existing cramjam (and stdlib, where applicable) implementations remains unchanged and are used as fallbacks if numcodecs is unavailable or unsuitable.

As of now, I have intentionally limited the scope of this PR to LZMA and ZSTD. While reading through the existng code, it seemed to me that for zlib and LZ4 paths rely on mroe specific behavior and error handling, and I wasn't confident that a straightforward swap to numcodecs would preserve semantics there. To avoid guesing and to keep this change minimal, those codecs are left unchanged for now. 