### PR TITLE
fix: use Python ints for start/stop when reading a single basket

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2655,6 +2655,8 @@ in file {self._file.file_path}"""
         if 0 <= basket_num < self._num_normal_baskets:
             start = self.member("fBasketSeek")[basket_num]
             stop = start + self.basket_compressed_bytes(basket_num)
+            # fsspec-xrootd doesn't like NumPy ints
+            start, stop = int(start), int(stop)
             cursor = uproot.source.cursor.Cursor(start)
             chunk = self._file.source.chunk(start, stop)
             return chunk, cursor

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2655,7 +2655,7 @@ in file {self._file.file_path}"""
         if 0 <= basket_num < self._num_normal_baskets:
             start = self.member("fBasketSeek")[basket_num]
             stop = start + self.basket_compressed_bytes(basket_num)
-            # fsspec-xrootd doesn't like NumPy ints
+            # xrootd doesn't like NumPy ints
             start, stop = int(start), int(stop)
             cursor = uproot.source.cursor.Cursor(start)
             chunk = self._file.source.chunk(start, stop)


### PR DESCRIPTION
`xrootd` refuses to work with NumPy ints, which was preventing reading single baskets with `xrootd`. I simply converted them to Python ints.

Closes #1582 