### PR TITLE
feat: support path objects with storage_options in uproot.open

### DIFF
--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -130,16 +130,17 @@ def open(
         file_path = path
         object_path = None
 
-    file_path = uproot._util.regularize_path(file_path)
-
     # Support path objects that carry fsspec storage_options (e.g. UPath from
-    # universal-pathlib). Caller-provided kwargs take precedence over the
-    # path-embedded options so that one-off overrides still work.
+    # universal-pathlib). Extract before regularize_path so that if the object
+    # ever gains __fspath__ the options aren't lost when it is converted to str.
+    # Caller-provided kwargs take precedence over path-embedded options.
     if hasattr(file_path, "storage_options") and not isinstance(
         file_path, (str, bytes)
     ):
         options = {**file_path.storage_options, **options}
         file_path = str(file_path)
+
+    file_path = uproot._util.regularize_path(file_path)
 
     if not isinstance(file_path, str) and not (
         hasattr(file_path, "read") and hasattr(file_path, "seek")

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -132,6 +132,15 @@ def open(
 
     file_path = uproot._util.regularize_path(file_path)
 
+    # Support path objects that carry fsspec storage_options (e.g. UPath from
+    # universal-pathlib). Caller-provided kwargs take precedence over the
+    # path-embedded options so that one-off overrides still work.
+    if hasattr(file_path, "storage_options") and not isinstance(
+        file_path, (str, bytes)
+    ):
+        options = {**file_path.storage_options, **options}
+        file_path = str(file_path)
+
     if not isinstance(file_path, str) and not (
         hasattr(file_path, "read") and hasattr(file_path, "seek")
     ):

--- a/tests/test_1631_path_with_storage_options.py
+++ b/tests/test_1631_path_with_storage_options.py
@@ -1,0 +1,78 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""
+Tests for path objects that carry storage_options (e.g. UPath from universal-pathlib).
+The fix allows users to bundle a URL and its fsspec storage options (auth headers,
+credentials, etc.) into a single path object and pass it directly to uproot functions.
+"""
+
+import pytest
+import skhep_testdata
+
+import uproot
+import uproot.source.fsspec
+
+
+class PathWithStorageOptions:
+    """
+    Minimal stand-in for universal_pathlib.UPath: a path object that pairs a
+    URL string with fsspec storage_options.  No upath dependency required.
+    """
+
+    def __init__(self, url, storage_options=None):
+        self._url = url
+        self.storage_options = storage_options or {}
+
+    def __str__(self):
+        return self._url
+
+    def __repr__(self):
+        return f"PathWithStorageOptions({self._url!r}, {self.storage_options!r})"
+
+
+def test_open_propagates_storage_options():
+    """storage_options on a path object must reach FSSpecSource._fsspec_options."""
+    path = PathWithStorageOptions(
+        skhep_testdata.data_path("uproot-HZZ.root"),
+        storage_options={"headers": {"Authorization": "Bearer test-token"}},
+    )
+    with uproot.open(path) as f:
+        source = f._file._source
+        assert isinstance(source, uproot.source.fsspec.FSSpecSource)
+        assert source._fsspec_options.get("headers") == {
+            "Authorization": "Bearer test-token"
+        }
+
+
+def test_open_with_storage_options_reads_data():
+    """A path object with storage_options must open and read data correctly."""
+    path = PathWithStorageOptions(
+        skhep_testdata.data_path("uproot-HZZ.root"),
+        storage_options={"headers": {"Authorization": "Bearer test-token"}},
+    )
+    with uproot.open(path) as f:
+        tree = f["events"]
+        assert tree.num_entries == 2421
+
+
+def test_open_empty_storage_options_is_noop():
+    """A path object with empty storage_options behaves identically to a plain string."""
+    plain_path = skhep_testdata.data_path("uproot-HZZ.root")
+    path_obj = PathWithStorageOptions(plain_path, storage_options={})
+    with uproot.open(path_obj) as f:
+        tree = f["events"]
+        assert tree.num_entries == 2421
+
+
+def test_open_explicit_kwarg_wins_over_storage_options():
+    """Explicit kwargs to uproot.open() must take precedence over storage_options."""
+    path = PathWithStorageOptions(
+        skhep_testdata.data_path("uproot-HZZ.root"),
+        storage_options={"headers": {"Authorization": "Bearer from-path"}},
+    )
+    # The caller's explicit kwarg should override the path's storage_options
+    with uproot.open(path, headers={"Authorization": "Bearer explicit"}) as f:
+        source = f._file._source
+        assert source._fsspec_options.get("headers") == {
+            "Authorization": "Bearer explicit"
+        }


### PR DESCRIPTION
## Summary

- Allows path objects with a `storage_options` attribute (e.g. `UPath` from `universal-pathlib`) to be passed directly to `uproot.open()`
- `storage_options` are merged into the kwargs forwarded to `FSSpecSource`/fsspec, so auth headers, Bearer tokens, and macaroons can be bundled into the path object rather than passed as separate kwargs every call
- Explicit kwargs to `uproot.open()` still take precedence over path-embedded options

```python
from upath import UPath

f = UPath("https://storage.example.com/file.root", headers={"Authorization": f"Bearer {token}"})
uproot.open(f)  # no separate headers= needed
```

/cc @ponyisi