### PR TITLE
fix: allow tuples and slightly more generic NumPy dtypes in mktree and mkrntuple

### DIFF
--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -2234,8 +2234,38 @@ def _is_type_specification(obj):
             else:
                 return False
         if not isinstance(
-            obj, (numpy.dtype, awkward.types.Type, awkward.types.ArrayType, str, type)
+            obj,
+            (
+                numpy.dtype,
+                awkward.types.Type,
+                awkward.types.ArrayType,
+                type,
+                str,
+                tuple,
+            ),
         ):
+            return False
+        # for tuples and strings we need to make sure they actually specify a type and are not just data
+        if isinstance(obj, tuple):
+            try:
+                numpy.dtype(obj)
+                return True
+            except (TypeError, ValueError):
+                return False
+        if isinstance(obj, str):
+            try:
+                numpy.dtype(obj)
+                return True
+            except (TypeError, ValueError):
+                pass
+            try:
+                awkward.types.from_datashape(obj, highlevel=False)
+                return True
+            except (
+                awkward.types._awkward_datashape_parser.UnexpectedToken,
+                awkward.types._awkward_datashape_parser.UnexpectedCharacters,
+            ):
+                pass
             return False
     return True
 
@@ -2245,12 +2275,42 @@ def _type_specification_to_awkward_form(obj):
         return obj
     if isinstance(obj, (awkward.types.Type, awkward.types.ArrayType)):
         return awkward.forms.from_type(obj)
-    if isinstance(obj, (numpy.dtype, type)):
-        obj = str(numpy.dtype(obj))
+    if isinstance(obj, type):
+        try:
+            obj = numpy.dtype(obj)
+        except (TypeError, ValueError):
+            raise TypeError(
+                f"Cannot construct a NumPy dtype from {obj!r} of type {type(obj).__name__}."
+            ) from None
+    if isinstance(obj, tuple):
+        try:
+            obj = numpy.dtype(obj)
+        except (TypeError, ValueError):
+            raise TypeError(
+                f"Cannot construct a NumPy dtype from the tuple {obj!r}."
+            ) from None
+    if isinstance(obj, numpy.dtype):
+        obj = obj.newbyteorder("<")
+        if obj.subdtype is None:
+            field_shape = ()
+        else:
+            obj, field_shape = obj.subdtype
+        dims = ""
+        if len(field_shape) > 0:
+            dims = dims + "".join(str(x) + " * " for x in field_shape)
+        obj = f"{dims}{obj}"
     if isinstance(obj, str):
-        return awkward.forms.from_type(
-            awkward.types.from_datashape(obj, highlevel=False)
-        )
+        try:
+            return awkward.forms.from_type(
+                awkward.types.from_datashape(obj, highlevel=False)
+            )
+        except (
+            awkward.types._awkward_datashape_parser.UnexpectedToken,
+            awkward.types._awkward_datashape_parser.UnexpectedCharacters,
+        ):
+            raise TypeError(
+                f"Cannot construct an Awkward Form of from type specification {obj!r}"
+            ) from None
     if isinstance(obj, Mapping):
         return awkward.forms.RecordForm(
             [_type_specification_to_awkward_form(v) for v in obj.values()],
@@ -2258,7 +2318,7 @@ def _type_specification_to_awkward_form(obj):
         )
     raise TypeError(
         f"Cannot construct an Awkward Form from {type(obj).__name__}. "
-        f"Supported types: Form, Type, ArrayType, dtype, str, Mapping"
+        f"Supported types: Form, Type, ArrayType, dtype, Mapping, str, tuple."
     )
 
 

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -2249,23 +2249,26 @@ def _is_type_specification(obj):
         if isinstance(obj, tuple):
             try:
                 numpy.dtype(obj)
-                return True
             except (TypeError, ValueError):
                 return False
+            else:
+                continue
         if isinstance(obj, str):
             try:
                 numpy.dtype(obj)
-                return True
             except (TypeError, ValueError):
                 pass
+            else:
+                continue
             try:
                 awkward.types.from_datashape(obj, highlevel=False)
-                return True
             except (
                 awkward.types._awkward_datashape_parser.UnexpectedToken,
                 awkward.types._awkward_datashape_parser.UnexpectedCharacters,
             ):
                 pass
+            else:
+                continue
             return False
     return True
 
@@ -2289,6 +2292,15 @@ def _type_specification_to_awkward_form(obj):
             raise TypeError(
                 f"Cannot construct a NumPy dtype from the tuple {obj!r}."
             ) from None
+    if isinstance(obj, str):
+        # First we try to interpret the string as a NumPy dtype
+        # so we can try to convert it to a string Awkward unterstands
+        try:
+            dt = numpy.dtype(obj)
+        except (TypeError, ValueError):
+            pass
+        else:
+            obj = dt
     if isinstance(obj, numpy.dtype):
         obj = obj.newbyteorder("<")
         if obj.subdtype is None:
@@ -2309,7 +2321,7 @@ def _type_specification_to_awkward_form(obj):
             awkward.types._awkward_datashape_parser.UnexpectedCharacters,
         ):
             raise TypeError(
-                f"Cannot construct an Awkward Form of from type specification {obj!r}"
+                f"Cannot construct an Awkward Form from type specification {obj!r}"
             ) from None
     if isinstance(obj, Mapping):
         return awkward.forms.RecordForm(

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -2262,10 +2262,7 @@ def _is_type_specification(obj):
                 continue
             try:
                 awkward.types.from_datashape(obj, highlevel=False)
-            except (
-                awkward.types._awkward_datashape_parser.UnexpectedToken,
-                awkward.types._awkward_datashape_parser.UnexpectedCharacters,
-            ):
+            except Exception:
                 pass
             else:
                 continue
@@ -2282,9 +2279,7 @@ def _type_specification_to_awkward_form(obj):
         try:
             obj = numpy.dtype(obj)
         except (TypeError, ValueError):
-            raise TypeError(
-                f"Cannot construct a NumPy dtype from {obj!r} of type {type(obj).__name__}."
-            ) from None
+            raise TypeError(f"Cannot construct a NumPy dtype from {obj!r}.") from None
     if isinstance(obj, tuple):
         try:
             obj = numpy.dtype(obj)
@@ -2294,7 +2289,7 @@ def _type_specification_to_awkward_form(obj):
             ) from None
     if isinstance(obj, str):
         # First we try to interpret the string as a NumPy dtype
-        # so we can try to convert it to a string Awkward unterstands
+        # so we can try to convert it to a string Awkward understands
         try:
             dt = numpy.dtype(obj)
         except (TypeError, ValueError):
@@ -2316,10 +2311,7 @@ def _type_specification_to_awkward_form(obj):
             return awkward.forms.from_type(
                 awkward.types.from_datashape(obj, highlevel=False)
             )
-        except (
-            awkward.types._awkward_datashape_parser.UnexpectedToken,
-            awkward.types._awkward_datashape_parser.UnexpectedCharacters,
-        ):
+        except Exception:
             raise TypeError(
                 f"Cannot construct an Awkward Form from type specification {obj!r}"
             ) from None

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -2276,10 +2276,9 @@ def _type_specification_to_awkward_form(obj):
     if isinstance(obj, (awkward.types.Type, awkward.types.ArrayType)):
         return awkward.forms.from_type(obj)
     if isinstance(obj, type):
-        try:
-            obj = numpy.dtype(obj)
-        except (TypeError, ValueError):
-            raise TypeError(f"Cannot construct a NumPy dtype from {obj!r}.") from None
+        obj = numpy.dtype(obj)
+        if obj == numpy.dtype("O"):
+            raise TypeError(f"Cannot construct a NumPy dtype from {obj!r}.")
     if isinstance(obj, tuple):
         try:
             obj = numpy.dtype(obj)

--- a/tests/test_1604_write_tuple_dtypes.py
+++ b/tests/test_1604_write_tuple_dtypes.py
@@ -22,12 +22,20 @@ def test_mktree_tuple_dtype(tmp_path):
         dt3 = ("int32", ("int8", 4))
         t3 = file.mktree("tree3", {"z": dt3})
         t3.extend({"z": np.zeros(5, dtype=dt3)})
+        dt4 = "2i4"
+        t4 = file.mktree("tree4", {"w": dt4})
+        t4.extend({"w": np.zeros(5, dtype=dt4)})
+        dt5 = "(2,3,4)f4"
+        t5 = file.mktree("tree5", {"v": dt5})
+        t5.extend({"v": np.zeros(5, dtype=dt5)})
 
     with uproot.open(filepath) as file:
-        assert file.keys(cycle=False) == ["tree1", "tree2", "tree3"]
+        assert file.keys(cycle=False) == ["tree1", "tree2", "tree3", "tree4", "tree5"]
         assert file["tree1"].num_entries == 5
         assert file["tree2"].num_entries == 5
         assert file["tree3"].num_entries == 5
+        assert file["tree4"].num_entries == 5
+        assert file["tree5"].num_entries == 5
 
 
 def test_mkrntuple_tuple_dtype(tmp_path):
@@ -43,12 +51,26 @@ def test_mkrntuple_tuple_dtype(tmp_path):
         dt3 = ("int32", ("int8", 4))
         t3 = file.mkrntuple("ntuple3", {"z": dt3})
         t3.extend({"z": np.zeros(5, dtype=dt3)})
+        dt4 = "2i4"
+        t4 = file.mkrntuple("ntuple4", {"w": dt4})
+        t4.extend({"w": np.zeros(5, dtype=dt4)})
+        dt5 = "(2,3,4)f4"
+        t5 = file.mkrntuple("ntuple5", {"v": dt5})
+        t5.extend({"v": np.zeros(5, dtype=dt5)})
 
     with uproot.open(filepath) as file:
-        assert file.keys(cycle=False) == ["ntuple1", "ntuple2", "ntuple3"]
+        assert file.keys(cycle=False) == [
+            "ntuple1",
+            "ntuple2",
+            "ntuple3",
+            "ntuple4",
+            "ntuple5",
+        ]
         assert file["ntuple1"].num_entries == 5
         assert file["ntuple2"].num_entries == 5
         assert file["ntuple3"].num_entries == 5
+        assert file["ntuple4"].num_entries == 5
+        assert file["ntuple5"].num_entries == 5
 
 
 def test_unsupported_numpy_dtypes(tmp_path):
@@ -79,6 +101,13 @@ def test_unsupported_numpy_dtypes(tmp_path):
             file.mktree("tree3", {"x": dt_tuple})
         # this should work, but it is interpreted as data, not a dtype
         file.mkrntuple("ntuple3", {"x": dt_tuple})
+
+        # using some random type should not work
+        dt_unknown = frozenset
+        with pytest.raises(TypeError):
+            file.mktree("tree4", {"x": dt_tuple})
+        with pytest.raises(TypeError):
+            file.mkrntuple("ntuple4", {"x": dt_unknown})
 
     # make sure that things were written as data instead of being interpreted as dtypes
     with uproot.open(filepath) as file:

--- a/tests/test_1604_write_tuple_dtypes.py
+++ b/tests/test_1604_write_tuple_dtypes.py
@@ -105,7 +105,7 @@ def test_unsupported_numpy_dtypes(tmp_path):
         # using some random type should not work
         dt_unknown = frozenset
         with pytest.raises(TypeError):
-            file.mktree("tree4", {"x": dt_tuple})
+            file.mktree("tree4", {"x": dt_unknown})
         with pytest.raises(TypeError):
             file.mkrntuple("ntuple4", {"x": dt_unknown})
 

--- a/tests/test_1604_write_tuple_dtypes.py
+++ b/tests/test_1604_write_tuple_dtypes.py
@@ -1,0 +1,93 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import os
+import pytest
+
+import uproot
+
+import awkward as ak
+import numpy as np
+
+
+def test_mktree_tuple_dtype(tmp_path):
+    filepath = os.path.join(tmp_path, "test.root")
+
+    with uproot.recreate(filepath) as file:
+        dt1 = ("int32", (2,))
+        t1 = file.mktree("tree1", {"x": dt1})
+        t1.extend({"x": np.zeros(5, dtype=dt1)})
+        dt2 = ("int32", (2, 4, 1))
+        t2 = file.mktree("tree2", {"y": dt2})
+        t2.extend({"y": np.zeros(5, dtype=dt2)})
+        dt3 = ("int32", ("int8", 4))
+        t3 = file.mktree("tree3", {"z": dt3})
+        t3.extend({"z": np.zeros(5, dtype=dt3)})
+
+    with uproot.open(filepath) as file:
+        assert file.keys(cycle=False) == ["tree1", "tree2", "tree3"]
+        assert file["tree1"].num_entries == 5
+        assert file["tree2"].num_entries == 5
+        assert file["tree3"].num_entries == 5
+
+
+def test_mkrntuple_tuple_dtype(tmp_path):
+    filepath = os.path.join(tmp_path, "test.root")
+
+    with uproot.recreate(filepath) as file:
+        dt1 = ("int32", (2,))
+        t1 = file.mkrntuple("ntuple1", {"x": dt1})
+        t1.extend({"x": np.zeros(5, dtype=dt1)})
+        dt2 = ("int32", (2, 4, 1))
+        t2 = file.mkrntuple("ntuple2", {"y": dt2})
+        t2.extend({"y": np.zeros(5, dtype=dt2)})
+        dt3 = ("int32", ("int8", 4))
+        t3 = file.mkrntuple("ntuple3", {"z": dt3})
+        t3.extend({"z": np.zeros(5, dtype=dt3)})
+
+    with uproot.open(filepath) as file:
+        assert file.keys(cycle=False) == ["ntuple1", "ntuple2", "ntuple3"]
+        assert file["ntuple1"].num_entries == 5
+        assert file["ntuple2"].num_entries == 5
+        assert file["ntuple3"].num_entries == 5
+
+
+def test_unsupported_numpy_dtypes(tmp_path):
+    filepath = os.path.join(tmp_path, "test.root")
+
+    with uproot.recreate(filepath) as file:
+        # this should work, but it is interpreted as data, not a dtype
+        file.mktree("tree", {"x": ("int32", "not a type")})
+        file.mkrntuple("ntuple", {"x": ("int32", "not a type")})
+
+        # structured dtypes are not supported
+        complex_dtype = np.dtype([("real", "float32"), ("imag", "float32")])
+        with pytest.raises(TypeError):
+            file.mktree("tree1", {"x": complex_dtype})
+        with pytest.raises(TypeError):
+            file.mkrntuple("ntuple1", {"x": complex_dtype})
+
+        # structured dtypes specified as strings are also not supported
+        dt_str = "i4, (2,3)f8, f4"
+        with pytest.raises(TypeError):
+            file.mktree("tree2", {"x": dt_str})
+        with pytest.raises(TypeError):
+            file.mkrntuple("ntuple2", {"x": dt_str})
+
+        # using tuples to specify structured dtypes is not supported
+        dt_tuple = ("int32", [("real", "float32"), ("imag", "float32")])
+        with pytest.raises(TypeError):
+            file.mktree("tree3", {"x": dt_tuple})
+        # this should work, but it is interpreted as data, not a dtype
+        file.mkrntuple("ntuple3", {"x": dt_tuple})
+
+    # make sure that things were written as data instead of being interpreted as dtypes
+    with uproot.open(filepath) as file:
+        assert file.keys(cycle=False) == ["tree", "ntuple", "ntuple3"]
+        assert file["tree"].arrays().x[0] == "int32"
+        assert file["tree"].arrays().x[1] == "not a type"
+        assert file["ntuple"].arrays().x[0] == "int32"
+        assert file["ntuple"].arrays().x[1] == "not a type"
+        assert file["ntuple3"].arrays().x[0] == "int32"
+        assert ak.array_equal(
+            file["ntuple3"].arrays().x[1], [("real", "float32"), ("imag", "float32")]
+        )

--- a/tests/test_1604_write_tuple_dtypes.py
+++ b/tests/test_1604_write_tuple_dtypes.py
@@ -109,9 +109,20 @@ def test_unsupported_numpy_dtypes(tmp_path):
         with pytest.raises(TypeError):
             file.mkrntuple("ntuple4", {"x": dt_unknown})
 
+        with pytest.raises(AttributeError):
+            file.mktree("tree5", {1: "unknown type"})
+        with pytest.raises(ValueError):
+            file.mkrntuple("ntuple5", {1: "unknown type"})
+
+        with pytest.raises(TypeError):
+            # this one ends up creating a tree, but fails when writing the data
+            file.mktree("tree6", {"x": "unknown type"})
+        with pytest.raises(ValueError):
+            file.mkrntuple("ntuple6", {"x": "unknown type"})
+
     # make sure that things were written as data instead of being interpreted as dtypes
     with uproot.open(filepath) as file:
-        assert file.keys(cycle=False) == ["tree", "ntuple", "ntuple3"]
+        assert file.keys(cycle=False) == ["tree", "ntuple", "ntuple3", "tree6"]
         assert file["tree"].arrays().x[0] == "int32"
         assert file["tree"].arrays().x[1] == "not a type"
         assert file["ntuple"].arrays().x[0] == "int32"
@@ -120,3 +131,21 @@ def test_unsupported_numpy_dtypes(tmp_path):
         assert ak.array_equal(
             file["ntuple3"].arrays().x[1], [("real", "float32"), ("imag", "float32")]
         )
+
+
+def test_type_specification_to_awkward_form():
+    form = ak.forms.EmptyForm()
+    assert uproot.writing.writable._type_specification_to_awkward_form(form) is form
+
+    assert uproot.writing.writable._type_specification_to_awkward_form(
+        ak.types.NumpyType("int32")
+    ) == ak.forms.NumpyForm("int32")
+
+    with pytest.raises(TypeError):
+        uproot.writing.writable._type_specification_to_awkward_form(frozenset)
+
+    with pytest.raises(TypeError):
+        uproot.writing.writable._type_specification_to_awkward_form((1, 2, 3))
+
+    with pytest.raises(TypeError):
+        uproot.writing.writable._type_specification_to_awkward_form(0)


### PR DESCRIPTION
This PR fixed the regression introduced in #1515 where `mktree` stopped accepting tuples to specify a type specification. `mkrntuple` now also accepts these tuples, and in both cases the error messages for wrong types should be better.

Closes #1597