### PR TITLE
ci: pin micromamba version and bump Pyodide version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,6 +38,7 @@ jobs:
             --strict-channel-priority
             conda-forge/label/python_rc::_python_rc
             python=${{ matrix.python-version }}
+          micromamba-version: 2.6.0-0   # unpin when there is a release newer than 2.6.1-0
 
       - name: Set PYTHON_GIL=0 for free-threaded builds
         if: contains(matrix.python-version, 'python-freethreading')

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -156,7 +156,9 @@ jobs:
       - uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install pyodide-build
-        run: python3 -m pip install pyodide-build==$PYODIDE_BUILD_VERSION
+        run: >
+          python3 -m pip install pyodide-build==$PYODIDE_BUILD_VERSION
+          pydantic==2.13.3 pydantic_core==2.46.3 # unpin after checking if newer versions allow checking emscripten versions as before
 
       - name: Determine EMSDK version
         id: compute-emsdk-version

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -140,8 +140,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      PYODIDE_VERSION: 0.28.1
-      PYODIDE_BUILD_VERSION: 0.30.5
+      PYODIDE_VERSION: 0.29.4
+      PYODIDE_BUILD_VERSION: 0.34.4
       AWKWARD_VERSION: v2.8.5
 
     steps:
@@ -156,9 +156,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install pyodide-build
-        run: >
-          python3 -m pip install pyodide-build==$PYODIDE_BUILD_VERSION
-          pydantic==2.13.3 pydantic_core==2.46.3 # unpin after checking if newer versions allow checking emscripten versions as before
+        run: python3 -m pip install pyodide-build==$PYODIDE_BUILD_VERSION
 
       - name: Determine EMSDK version
         id: compute-emsdk-version


### PR DESCRIPTION
We'll have to pin the micromamba version that the CI uses because the latest release is broken on Windows. (See https://github.com/mamba-org/setup-micromamba/issues/306 and https://github.com/mamba-org/micromamba-releases/issues/97)

Also, the Pyodide build started failing, but simply bumping the version fixed it.