### PR TITLE
fix: `uproot.dask` cannot handle grouped `TObject` properly

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1649,6 +1649,18 @@ def _get_dak_array(
             )
         )
 
+    # Filter out AsGrouped branches: they are grouping containers without their own
+    # data buffers. This matches tree.arrays(expressions=None) which also skips them.
+    if ttrees and not isinstance(ttrees[0], HasFields):
+        common_keys = [
+            k
+            for k in common_keys
+            if not isinstance(
+                ttrees[0][k].interpretation,
+                uproot.interpretation.grouped.AsGrouped,
+            )
+        ]
+
     step_sum = 0
     for ttree in ttrees:
         entry_start = 0
@@ -1785,6 +1797,17 @@ def _get_dak_array_delay_open(
             full_paths=full_paths,
             ignore_duplicates=True,
         )
+        # Filter out AsGrouped branches: they are grouping containers without their own
+        # data buffers. This matches tree.arrays(expressions=None) which also skips them.
+        if not isinstance(obj, HasFields):
+            common_keys = [
+                k
+                for k in common_keys
+                if not isinstance(
+                    obj[k].interpretation,
+                    uproot.interpretation.grouped.AsGrouped,
+                )
+            ]
         base_form = _get_ttree_form(
             awkward, obj, common_keys, interp_options.get("ak_add_doc")
         )

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -861,6 +861,7 @@ class HasBranches(Mapping):
                 filter_name=filter_name,
                 filter_typename=filter_typename,
                 filter_branch=filter_branch,
+                full_paths=False,
                 entry_start=entry_start,
                 entry_stop=entry_stop,
                 decompression_executor=decompression_executor,
@@ -993,6 +994,17 @@ class HasBranches(Mapping):
             full_paths=full_paths,
             ignore_duplicates=ignore_duplicates,
         )
+
+        # Filter out AsGrouped branches: they are grouping containers with no data
+        # buffers of their own. Their children appear separately in `keys` already.
+        keys = [
+            k
+            for k in keys
+            if not isinstance(
+                self[k].interpretation,
+                uproot.interpretation.grouped.AsGrouped,
+            )
+        ]
 
         # we're dealing with a single branch here:
         if isinstance(self, TBranch) and len(keys) == 0:
@@ -3539,7 +3551,11 @@ def _fix_asgrouped(
             branch = context["branches"][-1]
             interpretation = branchid_interpretation[branch.cache_key]
             if isinstance(interpretation, uproot.interpretation.grouped.AsGrouped):
-                assert arrays[branch.cache_key] is None
+                if arrays[branch.cache_key] is not None:
+                    # Already assembled in a prior iteration (e.g., this branch
+                    # was recursively processed as a nested sub-branch of a parent
+                    # AsGrouped branch that also appears in expression_context).
+                    continue
 
                 limited_context = dict(expression_context[index_start:index_stop])
 

--- a/tests/test_1642_read_AsGrouped_with_dask_or_virtual_array.py
+++ b/tests/test_1642_read_AsGrouped_with_dask_or_virtual_array.py
@@ -1,0 +1,27 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import pytest
+import skhep_testdata
+import awkward
+
+import uproot
+
+dask = pytest.importorskip("dask")
+da = pytest.importorskip("dask.array")
+
+
+def test_read_AsGrouped_with_dask_or_virtual_array():
+    """
+    ``RNTuple.iterate(report=True)`` must yield ``(arrays, Report)`` pairs,
+    matching the contract documented in its docstring and already provided
+    by ``TTree.iterate``.
+    """
+    path = skhep_testdata.data_path("uproot-issue-1502.root")
+    with uproot.open(path) as f:
+        arr = f["tree"].arrays()
+        virtual_arr = f["tree"].arrays(virtual=True)
+
+    assert awkward.array_equal(arr, awkward.materialize(virtual_arr))
+
+    dask_arr = uproot.dask(path).compute()
+    assert awkward.array_equal(arr, dask_arr)

--- a/tests/test_1642_read_AsGrouped_with_dask_or_virtual_array.py
+++ b/tests/test_1642_read_AsGrouped_with_dask_or_virtual_array.py
@@ -21,7 +21,7 @@ def test_read_AsGrouped_with_dask_or_virtual_array():
         arr = f["tree"].arrays()
         virtual_arr = f["tree"].arrays(virtual=True)
 
-    assert awkward.array_equal(arr, awkward.materialize(virtual_arr))
+        assert awkward.array_equal(arr, awkward.materialize(virtual_arr))
 
     dask_arr = uproot.dask(path).compute()
     assert awkward.array_equal(arr, dask_arr)


### PR DESCRIPTION
Hi @ariostas @ikrommyd ,

I tried to have an LLM fix issue #1502 , and it made the following changes. It seems like all the tests pass and the issue is resolved, but the changes are quite extensive, so I don’t feel very confident reviewing them.

I’ve written down the LLM’s understanding of the bug and the fix, which might be helpful:
- [dask.md](https://github.com/user-attachments/files/28687095/dask.md) which fixes the but in `uproot.dask`
- [virtual.md](https://github.com/user-attachments/files/28687097/virtual.md) which fixes the similar bug when using awkward virtual array (`.arrays(virtual=True)`)

I’d like to know what you think of the LLM’s fix — is it something we could consider improving the tests for and then merge, or should we set it aside for now and conduct a more detailed review later?