### PR TITLE
ci: Move fsspec-xrootd into separate dependency group

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -244,7 +244,7 @@ jobs:
             ${{ matrix.cuda-version == 13 && 'root' || '' }}
 
       - name: Pip install the package
-        run: pip install --group=dev .
+        run: pip install --group=dev --group=test-xrootd .
 
       - name: Run only GPU tests
         if: matrix.cuda-version != 13

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,11 +68,9 @@ jobs:
           ssh -o StrictHostKeyChecking=no localhost echo "ssh connection successful"
 
       - name: Install XRootD
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && !contains(matrix.python-version, 'python-freethreading')
         run: |
-          micromamba env list
-          micromamba install xrootd
-          micromamba list
+          uv pip install --group=test-xrootd
 
       - name: Pip install the package
         run: uv pip install --system -e. --group=dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ extra = [
 test = [
   "aiohttp",
   "deflate",
-  "fsspec-xrootd>=0.5.0",
   "isal",
   "paramiko",
   "pytest-rerunfailures",
@@ -47,6 +46,10 @@ test-gpu-cu13 = [
 ]
 test-pyodide = [
   "pytest-pyodide; python_version >='3.11'",
+  {include-group = "test-core"}
+]
+test-xrootd = [
+  "fsspec-xrootd>=0.5.0",
   {include-group = "test-core"}
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,8 @@ def xrootd_server(tmpdir_factory):
     temp_path = os.path.join(server_dir, "Folder")
     os.mkdir(temp_path)
     xrootd = shutil.which("xrootd")
+    if xrootd is None:
+        pytest.skip("xrootd server executable is not available on PATH")
     proc = subprocess.Popen([xrootd, server_dir])
     time.sleep(2)  # give it some startup
     yield "root://localhost/" + str(temp_path), temp_path

--- a/tests/test_0302_pickle.py
+++ b/tests/test_0302_pickle.py
@@ -80,6 +80,7 @@ def test_pickle_roundtrip_http(handler):
 @pytest.mark.xrootd
 def test_pickle_roundtrip_xrootd(handler):
     pytest.importorskip("XRootD")
+    pytest.importorskip("fsspec_xrootd")
     with uproot.open(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         handler=handler,

--- a/tests/test_0692_fsspec_reading.py
+++ b/tests/test_0692_fsspec_reading.py
@@ -313,6 +313,7 @@ def test_fsspec_zip(tmp_path):
 )
 def test_open_fsspec_xrootd_iterate_files(handler):
     pytest.importorskip("XRootD")
+    pytest.importorskip("fsspec_xrootd")
 
     iterator = uproot.iterate(
         files=[
@@ -347,6 +348,7 @@ def test_open_fsspec_xrootd_iterate_files(handler):
 )
 def test_open_fsspec_xrootd_iterate_tree(handler):
     pytest.importorskip("XRootD")
+    pytest.importorskip("fsspec_xrootd")
 
     with uproot.open(
         {


### PR DESCRIPTION
`fsspec-xrootd` started depending on the Python `xrootd` package since they started shipping wheels. However, they don't build wheels for Windows or for free-threaded Python. I moved it into a separate dependency group, so that we have more control of when to install it.