### PR TITLE
fix: issues with freethreading and include Python 3.14t in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
 
       - name: Check active Python version
-        run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}', f'{version} incorrect!'"
+        run: python -c "import sys; assert '.'.join(str(s) for s in sys.version_info[:2]) == '${{ matrix.python-version }}'.split()[0], f'{version} incorrect!'"
 
       - name: Install ROOT
         if: matrix.python-version == 3.10  &&  runner.os == 'Linux'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,6 +39,10 @@ jobs:
             conda-forge/label/python_rc::_python_rc
             python=${{ matrix.python-version }}
 
+      - name: Set PYTHON_GIL=0 for free-threaded builds
+        if: contains(matrix.python-version, 'python-freethreading')
+        run: echo "PYTHON_GIL=0" >> $GITHUB_ENV
+
       - uses: astral-sh/setup-uv@v8.0.0
 
       - name: Check active Python version

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ['3.10', '3.14', 3.14t]
+        python-version: ['3.10', '3.14', 3.14 python-freethreading]
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -266,9 +266,10 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && matrix.cuda-version == 13 }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
 
   pass:
     if: always()

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.14', 3.14t]
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -646,7 +646,7 @@ in file {file_path}""")
         :ref:`uproot.reading.ReadOnlyFile.object_cache` would still be
         accessible.
         """
-        if hasattr(self, "source"):
+        if hasattr(self, "_source") and hasattr(self._source, "close"):
             self._source.close()
         if hasattr(self._decompression_executor, "shutdown"):
             self._decompression_executor.shutdown()
@@ -678,7 +678,7 @@ in file {file_path}""")
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        if hasattr(self, "_source"):
+        if hasattr(self, "_source") and hasattr(self._source, "__exit__"):
             self._source.__exit__(exception_type, exception_value, traceback)
         if hasattr(self._decompression_executor, "shutdown"):
             self._decompression_executor.shutdown()

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -646,11 +646,15 @@ in file {file_path}""")
         :ref:`uproot.reading.ReadOnlyFile.object_cache` would still be
         accessible.
         """
-        self._source.close()
+        if hasattr(self, "source"):
+            self._source.close()
         if hasattr(self._decompression_executor, "shutdown"):
-            getattr(self._decompression_executor, "shutdown", None)()
+            self._decompression_executor.shutdown()
         if hasattr(self._interpretation_executor, "shutdown"):
-            getattr(self._interpretation_executor, "shutdown", None)()
+            self._interpretation_executor.shutdown()
+
+    def __del__(self):
+        self.close()
 
     @property
     def closed(self):
@@ -674,11 +678,12 @@ in file {file_path}""")
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        self._source.__exit__(exception_type, exception_value, traceback)
+        if hasattr(self, "_source"):
+            self._source.__exit__(exception_type, exception_value, traceback)
         if hasattr(self._decompression_executor, "shutdown"):
-            getattr(self._decompression_executor, "shutdown", None)()
+            self._decompression_executor.shutdown()
         if hasattr(self._interpretation_executor, "shutdown"):
-            getattr(self._interpretation_executor, "shutdown", None)()
+            self._interpretation_executor.shutdown()
 
     @property
     def source(self):

--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import queue
 import re
 
@@ -55,20 +56,20 @@ class FSSpecSource(uproot.source.chunk.Source):
 
         file_path = _maybe_wrap_remote_url(file_path)
 
-        fsspec_options = {
+        self._fsspec_options = {
             k: v for k, v in options.items() if k not in uproot.reading.open.defaults
         }
-        self._fs, self._file_path = fsspec.core.url_to_fs(file_path, **fsspec_options)
-
-        # What should we do when there is a chain of filesystems?
-        self._async_impl = self._fs.async_impl
-
+        self._file_path_orig = file_path
         self._open()
-
-        self.__enter__()
 
     def _open(self):
         self._executor = FSSpecLoopExecutor()
+        self._open_file = fsspec.open(self._file_path_orig, **self._fsspec_options)
+        self._fs = self._open_file.fs
+        self._file_path = self._open_file.path
+        self._fo = self._open_file.__enter__()
+        self._async_impl = self._fs.async_impl
+        self._closed = False
 
     def __repr__(self):
         path = repr(self._file_path)
@@ -79,6 +80,9 @@ class FSSpecSource(uproot.source.chunk.Source):
     def __getstate__(self):
         state = dict(self.__dict__)
         state.pop("_executor")
+        state.pop("_open_file")
+        state.pop("_fo")
+        state.pop("_fs")
         return state
 
     def __setstate__(self, state):
@@ -90,6 +94,19 @@ class FSSpecSource(uproot.source.chunk.Source):
 
     def __exit__(self, exception_type, exception_value, traceback):
         self._executor.shutdown()
+        if not self._closed:
+            self._open_file.__exit__(exception_type, exception_value, traceback)
+
+            # Workaround for leaking fsspec filesystems (like ZipFileSystem/TarFileSystem)
+            # that don't correctly close their underlying file objects.
+            if hasattr(self._fs, "close"):
+                with contextlib.suppress(Exception):
+                    self._fs.close()
+            if hasattr(self._fs, "of") and hasattr(self._fs.of, "__exit__"):
+                with contextlib.suppress(Exception):
+                    self._fs.of.__exit__(None, None, None)
+
+            self._closed = True
 
     def chunk(self, start: int, stop: int) -> uproot.source.chunk.Chunk:
         """
@@ -199,8 +216,7 @@ class FSSpecSource(uproot.source.chunk.Source):
         True if the associated file/connection/thread pool is closed; False
         otherwise.
         """
-        # FSSpecSource uses entirely stateless interfaces
-        return False
+        return self._closed
 
 
 class FSSpecLoopExecutor(uproot.source.futures.Executor):

--- a/src/uproot/writing/_dask_write.py
+++ b/src/uproot/writing/_dask_write.py
@@ -176,19 +176,22 @@ def ak_to_root(
         **(storage_options or {}),
     )
 
-    branch_types = {name: array[name].type for name in array.fields}
+    try:
+        branch_types = {name: array[name].type for name in array.fields}
 
-    out_file.mktree(
-        tree_name,
-        branch_types,
-        title=title,
-        counter_name=counter_name,
-        field_name=field_name,
-        initial_basket_capacity=initial_basket_capacity,
-        resize_factor=resize_factor,
-    )
+        out_file.mktree(
+            tree_name,
+            branch_types,
+            title=title,
+            counter_name=counter_name,
+            field_name=field_name,
+            initial_basket_capacity=initial_basket_capacity,
+            resize_factor=resize_factor,
+        )
 
-    out_file[tree_name].extend({name: array[name] for name in array.fields})
+        out_file[tree_name].extend({name: array[name] for name in array.fields})
+    finally:
+        out_file.close()
 
 
 def none_to_none(*_):

--- a/tests/test_1085_dask_write.py
+++ b/tests/test_1085_dask_write.py
@@ -13,33 +13,36 @@ from distributed import Client
 import uproot
 
 
-def simple_test(tmp_path):
+def test_simple(tmp_path):
     partitions = 2
     arr = ak.Array([{"a": [1, 2, 3]}, {"a": [4, 5]}])
     dask_arr = dask_awkward.from_awkward(arr, npartitions=partitions)
     uproot.dask_write(dask_arr, tmp_path, prefix="data")
-    file_1 = uproot.open(os.path.join(tmp_path, "data-part0.root"))
-    assert len(file_1["tree"]["a"].arrays()) == math.ceil(len(arr) / partitions)
-    assert ak.all(file_1["tree"]["a"].arrays()["a"][0] == arr[0]["a"])
-    file_2 = uproot.open(os.path.join(tmp_path, "data-part1.root"))
-    assert len(file_2["tree"]["a"].arrays()) == int(len(arr) / partitions)
-    assert ak.all(file_2["tree"]["a"].arrays()["a"][0] == arr[1]["a"])
+    with uproot.open(os.path.join(tmp_path, "data-part0.root")) as file_1:
+        assert len(file_1["tree"]["a"].arrays()) == math.ceil(len(arr) / partitions)
+        assert ak.all(file_1["tree"]["a"].arrays()["a"][0] == arr[0]["a"])
+    with uproot.open(os.path.join(tmp_path, "data-part1.root")) as file_2:
+        assert len(file_2["tree"]["a"].arrays()) == int(len(arr) / partitions)
+        assert ak.all(file_2["tree"]["a"].arrays()["a"][0] == arr[1]["a"])
 
 
-def HZZ_test(tmp_path):
+def test_HZZ(tmp_path):
     """
     Write data from HZZ with 3 partitions.
     """
     partitions = 2
-    arr = uproot.open(skhep_testdata.data_path("uproot-HZZ.root"))["events"].arrays()
+    with uproot.open(skhep_testdata.data_path("uproot-HZZ.root")) as f:
+        arr = f["events"].arrays()
     dask_arr = dask_awkward.from_awkward(ak.from_iter(arr), partitions)
     uproot.dask_write(dask_arr, tmp_path, prefix="data")
-    file_1 = uproot.open(os.path.join(tmp_path, "data-part0.root"))
-    assert len(file_1["tree"]["Jet_Px"].arrays()) == math.ceil(len(arr) / partitions)
-    assert ak.all(file_1["tree"]["Jet_Px"].arrays()["Jet_Px"][0] == arr["Jet_Px"])
-    file_2 = uproot.open(os.path.join(tmp_path, "data-part1.root"))
-    assert len(file_2["tree"]["Jet_Px"].arrays()) == int(len(arr) / partitions)
-    assert ak.all(file_2["tree"]["Jet_Px"].arrays()["Jet_Px"][0] == arr["Jet_Px"])
+    with uproot.open(os.path.join(tmp_path, "data-part0.root")) as file_1:
+        assert len(file_1["tree"]["Jet_Px"].arrays()) == math.ceil(
+            len(arr) / partitions
+        )
+        assert ak.all(file_1["tree"]["Jet_Px"].arrays()["Jet_Px"][0] == arr["Jet_Px"])
+    with uproot.open(os.path.join(tmp_path, "data-part1.root")) as file_2:
+        assert len(file_2["tree"]["Jet_Px"].arrays()) == int(len(arr) / partitions)
+        assert ak.all(file_2["tree"]["Jet_Px"].arrays()["Jet_Px"][0] == arr["Jet_Px"])
 
 
 def test_graph(tmp_path):
@@ -56,18 +59,19 @@ def test_graph(tmp_path):
         compute=False,
     )
     graph.compute()
-    file_1 = uproot.open(os.path.join(tmp_path, "compute-part0.root"))
-    assert len(file_1["tree"]["a"].arrays()) == math.ceil(len(arr) / partitions)
-    assert ak.all(file_1["tree"]["a"].arrays()["a"][0] == arr[0]["a"])
-    file_2 = uproot.open(os.path.join(tmp_path, "compute-part1.root"))
-    assert len(file_2["tree"]["a"].arrays()) == int(len(arr) / partitions)
-    assert ak.all(file_2["tree"]["a"].arrays()["a"][0] == arr[1]["a"])
+    with uproot.open(os.path.join(tmp_path, "compute-part0.root")) as file_1:
+        assert len(file_1["tree"]["a"].arrays()) == math.ceil(len(arr) / partitions)
+        assert ak.all(file_1["tree"]["a"].arrays()["a"][0] == arr[0]["a"])
+    with uproot.open(os.path.join(tmp_path, "compute-part1.root")) as file_2:
+        assert len(file_2["tree"]["a"].arrays()) == int(len(arr) / partitions)
+        assert ak.all(file_2["tree"]["a"].arrays()["a"][0] == arr[1]["a"])
 
 
 @pytest.mark.distributed
 def test_compute(tmp_path):
     partitions = 2
-    arr = uproot.open(skhep_testdata.data_path("uproot-HZZ.root"))["events"].arrays()
+    with uproot.open(skhep_testdata.data_path("uproot-HZZ.root")) as f:
+        arr = f["events"].arrays()
     dask_arr = dask_awkward.from_awkward(ak.from_iter(arr), partitions)
     with Client():
         graph = uproot.dask_write(
@@ -75,9 +79,11 @@ def test_compute(tmp_path):
         )
         dask.compute(graph)
     dask_arr = dask_awkward.from_awkward(ak.from_iter(arr), partitions)
-    file_1 = uproot.open(os.path.join(tmp_path, "distribute-part0.root"))
-    assert len(file_1["tree"]["Jet_Px"].arrays()) == math.ceil(len(arr) / partitions)
-    assert ak.all(file_1["tree"]["Jet_Px"].arrays()["Jet_Px"][0] == arr["Jet_Px"])
-    file_2 = uproot.open(os.path.join(tmp_path, "distribute-part1.root"))
-    assert len(file_2["tree"]["Jet_Px"].arrays()) == int(len(arr) / partitions)
-    assert ak.all(file_2["tree"]["Jet_Px"].arrays()["Jet_Px"][0] == arr["Jet_Px"])
+    with uproot.open(os.path.join(tmp_path, "distribute-part0.root")) as file_1:
+        assert len(file_1["tree"]["Jet_Px"].arrays()) == math.ceil(
+            len(arr) / partitions
+        )
+        assert ak.all(file_1["tree"]["Jet_Px"].arrays()["Jet_Px"][0] == arr["Jet_Px"])
+    with uproot.open(os.path.join(tmp_path, "distribute-part1.root")) as file_2:
+        assert len(file_2["tree"]["Jet_Px"].arrays()) == int(len(arr) / partitions)
+        assert ak.all(file_2["tree"]["Jet_Px"].arrays()["Jet_Px"][0] == arr["Jet_Px"])

--- a/tests/test_1393_TTree_virtual_arrays.py
+++ b/tests/test_1393_TTree_virtual_arrays.py
@@ -14,8 +14,7 @@ def test_ttree_virtual_arrays_no_log():
         tree = file["events"]
         eager = tree.arrays()
         virtual = tree.arrays(virtual=True, access_log=None)
-
-    assert ak.materialize(virtual).layout.is_equal_to(eager.layout)
+        assert ak.materialize(virtual).layout.is_equal_to(eager.layout)
 
 
 def test_ttree_virtual_arrays_with_log():
@@ -26,11 +25,11 @@ def test_ttree_virtual_arrays_with_log():
         eager = tree.arrays()
         virtual = tree.arrays(virtual=True, access_log=log)
 
-    assert len(log) == 0
-    assert ak.materialize(virtual).layout.is_equal_to(eager.layout)
-    assert len(log) == 21
+        assert len(log) == 0
+        assert ak.materialize(virtual).layout.is_equal_to(eager.layout)
+        assert len(log) == 21
 
-    assert set(tree.keys()) == set({a.branch for a in log})
+        assert set(tree.keys()) == set({a.branch for a in log})
 
 
 def test_ttree_virtual_arrays_single_branch():
@@ -41,11 +40,11 @@ def test_ttree_virtual_arrays_single_branch():
         eager = branch.arrays()
         virtual = branch.arrays(virtual=True, access_log=log)
 
-    assert len(log) == 0
-    assert ak.materialize(virtual).layout.is_equal_to(eager.layout)
-    assert len(log) == 1
+        assert len(log) == 0
+        assert ak.materialize(virtual).layout.is_equal_to(eager.layout)
+        assert len(log) == 1
 
-    assert {"Run"} == set({a.branch for a in log})
+        assert {"Run"} == set({a.branch for a in log})
 
 
 def test_ttree_virtual_arrays_nonsense_kwargs_combinations():


### PR DESCRIPTION
This PR adds 3.14t to the CI matrix. I also removed intermediate versions to keep the number of jobs now, since they shouldn't really be necessary.

AI disclosure: I used assistance from Gemini for this PR.