### PR TITLE
fix: interpretation dtype handling returned byte-swapped data

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -3053,12 +3053,10 @@ def _regularize_aliases(hasbranches, aliases):
 def _regularize_interpretation(interpretation):
     if isinstance(interpretation, uproot.interpretation.Interpretation):
         return interpretation
-    elif isinstance(interpretation, numpy.dtype):
-        return uproot.interpretation.numerical.AsDtype(interpretation)
     else:
         dtype = numpy.dtype(interpretation)
         dtype = dtype.newbyteorder(">")
-        return uproot.interpretation.numerical.AsDtype(interpretation)
+        return uproot.interpretation.numerical.AsDtype(dtype)
 
 
 def _regularize_branchname(

--- a/src/uproot/interpretation/__init__.py
+++ b/src/uproot/interpretation/__init__.py
@@ -176,9 +176,6 @@ class Interpretation:
     def __eq__(self, other):
         raise AssertionError
 
-    def __ne__(self, other):
-        raise not self == other
-
     def hook_before_basket_array(self, *args, **kwargs):
         """
         Called in :ref:`uproot.interpretation.Interpretation.basket_array`,

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -108,7 +108,9 @@ class Numerical(uproot.interpretation.Interpretation):
 
                 start = stop
 
-        output = output.view(output.dtype.newbyteorder("="))
+        native_dtype = output.dtype.newbyteorder("=")
+        if output.dtype != native_dtype:
+            output = output.astype(native_dtype)
         self.hook_before_library_finalize(
             basket_arrays=basket_arrays,
             entry_start=entry_start,

--- a/tests/test_1648_interpretation_dtype_byteorder.py
+++ b/tests/test_1648_interpretation_dtype_byteorder.py
@@ -1,0 +1,48 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import numpy
+import skhep_testdata
+
+import uproot
+import uproot.interpretation.numerical as N
+
+# First few values of branch "px1" in tree "events" of uproot-Zmumu.root.
+EXPECTED = numpy.array([-41.1952876, 35.1180498, 35.1180498])
+
+
+def test_interpretation_string_spec_not_byteswapped():
+    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root")) as f:
+        array = f["events"]["px1"].array(interpretation="f8", library="np")
+    numpy.testing.assert_allclose(array[:3], EXPECTED)
+
+
+def test_interpretation_numpy_dtype_not_byteswapped():
+    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root")) as f:
+        array = f["events"]["px1"].array(interpretation=numpy.dtype("f8"), library="np")
+    numpy.testing.assert_allclose(array[:3], EXPECTED)
+
+
+def test_interpretation_bigendian_to_dtype_preserves_values():
+    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root")) as f:
+        array = f["events"]["px1"].array(
+            interpretation=N.AsDtype(">f8", ">f8"), library="np"
+        )
+    numpy.testing.assert_allclose(array[:3], EXPECTED)
+
+
+def test_interpretation_default_matches_explicit_spec():
+    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root")) as f:
+        branch = f["events"]["px1"]
+        default = branch.array(library="np")
+        explicit = branch.array(interpretation="f8", library="np")
+    numpy.testing.assert_array_equal(default, explicit)
+
+
+def test_interpretation_not_equal_does_not_raise():
+    same_a = N.AsDtype("f8")
+    same_b = N.AsDtype("f8")
+    different = N.AsDtype("f4")
+
+    assert (same_a != same_b) is False
+    assert (same_a != different) is True
+    assert (same_a == same_b) is True

--- a/tests/test_1648_interpretation_dtype_byteorder.py
+++ b/tests/test_1648_interpretation_dtype_byteorder.py
@@ -10,35 +10,29 @@ import uproot.interpretation.numerical as N
 EXPECTED = numpy.array([-41.1952876, 35.1180498, 35.1180498])
 
 
-def test_interpretation_string_spec_not_byteswapped():
-    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root")) as f:
-        array = f["events"]["px1"].array(interpretation="f8", library="np")
-    numpy.testing.assert_allclose(array[:3], EXPECTED)
-
-
-def test_interpretation_numpy_dtype_not_byteswapped():
-    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root")) as f:
-        array = f["events"]["px1"].array(interpretation=numpy.dtype("f8"), library="np")
-    numpy.testing.assert_allclose(array[:3], EXPECTED)
-
-
-def test_interpretation_bigendian_to_dtype_preserves_values():
-    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root")) as f:
-        array = f["events"]["px1"].array(
-            interpretation=N.AsDtype(">f8", ">f8"), library="np"
-        )
-    numpy.testing.assert_allclose(array[:3], EXPECTED)
-
-
-def test_interpretation_default_matches_explicit_spec():
+def test_interpretation_dtype_and_byteorder():
     with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root")) as f:
         branch = f["events"]["px1"]
+
+        # String spec is not byteswapped.
+        array = branch.array(interpretation="f8", library="np")
+        numpy.testing.assert_allclose(array[:3], EXPECTED)
+
+        # numpy.dtype spec is not byteswapped.
+        array = branch.array(interpretation=numpy.dtype("f8"), library="np")
+        numpy.testing.assert_allclose(array[:3], EXPECTED)
+
+        # Big-endian AsDtype preserves values.
+        array = branch.array(interpretation=N.AsDtype(">f8", ">f8"), library="np")
+        numpy.testing.assert_allclose(array[:3], EXPECTED)
+
+        # Default interpretation matches explicit string spec.
         default = branch.array(library="np")
         explicit = branch.array(interpretation="f8", library="np")
-    numpy.testing.assert_array_equal(default, explicit)
+        numpy.testing.assert_array_equal(default, explicit)
 
 
-def test_interpretation_not_equal_does_not_raise():
+def test_interpretation_comparison():
     same_a = N.AsDtype("f8")
     same_b = N.AsDtype("f8")
     different = N.AsDtype("f4")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Three related bugs caused user-supplied `interpretation=` specs to return byte-swapped garbage, and `!=` between interpretations to crash.

### What was broken

Raw `TBasket` data is big-endian. Several code paths mishandled byte order:

1. **`_regularize_interpretation` (`behaviors/TBranch.py`)** — the else branch computed a big-endian `dtype` but then returned `AsDtype(interpretation)` using the **original** argument, discarding the conversion. The separate `numpy.dtype` branch had the same problem.
2. **`AsDtype.final_array` (`interpretation/numerical.py`)** — `output = output.view(output.dtype.newbyteorder("="))` **reinterpreted** bytes instead of converting values. A no-op for native `to_dtype`, but corrupted values for a user-supplied big-endian `to_dtype`.
3. **`Interpretation.__ne__` (`interpretation/__init__.py`)** — `raise not self == other` raised `TypeError: exceptions must derive from BaseException` for any `!=`.

### Minimal reproducer

```python
import uproot, skhep_testdata, numpy
import uproot.interpretation.numerical as N

t = uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"]

# before: [1.27e+239, ...]   after: [-41.195, 35.118, 35.118]
t["px1"].array(interpretation="f8", library="np")[:3]
t["px1"].array(interpretation=numpy.dtype("f8"), library="np")[:3]
t["px1"].array(interpretation=N.AsDtype(">f8", ">f8"), library="np")[:3]

N.AsDtype("f8") != N.AsDtype("f8")   # before: TypeError   after: False
```

### What changed

1. `_regularize_interpretation` now returns `AsDtype(dtype)` with the big-endian-converted dtype, and both the `numpy.dtype` and string-spec cases go through the same branch for consistency.
2. `final_array` converts a non-native `to_dtype` output to native byte order by value (`astype`) rather than reinterpreting bytes. For native `to_dtype` (the default) it leaves `output` untouched, which preserves the in-place buffer used by `AsDtypeInPlace`.
3. Deleted the broken `__ne__`; Python 3 negates `__eq__` automatically.

### Testing

Relevant existing suites pass (`test_0017`, `test_0018`, `test_0034`, `test_0487`, `test_1477`, etc.). Nothing skipped.



Part of #1646.
