### PR TITLE
feat: finish implementing `library` kwarg for RNTuples

### DIFF
--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -866,12 +866,11 @@ class HasFields(Mapping):
                 try:
                     numpy_data[f] = arrays[f].to_numpy()
                 except (ValueError, TypeError):
-                    # try:
-                    #     numpy_data[f] = _jagged_to_numpy(arrays[f])
-                    # except Exception:
-                    #     msg = f"Field {f} cannot be converted to NumPy/Pandas"
-                    #     raise ValueError(msg) from None
-                    numpy_data[f] = _jagged_to_numpy(arrays[f])
+                    try:
+                        numpy_data[f] = _awkward_to_numpy(arrays[f])
+                    except Exception:
+                        msg = f"Field {f} cannot be converted to NumPy/Pandas"
+                        raise ValueError(msg) from None
             if library.name == "pd":
                 pd = uproot.extras.pandas()
                 pandas_data = pd.DataFrame(numpy_data)
@@ -1974,7 +1973,7 @@ def _fill_container_dict(container_dict, content, key, dtype_byte, dtype):
             container_dict[f"{key}-offsets"] = content
 
 
-def _jagged_to_numpy(data):
+def _awkward_to_numpy(data):
     if isinstance(data, str):
         return data
 
@@ -1983,7 +1982,7 @@ def _jagged_to_numpy(data):
             return data.to_numpy()
         except (TypeError, ValueError):
             fields = data.fields
-            arrays = [_jagged_to_numpy(data[f]) for f in fields]
+            arrays = [_awkward_to_numpy(data[f]) for f in fields]
             dtypes = [arr.dtype if len(arr.shape) == 1 else "O" for arr in arrays]
             tuple_array = [tuple(arr[i] for arr in arrays) for i in range(len(data))]
             del arrays
@@ -1994,7 +1993,7 @@ def _jagged_to_numpy(data):
     if not isinstance(data, Iterable) or len(data) == 0:
         return numpy.asarray(data)
 
-    converted = [_jagged_to_numpy(item) for item in data]
+    converted = [_awkward_to_numpy(item) for item in data]
 
     shapes = [c.shape if isinstance(c, numpy.ndarray) else (1,) for c in converted]
     if len(set(shapes)) == 1:

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -41,7 +41,7 @@ def iterate(
     language=uproot.language.python.python_language,  # TODO: Not implemented yet
     step_size="100 MB",
     decompression_executor=None,  # TODO: Not implemented yet
-    library="ak",  # TODO: Not implemented yet
+    library="ak",
     ak_add_doc=False,
     how=None,
     report=False,  # TODO: Not implemented yet
@@ -84,7 +84,7 @@ def iterate(
             :doc:`uproot.source.futures.TrivialExecutor` is created. (Not implemented yet.)
         library (str or :doc:`uproot.interpretation.library.Library`): The library
             that is used to represent arrays. Options are ``"np"`` for NumPy,
-            ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas. (Not implemented yet.)
+            ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
         ak_add_doc (bool | dict ): If True and ``library="ak"``, add the RField ``description``
             to the Awkward ``__doc__`` parameter of the array.
             if dict = {key:value} and ``library="ak"``, add the RField ``value`` to the
@@ -211,7 +211,7 @@ def concatenate(
     entry_start=None,
     entry_stop=None,
     decompression_executor=None,  # TODO: Not implemented yet
-    library="ak",  # TODO: Not implemented yet
+    library="ak",
     backend="cpu",
     interpreter="cpu",
     ak_add_doc=False,
@@ -257,7 +257,7 @@ def concatenate(
             :doc:`uproot.source.futures.TrivialExecutor` is created. (Not implemented yet.)
         library (str or :doc:`uproot.interpretation.library.Library`): The library
             that is used to represent arrays. Options are ``"np"`` for NumPy,
-            ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas. (Not implemented yet.)
+            ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
         ak_add_doc (bool | dict ): If True and ``library="ak"``, add the RField ``description``
             to the Awkward ``__doc__`` parameter of the array.
             if dict = {key:value} and ``library="ak"``, add the RField ``value`` to the
@@ -522,9 +522,9 @@ class HasFields(Mapping):
                 filter to select ``RFields`` using the full
                 :doc:`uproot.models.RNTuple.RField` object. The ``RField`` is
                 included if the function returns True, excluded if it returns False.
-            ak_add_doc (bool | dict ): If True and ``library="ak"``, add the RField ``description``
+            ak_add_doc (bool | dict ): If True, add the RField ``description``
                 to the Awkward ``__doc__`` parameter of the array.
-                if dict = {key:value} and ``library="ak"``, add the RField ``value`` to the
+                if dict = {key:value}, add the RField ``value`` to the
                 Awkward ``key`` parameter of the array.
             filter_branch (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool): An alias for ``filter_field`` included
                 for compatibility with software that was used for :doc:`uproot.behaviors.TBranch.TBranch`. This argument should not be used
@@ -620,7 +620,7 @@ class HasFields(Mapping):
         entry_stop=None,
         decompression_executor=None,  # TODO: Not implemented yet
         array_cache="inherit",
-        library="ak",  # TODO: Not implemented yet
+        library="ak",
         backend="cpu",
         interpreter="cpu",
         ak_add_doc=False,
@@ -668,7 +668,7 @@ class HasFields(Mapping):
                 if a memory size, create a new cache of this size.
             library (str or :doc:`uproot.interpretation.library.Library`): The library
                 that is used to represent arrays. Options are ``"np"`` for NumPy,
-                ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas. (Not implemented yet.)
+                ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
             backend (str): The backend Awkward Array will use.
             interpreter (str): If "cpu" will use cpu to interpret raw data. If "gpu" and
                 ``backend="cuda"`` will use KvikIO bindings to CuFile and nvCOMP to
@@ -860,11 +860,22 @@ class HasFields(Mapping):
                         )
 
         # TODO: The conversion would be ideally be fully handled by Awkward.
-        # However, jagged arrays fail to be converted.
-        # We still need to match the TTree behavior for jagged arrays, and implement
-        # the conversion to Pandas.
-        if library.name == "np":
-            return arrays.to_numpy()
+        if library.name in ("np", "pd"):
+            numpy_data = {}
+            for f in arrays.fields:
+                try:
+                    numpy_data[f] = arrays[f].to_numpy()
+                except (ValueError, TypeError):
+                    try:
+                        numpy_data[f] = _jagged_to_numpy(arrays[f].tolist())
+                    except Exception:
+                        msg = f"Field {f} cannot be converted to NumPy/Pandas"
+                        raise ValueError(msg) from None
+            if library.name == "pd":
+                pd = uproot.extras.pandas()
+                pandas_data = pd.DataFrame(numpy_data)
+                return pandas_data
+            return numpy_data
 
         # TODO: This should be done with library.group, if possible
         if how is tuple:
@@ -903,7 +914,7 @@ class HasFields(Mapping):
         entry_stop=None,
         step_size="100 MB",
         decompression_executor=None,  # TODO: Not implemented yet
-        library="ak",  # TODO: Not implemented yet
+        library="ak",
         backend="cpu",
         interpreter="cpu",
         ak_add_doc=False,
@@ -951,11 +962,11 @@ class HasFields(Mapping):
                 is used. (Not implemented yet.)
             library (str or :doc:`uproot.interpretation.library.Library`): The library
                 that is used to represent arrays. Options are ``"np"`` for NumPy,
-                ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas. (Not implemented yet.)
+                ``"ak"`` for Awkward Array, and ``"pd"`` for Pandas.
             ak_add_doc (bool | dict ): If True and ``library="ak"``, add the RField ``description``
                 to the Awkward ``__doc__`` parameter of the array.
                 if dict = {key:value} and ``library="ak"``, add the RField ``value`` to the
-                Awkward ``key`` parameter of the array. (Not implemented yet.)
+                Awkward ``key`` parameter of the array.
             how (None, str, or container type): Library-dependent instructions
                 for grouping. The only recognized container types are ``tuple``,
                 ``list``, and ``dict``. Note that the container *type itself*
@@ -1960,3 +1971,18 @@ def _fill_container_dict(container_dict, content, key, dtype_byte, dtype):
         else:
             container_dict[f"{key}-data"] = content
             container_dict[f"{key}-offsets"] = content
+
+
+def _jagged_to_numpy(data):
+    if not isinstance(data, list) or len(data) == 0:
+        return numpy.asarray(data)
+
+    converted = [_jagged_to_numpy(item) for item in data]
+
+    shapes = [c.shape for c in converted]
+    if len(set(shapes)) == 1:
+        return numpy.array(converted)
+
+    arr = numpy.empty(len(converted), dtype=object)
+    arr[:] = converted
+    return arr

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import sys
 import warnings
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from functools import partial
 
 import awkward as ak
@@ -866,11 +866,12 @@ class HasFields(Mapping):
                 try:
                     numpy_data[f] = arrays[f].to_numpy()
                 except (ValueError, TypeError):
-                    try:
-                        numpy_data[f] = _jagged_to_numpy(arrays[f].tolist())
-                    except Exception:
-                        msg = f"Field {f} cannot be converted to NumPy/Pandas"
-                        raise ValueError(msg) from None
+                    # try:
+                    #     numpy_data[f] = _jagged_to_numpy(arrays[f])
+                    # except Exception:
+                    #     msg = f"Field {f} cannot be converted to NumPy/Pandas"
+                    #     raise ValueError(msg) from None
+                    numpy_data[f] = _jagged_to_numpy(arrays[f])
             if library.name == "pd":
                 pd = uproot.extras.pandas()
                 pandas_data = pd.DataFrame(numpy_data)
@@ -1974,12 +1975,28 @@ def _fill_container_dict(container_dict, content, key, dtype_byte, dtype):
 
 
 def _jagged_to_numpy(data):
-    if not isinstance(data, list) or len(data) == 0:
+    if isinstance(data, str):
+        return data
+
+    if isinstance(data, ak.Array) and isinstance(data.layout, ak.contents.RecordArray):
+        try:
+            return data.to_numpy()
+        except (TypeError, ValueError):
+            fields = data.fields
+            arrays = [_jagged_to_numpy(data[f]) for f in fields]
+            dtypes = [arr.dtype if len(arr.shape) == 1 else "O" for arr in arrays]
+            tuple_array = [tuple(arr[i] for arr in arrays) for i in range(len(data))]
+            del arrays
+            return numpy.array(
+                tuple_array, dtype=list(zip(fields, dtypes, strict=True))
+            )
+
+    if not isinstance(data, Iterable) or len(data) == 0:
         return numpy.asarray(data)
 
     converted = [_jagged_to_numpy(item) for item in data]
 
-    shapes = [c.shape for c in converted]
+    shapes = [c.shape if isinstance(c, numpy.ndarray) else (1,) for c in converted]
     if len(set(shapes)) == 1:
         return numpy.array(converted)
 

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -875,7 +875,10 @@ class HasFields(Mapping):
                         raise ValueError(msg) from None
             if library.name == "pd":
                 pd = uproot.extras.pandas()
-                pandas_data = pd.DataFrame(numpy_data)
+                pandas_index = pd.RangeIndex(
+                    start=entry_start, stop=entry_start + len(arrays)
+                )
+                pandas_data = pd.DataFrame(numpy_data, index=pandas_index)
                 arrays = pandas_data
             else:
                 arrays = numpy_data

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -877,7 +877,8 @@ class HasFields(Mapping):
                 pd = uproot.extras.pandas()
                 pandas_data = pd.DataFrame(numpy_data)
                 arrays = pandas_data
-            arrays = numpy_data
+            else:
+                arrays = numpy_data
 
         if how is not None:
             arrays = library.group(arrays, expression_context, how)

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -859,6 +859,8 @@ class HasFields(Mapping):
                             "The array was not constructed correctly. Please report this issue."
                         )
 
+        expression_context = [(f, None) for f in arrays.fields]
+
         # TODO: The conversion would be ideally be fully handled by Awkward.
         if library.name in ("np", "pd"):
             numpy_data = {}
@@ -874,20 +876,12 @@ class HasFields(Mapping):
             if library.name == "pd":
                 pd = uproot.extras.pandas()
                 pandas_data = pd.DataFrame(numpy_data)
-                return pandas_data
-            return numpy_data
+                arrays = pandas_data
+            arrays = numpy_data
 
-        # TODO: This should be done with library.group, if possible
-        if how is tuple:
-            arrays = tuple(arrays[f] for f in arrays.fields)
-        elif how is list:
-            arrays = [arrays[f] for f in arrays.fields]
-        elif how is dict:
-            arrays = {f: arrays[f] for f in arrays.fields}
-        elif how is not None:
-            raise ValueError(
-                f"unrecognized 'how' parameter: {how}. Options are None, tuple, list and dict."
-            )
+        if how is not None:
+            arrays = library.group(arrays, expression_context, how)
+
         return arrays
 
     def __array__(self, *args, **kwargs):

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -210,6 +210,7 @@ def iterate(
                         filter_branch=(
                             filter_branch
                             if isinstance(hasbranches, HasBranches)
+                            or filter_branch is not no_filter
                             else unset
                         ),
                         **(
@@ -437,7 +438,10 @@ def concatenate(
                     filter_name=filter_name,
                     filter_typename=filter_typename,
                     filter_branch=(
-                        filter_branch if isinstance(hasbranches, HasBranches) else unset
+                        filter_branch
+                        if isinstance(hasbranches, HasBranches)
+                        or filter_branch is not no_filter
+                        else unset
                     ),
                     **(
                         {}

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -27,7 +27,7 @@ import uproot
 import uproot.interpretation.grouped
 import uproot.language.python
 import uproot.source.chunk
-from uproot._util import get_ttree_form, no_filter
+from uproot._util import get_ttree_form, no_filter, unset
 
 np_uint8 = numpy.dtype("u1")
 
@@ -57,6 +57,7 @@ def iterate(
     filter_name=no_filter,
     filter_typename=no_filter,
     filter_branch=no_filter,
+    filter_field=no_filter,
     aliases=None,
     language=uproot.language.python.python_language,
     step_size="100 MB",
@@ -90,7 +91,12 @@ def iterate(
             returns True, it is included with its standard
             :ref:`uproot.behaviors.TBranch.TBranch.interpretation`; if an
             :doc:`uproot.interpretation.Interpretation`, this interpretation
-            overrules the standard one.
+            overrules the standard one. Only used for TTrees.
+        filter_field (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool, or None): A
+            filter to select ``RFields`` using the full
+            :doc:`uproot.models.RNTuple.RField` object. If the function
+            returns False or None, the ``RField`` is excluded; if the function
+            returns True, it is included. Only used for RNTuples.
         aliases (None or dict of str \u2192 str): Mathematical expressions that
             can be used in ``expressions`` or other aliases (without cycles).
             Uses the ``language`` engine to evaluate. If None, only the
@@ -201,7 +207,16 @@ def iterate(
                         cut=cut,
                         filter_name=filter_name,
                         filter_typename=filter_typename,
-                        filter_branch=filter_branch,
+                        filter_branch=(
+                            filter_branch
+                            if isinstance(hasbranches, HasBranches)
+                            else unset
+                        ),
+                        **(
+                            {}
+                            if isinstance(hasbranches, HasBranches)
+                            else {"filter_field": filter_field}
+                        ),
                         aliases=aliases,
                         language=language,
                         step_size=step_size,
@@ -243,6 +258,7 @@ def concatenate(
     filter_name=no_filter,
     filter_typename=no_filter,
     filter_branch=no_filter,
+    filter_field=no_filter,
     aliases=None,
     language=uproot.language.python.python_language,
     entry_start=None,
@@ -276,7 +292,12 @@ def concatenate(
             returns True, it is included with its standard
             :ref:`uproot.behaviors.TBranch.TBranch.interpretation`; if an
             :doc:`uproot.interpretation.Interpretation`, this interpretation
-            overrules the standard one.
+            overrules the standard one. Only used for TTrees.
+        filter_field (None or function of :doc:`uproot.models.RNTuple.RField` \u2192 bool, or None): A
+            filter to select ``RFields`` using the full
+            :doc:`uproot.models.RNTuple.RField` object. If the function
+            returns False or None, the ``RField`` is excluded; if the function
+            returns True, it is included. Only used for RNTuples.
         aliases (None or dict of str \u2192 str): Mathematical expressions that
             can be used in ``expressions`` or other aliases (without cycles).
             Uses the ``language`` engine to evaluate. If None, only the
@@ -415,7 +436,14 @@ def concatenate(
                     cut=cut,
                     filter_name=filter_name,
                     filter_typename=filter_typename,
-                    filter_branch=filter_branch,
+                    filter_branch=(
+                        filter_branch if isinstance(hasbranches, HasBranches) else unset
+                    ),
+                    **(
+                        {}
+                        if isinstance(hasbranches, HasBranches)
+                        else {"filter_field": filter_field}
+                    ),
                     aliases=aliases,
                     language=language,
                     entry_start=local_entry_start,

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -2021,7 +2021,7 @@ class RField(uproot.behaviors.RNTuple.HasFields):
                     raise ValueError(msg) from None
             if library.name == "pd":
                 pd = uproot.extras.pandas()
-                pandas_data = pd.DataFrame({self.name: numpy_data})
+                pandas_data = pd.Series(numpy_data)
                 return pandas_data
             return numpy_data
 

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -2021,7 +2021,11 @@ class RField(uproot.behaviors.RNTuple.HasFields):
                     raise ValueError(msg) from None
             if library.name == "pd":
                 pd = uproot.extras.pandas()
-                pandas_data = pd.Series(numpy_data)
+                index_start = 0 if entry_start is None else entry_start
+                pandas_index = pd.RangeIndex(
+                    start=index_start, stop=index_start + len(arrays)
+                )
+                pandas_data = pd.Series(numpy_data, index=pandas_index)
                 return pandas_data
             return numpy_data
 

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -560,9 +560,9 @@ in file {self.file.file_path}"""
         Args:
             this_id (int): The field id.
             keys (list): The list of keys to search for.
-            ak_add_doc (bool | dict ): If True and ``library="ak"``, add the RField ``description``
+            ak_add_doc (bool | dict ): If True, add the RField ``description``
                 to the Awkward ``__doc__`` parameter of the array.
-                if dict = {key:value} and ``library="ak"``, add the RField ``value`` to the
+                if dict = {key:value}, add the RField ``value`` to the
                 Awkward ``key`` parameter of the array.
 
         Returns an Awkward Form describing the field.
@@ -2008,12 +2008,24 @@ class RField(uproot.behaviors.RNTuple.HasFields):
                     "The array was not constructed correctly. Please report this issue."
                 )
         library = uproot.interpretation.library._regularize_library(library)
+
         # TODO: The conversion would be ideally be fully handled by Awkward.
-        # However, jagged arrays fail to be converted.
-        # We still need to match the TTree behavior for jagged arrays, and implement
-        # the conversion to Pandas.
-        if library.name == "np":
-            return arrays.to_numpy()
+        if library.name in ("np", "pd"):
+            try:
+                numpy_data = arrays.to_numpy()
+            except (ValueError, TypeError):
+                try:
+                    numpy_data = uproot.behaviors.RNTuple._jagged_to_numpy(
+                        arrays.tolist()
+                    )
+                except Exception:
+                    msg = f"Field {self.name} cannot be converted to NumPy/Pandas"
+                    raise ValueError(msg) from None
+            if library.name == "pd":
+                pd = uproot.extras.pandas()
+                pandas_data = pd.DataFrame({self.name: numpy_data})
+                return pandas_data
+            return numpy_data
 
         return arrays
 

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -2015,7 +2015,7 @@ class RField(uproot.behaviors.RNTuple.HasFields):
                 numpy_data = arrays.to_numpy()
             except (ValueError, TypeError):
                 try:
-                    numpy_data = uproot.behaviors.RNTuple._jagged_to_numpy(arrays)
+                    numpy_data = uproot.behaviors.RNTuple._awkward_to_numpy(arrays)
                 except Exception:
                     msg = f"Field {self.name} cannot be converted to NumPy/Pandas"
                     raise ValueError(msg) from None

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -2015,9 +2015,7 @@ class RField(uproot.behaviors.RNTuple.HasFields):
                 numpy_data = arrays.to_numpy()
             except (ValueError, TypeError):
                 try:
-                    numpy_data = uproot.behaviors.RNTuple._jagged_to_numpy(
-                        arrays.tolist()
-                    )
+                    numpy_data = uproot.behaviors.RNTuple._jagged_to_numpy(arrays)
                 except Exception:
                     msg = f"Field {self.name} cannot be converted to NumPy/Pandas"
                     raise ValueError(msg) from None

--- a/tests/test_1591_rntuple_read_to_numpy.py
+++ b/tests/test_1591_rntuple_read_to_numpy.py
@@ -15,7 +15,8 @@ def test_reading_into_numpy():
         ak_arrays = obj.arrays(filter_name="n*")
         np_arrays = obj.arrays(library="np", filter_name="n*")
         assert isinstance(ak_arrays, ak.Array)
-        assert isinstance(np_arrays, np.ndarray)
+        assert isinstance(np_arrays, dict)
+        assert all(isinstance(arr, np.ndarray) for arr in np_arrays.values())
 
         nmuon_ak_array = obj["nMuon"].array()
         nmuon_np_array = obj["nMuon"].array(library="np")

--- a/tests/test_1632_rntuple_library_kwarg.py
+++ b/tests/test_1632_rntuple_library_kwarg.py
@@ -1,0 +1,184 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import awkward as ak
+import numpy as np
+import pytest
+import skhep_testdata
+
+import uproot
+
+SAMPLE_FILE = "Run2012BC_DoubleMuParked_Muons_1000evts_rntuple_v1-0-0-0.root"
+MULTI_FIELD_FILE = "test_int_float_rntuple_v1-0-0-0.root"
+
+
+def _lookup_file(name):
+    """Helper to look up object paths for known test files."""
+    if name == "test_int_float_rntuple_v1-0-0-0.root":
+        return "ntuple"
+    elif name == "ntpl001_staff_rntuple_v1-0-0-0.root":
+        return "Staff"
+    else:
+        return name.split("_")[0] if "_" in name else name
+
+
+def test_arrays_numpy_returns_dict():
+    filename = skhep_testdata.data_path(MULTI_FIELD_FILE)
+    obj_name = "ntuple"
+    with uproot.open(filename) as f:
+        obj = f[obj_name]
+        np_arrays = obj.arrays(library="np")
+        assert isinstance(np_arrays, dict)
+        assert set(np_arrays.keys()) == {"one_integers", "two_floats"}
+        assert isinstance(np_arrays["one_integers"], np.ndarray)
+        assert isinstance(np_arrays["two_floats"], np.ndarray)
+
+
+def test_arrays_numpy_how_tuple():
+    filename = skhep_testdata.data_path(MULTI_FIELD_FILE)
+    obj_name = "ntuple"
+    with uproot.open(filename) as f:
+        obj = f[obj_name]
+        result = obj.arrays(library="np", how=tuple)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert all(isinstance(arr, np.ndarray) for arr in result)
+
+
+def test_arrays_numpy_how_list():
+    filename = skhep_testdata.data_path(MULTI_FIELD_FILE)
+    obj_name = "ntuple"
+    with uproot.open(filename) as f:
+        obj = f[obj_name]
+        result = obj.arrays(library="np", how=list)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(arr, np.ndarray) for arr in result)
+
+
+def test_arrays_numpy_how_dict():
+    filename = skhep_testdata.data_path(MULTI_FIELD_FILE)
+    obj_name = "ntuple"
+    with uproot.open(filename) as f:
+        obj = f[obj_name]
+        result = obj.arrays(library="np", how=dict)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"one_integers", "two_floats"}
+
+
+def test_arrays_pandas_returns_dataframe():
+    pd = pytest.importorskip("pandas")
+    filename = skhep_testdata.data_path(MULTI_FIELD_FILE)
+    obj_name = "ntuple"
+    with uproot.open(filename) as f:
+        obj = f[obj_name]
+        result = obj.arrays(library="pd")
+        assert isinstance(result, pd.DataFrame)
+        assert set(result.columns.tolist()) == {"one_integers", "two_floats"}
+        assert len(result) == 10
+
+
+def test_arrays_pandas_how_dict():
+    pd = pytest.importorskip("pandas")
+    filename = skhep_testdata.data_path(MULTI_FIELD_FILE)
+    obj_name = "ntuple"
+    with uproot.open(filename) as f:
+        obj = f[obj_name]
+        result = obj.arrays(library="pd", how=dict)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"one_integers", "two_floats"}
+        assert all(isinstance(v, pd.Series) for v in result.values())
+
+
+def test_single_field_array_numpy():
+    filename = skhep_testdata.data_path(SAMPLE_FILE)
+    with uproot.open(filename) as f:
+        obj = f["Events"]
+        result = obj["nMuon"].array(library="np")
+        assert isinstance(result, np.ndarray)
+        assert len(result) == 1000
+
+
+def test_single_field_array_pandas():
+    pd = pytest.importorskip("pandas")
+    filename = skhep_testdata.data_path(SAMPLE_FILE)
+    with uproot.open(filename) as f:
+        obj = f["Events"]
+        result = obj["nMuon"].array(library="pd")
+        assert isinstance(result, pd.Series)
+        assert len(result) == 1000
+
+
+def test_numpy_values_match_awkward():
+    filename = skhep_testdata.data_path(SAMPLE_FILE)
+    with uproot.open(filename) as f:
+        obj = f["Events"]
+        ak_arrays = obj.arrays(filter_name="n*")
+        np_arrays = obj.arrays(library="np", filter_name="n*")
+
+        for field in ak_arrays.fields:
+            assert ak.array_equal(ak_arrays[field], np_arrays[field])
+
+
+def test_iterate_numpy():
+    filename = skhep_testdata.data_path(SAMPLE_FILE)
+    with uproot.open(filename) as f:
+        obj = f["Events"]
+        for i, arrays in enumerate(obj.iterate(step_size=100, library="np")):
+            assert isinstance(arrays, dict)
+            assert isinstance(arrays["nMuon"], np.ndarray)
+            assert len(arrays["nMuon"]) == 100
+            if i == 9:
+                break
+
+
+def test_iterate_pandas():
+    pd = pytest.importorskip("pandas")
+    filename = skhep_testdata.data_path(SAMPLE_FILE)
+    with uproot.open(filename) as f:
+        obj = f["Events"]
+        for i, arrays in enumerate(obj.iterate(step_size=100, library="pd")):
+            assert isinstance(arrays, pd.DataFrame)
+            assert len(arrays) == 100
+            if i == 9:
+                break
+
+
+def test_concatenate_numpy():
+    filename = skhep_testdata.data_path(SAMPLE_FILE)
+    result = uproot.concatenate({filename: "Events"}, library="np")
+    assert isinstance(result, dict)
+    assert len(result["nMuon"]) == 1000
+
+
+def test_concatenate_pandas():
+    pd = pytest.importorskip("pandas")
+    filename = skhep_testdata.data_path(SAMPLE_FILE)
+    result = uproot.concatenate({filename: "Events"}, library="pd")
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1000
+
+
+def test_nested_structs_numpy():
+    filename = skhep_testdata.data_path("test_nested_structs_rntuple_v1-0-0-0.root")
+    with uproot.open(filename) as f:
+        obj = f["ntuple"]
+        result = obj.arrays(library="np")
+        assert isinstance(result, dict)
+        assert "my_struct" in result
+        assert isinstance(result["my_struct"], np.ndarray)
+
+
+def test_jagged_arrays_numpy():
+    filename = skhep_testdata.data_path(SAMPLE_FILE)
+    with uproot.open(filename) as f:
+        obj = f["Events"]
+        ak_arrays = obj.arrays(filter_name=["Muon_pt"])
+        np_arrays = obj.arrays(library="np", filter_name=["Muon_pt"])
+
+        assert isinstance(np_arrays, dict)
+        assert "Muon_pt" in np_arrays
+        assert isinstance(np_arrays["Muon_pt"], np.ndarray)
+        assert np_arrays["Muon_pt"].dtype == object
+
+        for i in range(10):
+            assert ak.array_equal(ak_arrays["Muon_pt"][i], np_arrays["Muon_pt"][i])


### PR DESCRIPTION
This PR finishes implementing the `library` kwarg used in `arrays()` and similar functions for RNTuples. I initially postponed the implementation since I think it would be ideal to have all the conversions done by Awkward. But given that it is needed by users, I wrote a simple implementation.

AI disclosure: I didn't use AI for the code changes, but I did use Kimi K2 to review and to write tests.