### PR TITLE
fix: logical bug in boundary check for unique RField names

### DIFF
--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -229,15 +229,16 @@ in file {self.file.file_path}"""
                 ]
 
                 name_counter = Counter(new_names)
+                max_prefixes = max(len(stack) for stack in ancestor_name_stacks)
                 while len(new_names) != len(name_counter):
                     for i in range(len(n_prefixes)):
                         # For non-unique names, add one more prefix and regenerate the name
                         if name_counter[new_names[i]] > 1:
                             n_prefixes[i] += 1
 
-                            if n_prefixes[i] >= len(ancestor_name_stacks[i]):
+                            if n_prefixes[i] >= max_prefixes:
                                 raise RuntimeError(
-                                    "Ran out of prefixes to add, but names are still not unique."
+                                    "Reached maximum number of prefixes, but names are still not unique."
                                 )
 
                             new_names[i] = _generate_fieldname(

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -237,6 +237,7 @@ in file {self.file.file_path}"""
                             n_prefixes[i] += 1
 
                             if n_prefixes[i] >= max_prefixes:
+                                self._all_fields = None
                                 raise RuntimeError(
                                     "Reached maximum number of prefixes, but names are still not unique."
                                 )


### PR DESCRIPTION
I found a logical mistake in the boundary check in `RNTuple.all_fields`:

https://github.com/scikit-hep/uproot5/blob/f19065d10c3659e0bb52e3aa704f993a17749df5/src/uproot/models/RNTuple.py#L231-L246

Assume that we have an RField `A` with ancestor chain `[my_data]` and an RField `B` with ancestor chain `[BASE, my_data]`. When they are renamed:

- In the first loop, both `A` and `B` get the name `my_data`, which is not unique.
- In the second loop, if `A` is processed before `B`, the condition `if n_prefixes[i] >= len(ancestor_name_stacks[i]):` will be True and throw the exception, since no more ancestor exists for `A`. However, what we expect is the field name of `A` remains `my_data`, and `B`'s field name is renamed as `BASE::my_data`.

So I let it check whether `n_prefixes[i]` reaches the maximum length allowed.

I also invalidated `self._all_fields` if the renaming fails, to prevent user continuing to use the `RNTuple` and suffer potential mistake (I'm not sure whether this is a good choice, please let me know your idea!).

Thank you!