### PR TITLE
fix: resolve issue mktree/mkrntuple creating subdirectories

### DIFF
--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -1237,6 +1237,7 @@ class WritableDirectory(MutableMapping):
                     self._file.uuid_function(),
                 ),
             )
+            self._subdirs[head] = directory
 
         elif key.classname.string not in ("TDirectory", "TDirectoryFile"):
             raise TypeError(

--- a/tests/test_1599_mktree_mkrntuple_with_subdir.py
+++ b/tests/test_1599_mktree_mkrntuple_with_subdir.py
@@ -30,3 +30,30 @@ def test_mktree_repeated_same_subdir(tmp_path):
             "tree/z",
             "tree/w",
         }
+
+
+def test_mkrntuple_repeated_same_subdir(tmp_path):
+    newfile = os.path.join(tmp_path, "newfile.root")
+
+    with uproot.recreate(newfile) as f:
+        f.mkrntuple("ntpl/x", {"x": [1, 2, 3]})
+        f.mkrntuple("ntpl/y", {"x": [1, 2, 3]})
+        f.mkrntuple("ntpl/z", {"x": [1, 2, 3]})
+        f.mkrntuple("ntpl/w", {"x": [1, 2, 3]})
+
+        assert set(f.keys(cycle=False)) == {
+            "ntpl",
+            "ntpl/x",
+            "ntpl/y",
+            "ntpl/z",
+            "ntpl/w",
+        }
+
+    with uproot.open(newfile) as fin:
+        assert set(fin.keys(cycle=False)) == {
+            "ntpl",
+            "ntpl/x",
+            "ntpl/y",
+            "ntpl/z",
+            "ntpl/w",
+        }

--- a/tests/test_1599_mktree_with_subdir.py
+++ b/tests/test_1599_mktree_with_subdir.py
@@ -1,0 +1,32 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import os
+
+import uproot
+
+
+def test_mktree_repeated_same_subdir(tmp_path):
+    newfile = os.path.join(tmp_path, "newfile.root")
+
+    with uproot.recreate(newfile) as f:
+        f.mktree("tree/x", {"x": [1, 2, 3]})
+        f.mktree("tree/y", {"x": [1, 2, 3]})
+        f.mktree("tree/z", {"x": [1, 2, 3]})
+        f.mktree("tree/w", {"x": [1, 2, 3]})
+
+        assert set(f.keys(cycle=False)) == {
+            "tree",
+            "tree/x",
+            "tree/y",
+            "tree/z",
+            "tree/w",
+        }
+
+    with uproot.open(newfile) as fin:
+        assert set(fin.keys(cycle=False)) == {
+            "tree",
+            "tree/x",
+            "tree/y",
+            "tree/z",
+            "tree/w",
+        }


### PR DESCRIPTION
This PR fixes #1598, the issue was that a newly-created `WritableDirectory` was not being tracked properly, so it was being recreated during subsequent calls. Now, it is added to `_subdirs`, which fixes the issue.

AI disclosure: I used Claude Code to debug this.