### PR TITLE
fix: implement report=True for RNTuple.iterate

### DIFF
--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -44,7 +44,7 @@ def iterate(
     library="ak",  # TODO: Not implemented yet
     ak_add_doc=False,
     how=None,
-    report=False,  # TODO: Not implemented yet
+    report=False,
     allow_missing=False,  # TODO: Not implemented yet
     # For compatibility reasons we also accepts kwargs meant for TTrees
     filter_branch=unset,
@@ -908,7 +908,7 @@ class HasFields(Mapping):
         interpreter="cpu",
         ak_add_doc=False,
         how=None,
-        report=False,  # TODO: Not implemented yet
+        report=False,
         # For compatibility reasons we also accepts kwargs meant for TTrees
         interpretation_executor=None,
         filter_branch=unset,
@@ -964,7 +964,7 @@ class HasFields(Mapping):
             report (bool): If True, this generator yields
                 (arrays, :doc:`uproot.behaviors.TBranch.Report`) pairs; if False,
                 it only yields arrays. The report has data about the ``TFile``,
-                ``RNTuple``, and global and local entry ranges. (Not implemented yet.)
+                ``RNTuple``, and global and local entry ranges.
             interpretation_executor (None): This argument is not used and is only included for now
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
                 and will be removed in a future version.

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -1016,7 +1016,7 @@ class HasFields(Mapping):
         )
         # TODO: This can be done more efficiently
         for start in range(entry_start, entry_stop, step_size):
-            yield self.arrays(
+            arrays = self.arrays(
                 filter_name=filter_name,
                 filter_typename=filter_typename,
                 filter_field=filter_field,
@@ -1028,6 +1028,13 @@ class HasFields(Mapping):
                 how=how,
                 filter_branch=filter_branch,
             )
+            if report:
+                sub_entry_stop = min(start + step_size, entry_stop)
+                yield arrays, uproot.behaviors.TBranch.Report(
+                    self, start, sub_entry_stop
+                )
+            else:
+                yield arrays
 
     def keys(
         self,

--- a/tests/test_1630_rntuple_iterate_report.py
+++ b/tests/test_1630_rntuple_iterate_report.py
@@ -1,0 +1,36 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import skhep_testdata
+
+import uproot
+
+
+def test_rntuple_iterate_report():
+    """
+    ``RNTuple.iterate(report=True)`` must yield ``(arrays, Report)`` pairs,
+    matching the contract documented in its docstring and already provided
+    by ``TTree.iterate``.
+    """
+    path = skhep_testdata.data_path("ntpl001_staff_rntuple_v1-0-0-0.root")
+    with uproot.open(path)["Staff"] as rntuple:
+        for i, (arrays, report) in enumerate(
+            rntuple.iterate("Age", step_size=1000, report=True)
+        ):
+            if i == 0:
+                assert report.tree_entry_start == 0
+                assert report.tree_entry_stop == 1000
+                assert report.file_path == path
+            elif i == 1:
+                assert report.tree_entry_start == 1000
+                assert report.tree_entry_stop == 2000
+                assert report.file_path == path
+            elif i == 2:
+                assert report.tree_entry_start == 2000
+                assert report.tree_entry_stop == 3000
+                assert report.file_path == path
+            elif i == 3:
+                assert report.tree_entry_start == 3000
+                assert report.tree_entry_stop == 3354
+                assert report.file_path == path
+            else:
+                assert False


### PR DESCRIPTION
Fixes #1628 

`RNTuple.iterate` accepted a `report` parameter but never used it. As a result:

- `uproot.iterate("file.root:rntuple", report=True)` crashed with `ValueError: too many values to unpack (expected 2)` at `src/uproot/behaviors/TBranch.py:216`.
   - `rn.iterate(report=True)` silently returned a bare `Array` instead of the `(arrays, Report)` tuple that the docstring promises.

I have added the regression test (`tests/test_1630_rntuple_iterate_report.py`), mirroring the format of the existing TTree iterate-report tests in `tests/test_0043_iterate_function.py`. 

  This PR yields `(arrays, Report)` when `report=True`, matching the TTree contract. The `report=False` path is unchanged.