### PR TITLE
chore(ci): resolve issues with GPU CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -231,7 +231,6 @@ jobs:
             -c rapidsai
             python=3.13
             cuda-version=${{ matrix.cuda-version }}
-            cuda-core
             cuda-toolkit
             cuda-python
             cccl-python

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -234,7 +234,7 @@ jobs:
             cuda-version=${{ matrix.cuda-version }}
             cuda-toolkit
             cuda-python
-            cccl-python
+            cccl-python==0.5.1
             cupy
             kvikio
             nvcomp

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -229,10 +229,9 @@ jobs:
           init-shell: bash
           create-args: >-
             -c rapidsai
-            -c nvidia
             python=3.13
             cuda-version=${{ matrix.cuda-version }}
-            cuda-core>=0.6.0
+            cuda-core
             cuda-toolkit
             cuda-python
             cccl-python

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -232,9 +232,10 @@ jobs:
             -c nvidia
             python=3.13
             cuda-version=${{ matrix.cuda-version }}
+            cuda-core>=0.6.0
             cuda-toolkit
             cuda-python
-            cccl-python==0.5.1
+            cccl-python
             cupy
             kvikio
             nvcomp


### PR DESCRIPTION
`cccl-python` and `kvikio` recently got updated and broke the CI, so I'm checking how to keep the CI running while we figure out how to fix it.