### PR TITLE
fix: FreeSegments end calculation when crossing 2 GB boundary

### DIFF
--- a/src/uproot/writing/_cascade.py
+++ b/src/uproot/writing/_cascade.py
@@ -521,6 +521,20 @@ class FreeSegmentsData(CascadeLeaf):
 
         return total
 
+    def required_end(self, data_location):
+        total = 0
+        for _, stop in self._slices:
+            if stop - 1 >= uproot.const.kStartBigFile:
+                total += _free_format_big.size
+            else:
+                total += _free_format_small.size
+
+        tentative_end = data_location + total + _free_format_small.size
+        if tentative_end < uproot.const.kStartBigFile:
+            return tentative_end
+        else:
+            return data_location + total + _free_format_big.size
+
     def serialize(self):
         pairs = []
         for start, stop in self._slices:
@@ -660,8 +674,8 @@ class FreeSegments(CascadeNode):
             out = self._key.location
             if not dry_run:
                 self._key.location = self._key.location + num_bytes
-                self._data.end = (
-                    self._key.location + self._key.allocation + self._data.allocation
+                self._data.end = self._data.required_end(
+                    self._key.location + self._key.num_bytes
                 )
             return out
 
@@ -720,12 +734,11 @@ class FreeSegments(CascadeNode):
 
         if self.at_end:
             self._data.slices = new_slices
-            self._data.allocation = None
+            self._data.end = self._data.required_end(
+                self._key.location + self._key.num_bytes
+            )
             self._key.uncompressed_bytes = self._data.allocation
             self._key.compressed_bytes = self._key.uncompressed_bytes
-            self._data.end = (
-                self._key.location + self._key.allocation + self._key.uncompressed_bytes
-            )
 
         elif self._slices_bytes(new_slices) <= self._slices_bytes(self._data.slices):
             # Wherever the FreeSegments record is, it's not getting bigger.
@@ -744,12 +757,12 @@ class FreeSegments(CascadeNode):
                 self._key.location,
                 self._key.location + self._key.allocation + self._data.allocation,
             )
-            self._data.allocation = None
+            self._key.location = self._data.end
+            self._data.end = self._data.required_end(
+                self._key.location + self._key.num_bytes
+            )
             self._key.uncompressed_bytes = self._data.allocation
             self._key.compressed_bytes = self._key.uncompressed_bytes
-            self._key.location = self._data.end
-            self._data.location = self._key.location + self._key.allocation
-            self._data.end = self._data.location + self._key.uncompressed_bytes
 
     def write(self, sink):
         self._key.uncompressed_bytes = self._data.allocation

--- a/src/uproot/writing/_cascade.py
+++ b/src/uproot/writing/_cascade.py
@@ -451,6 +451,28 @@ _free_format_small = struct.Struct(">HII")
 _free_format_big = struct.Struct(">HQQ")
 
 
+def _slices_bytes(slices):
+    total = 0
+    for _, stop in slices:
+        if stop - 1 >= uproot.const.kStartBigFile:
+            total += _free_format_big.size
+        else:
+            total += _free_format_small.size
+    return total
+
+
+def _free_segments_num_bytes(slices, file_end, data_location=0):
+    total = _slices_bytes(slices)
+
+    if file_end is None:
+        file_end = (data_location or 0) + total + _free_format_small.size
+
+    if file_end >= uproot.const.kStartBigFile:
+        return total + _free_format_big.size
+    else:
+        return total + _free_format_small.size
+
+
 class FreeSegmentsData(CascadeLeaf):
     """
     A :doc:`uproot.writing._cascade.CascadeLeaf` for the FreeSegments record
@@ -502,38 +524,12 @@ class FreeSegmentsData(CascadeLeaf):
 
     @property
     def num_bytes(self):
-        total = 0
-        for _, stop in self._slices:
-            if stop - 1 >= uproot.const.kStartBigFile:
-                total += _free_format_big.size
-            else:
-                total += _free_format_small.size
-
-        if self._end is None:
-            if total + _free_format_small.size >= uproot.const.kStartBigFile:
-                total += _free_format_big.size
-            else:
-                total += _free_format_small.size
-        elif self._end >= uproot.const.kStartBigFile:
-            total += _free_format_big.size
-        else:
-            total += _free_format_small.size
-
-        return total
+        return _free_segments_num_bytes(self._slices, self._end, self._location)
 
     def required_end(self, data_location):
-        total = 0
-        for _, stop in self._slices:
-            if stop - 1 >= uproot.const.kStartBigFile:
-                total += _free_format_big.size
-            else:
-                total += _free_format_small.size
-
-        tentative_end = data_location + total + _free_format_small.size
-        if tentative_end < uproot.const.kStartBigFile:
-            return tentative_end
-        else:
-            return data_location + total + _free_format_big.size
+        return data_location + _free_segments_num_bytes(
+            self._slices, None, data_location
+        )
 
     def serialize(self):
         pairs = []
@@ -721,13 +717,7 @@ class FreeSegments(CascadeNode):
 
     @staticmethod
     def _slices_bytes(slices):
-        total = 0
-        for _, stop in slices:
-            if stop - 1 >= uproot.const.kStartBigFile:
-                total += _free_format_big.size
-            else:
-                total += _free_format_small.size
-        return total
+        return _slices_bytes(slices)
 
     def release(self, start, stop):
         new_slices = self._another_slice(self._data.slices, start, stop)

--- a/tests/test_1622_bigfile_boundary_crossing.py
+++ b/tests/test_1622_bigfile_boundary_crossing.py
@@ -1,0 +1,33 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import uproot
+import uproot.writing._cascade
+import uproot.const
+
+
+def test_freesegments_num_bytes_at_boundary():
+    # End pointer is below 2GB
+    data_small = uproot.writing._cascade.FreeSegmentsData(
+        0, (), uproot.const.kStartBigFile - 5
+    )
+    assert data_small.num_bytes == 10  # small format size
+
+    # End pointer is at or above 2GB
+    data_big = uproot.writing._cascade.FreeSegmentsData(
+        0, (), uproot.const.kStartBigFile + 5
+    )
+    assert data_big.num_bytes == 18  # big format size
+
+
+def test_freesegments_num_bytes_with_location():
+    # location is far below boundary, end is None (floating)
+    # tentative end would be 0 + 0 + 10 = 10 (< 2GB)
+    data_floating_small = uproot.writing._cascade.FreeSegmentsData(0, (), None)
+    assert data_floating_small.num_bytes == 10
+
+    # location is near boundary, end is None (floating)
+    # tentative end would be (2GB - 5) + 0 + 10 = 2GB + 5 (>= 2GB)
+    data_floating_big = uproot.writing._cascade.FreeSegmentsData(
+        uproot.const.kStartBigFile - 5, (), None
+    )
+    assert data_floating_big.num_bytes == 18


### PR DESCRIPTION
This PR fixes #1620. It turned out that #1601 caused an issue where `self._data.end` was set expecting the file to stay below 2GB, but then when writing it would realize it needed to switch to using a big file pointer, so there was a mismatch. The `required_end` takes into account whether it will have to be extended into a big file.

AI disclosure: I used assistance from Gemini for this PR, but I fully verified the changes and the logic.