### PR TITLE
ci: fix upload of test report

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -262,7 +262,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.cuda-version == 13 }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I forgot to include an extra restriction to the step that uploads the test report, so we end up getting a warning like this: https://github.com/scikit-hep/uproot5/pull/1599#issuecomment-4067968157

