### PR TITLE
perf: avoid full basket reads in num_entries_for and redundant reads on cache hits

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1185,9 +1185,15 @@ class HasBranches(Mapping):
         checked = set()
         for _, context in expression_context:
             for branch in context["branches"]:
-                if branch.cache_key not in checked and not isinstance(
-                    branchid_interpretation[branch.cache_key],
-                    uproot.interpretation.grouped.AsGrouped,
+                if (
+                    branch.cache_key not in checked
+                    # branches already satisfied from the array cache are present
+                    # in arrays; don't re-read and re-decompress their baskets
+                    and branch.cache_key not in arrays
+                    and not isinstance(
+                        branchid_interpretation[branch.cache_key],
+                        uproot.interpretation.grouped.AsGrouped,
+                    )
                 ):
                     checked.add(branch.cache_key)
                     for (
@@ -1230,8 +1236,7 @@ class HasBranches(Mapping):
                     if branch.cache_key not in checked:
                         checked.add(branch.cache_key)
                         interpretation = branchid_interpretation[branch.cache_key]
-                        if branch is not None:
-                            cache_key = f"{self.cache_key}:{expression}:{interpretation.cache_key}:{entry_start}-{entry_stop}:{library.name}"
+                        cache_key = f"{self.cache_key}:{expression}:{interpretation.cache_key}:{entry_start}-{entry_stop}:{library.name}"
                         array_cache[cache_key] = arrays[branch.cache_key]
 
         output = language.compute_expressions(
@@ -1920,10 +1925,11 @@ class HasBranches(Mapping):
         already-loaded ``TTree``; it only needs ``language`` to parse the
         expressions, not to evaluate them.
 
-        In addition, the estimate is based on compressed ``TBasket`` sizes
-        (the amount of data that would have to be read), not uncompressed
-        ``TBasket`` sizes (the amount of data that the final arrays would use
-        in memory, without considering ``cuts``).
+        In addition, the estimate is based on uncompressed ``TBasket`` sizes
+        (approximately the amount of data that the final arrays would use in
+        memory, without considering ``cuts``), not compressed ``TBasket`` sizes
+        (the amount of data that would have to be read). Only the ``TBasket``
+        ``TKeys`` are read to obtain these sizes, not the ``TBasket`` data.
 
         This is the algorithm that
         :ref:`uproot.behaviors.TBranch.HasBranches.iterate` uses to convert a
@@ -2703,10 +2709,19 @@ in file {self._file.file_path}"""
         ``TKey``, which are small, but may be slow for remote connections because
         of the latency of round-trip requests.
         """
-        if 0 <= basket_num < self.num_baskets:
+        if 0 <= basket_num < self._num_normal_baskets:
+            # Reading only the TKey (instead of the whole TBasket) is enough to
+            # determine the uncompressed size; add fKeylen to match the header-
+            # inclusive value reported by Model_TBasket.uncompressed_bytes.
+            key = self.basket_key(basket_num)
+            return key.data_uncompressed_bytes + key.fKeylen
+        elif 0 <= basket_num < self.num_baskets:
             return self.basket(basket_num).uncompressed_bytes
         else:
-            return self.basket_key(basket_num).data_uncompressed_bytes
+            raise IndexError(
+                f"""branch {self.name!r} has {self.num_baskets} baskets; cannot get basket {basket_num}
+in file {self._file.file_path}"""
+            )
 
     def basket_key(self, basket_num):
         """

--- a/tests/test_1649_avoid_full_basket_reads.py
+++ b/tests/test_1649_avoid_full_basket_reads.py
@@ -41,17 +41,6 @@ def test_num_entries_for_does_not_fully_read_baskets(monkeypatch):
         assert result > 0
 
 
-def test_basket_uncompressed_bytes_value_is_unchanged(monkeypatch):
-    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"] as tree:
-        for branch in tree.itervalues(recursive=True):
-            for basket_num in range(branch.num_baskets):
-                # Cheap TKey-only path must match the full-read value
-                # (fKeylen + fObjlen), so step-size estimates do not change.
-                cheap = branch.basket_uncompressed_bytes(basket_num)
-                full = branch.basket(basket_num).uncompressed_bytes
-                assert cheap == full
-
-
 def test_partial_cache_hit_does_not_reread(monkeypatch):
     with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"] as tree:
         reference = tree.arrays(["px1", "px2"], array_cache={})

--- a/tests/test_1649_avoid_full_basket_reads.py
+++ b/tests/test_1649_avoid_full_basket_reads.py
@@ -1,0 +1,82 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""Regression tests for PR #1649.
+
+- ``num_entries_for`` / memory-based ``step_size`` must not fully read and
+  decompress baskets; only the ``TBasket`` ``TKeys`` should be read.
+- A partial array-cache hit must not re-read (and re-decompress) the baskets of
+  branches that were already cached.
+"""
+
+import skhep_testdata
+
+import uproot
+import uproot.models.TBasket
+
+
+def _count_basket_reads(monkeypatch):
+    counter = {"n": 0}
+    original = uproot.models.TBasket.Model_TBasket.read
+
+    def spy(self, *args, **kwargs):
+        counter["n"] += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(uproot.models.TBasket.Model_TBasket, "read", spy)
+    return counter
+
+
+def test_num_entries_for_does_not_fully_read_baskets(monkeypatch):
+    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"] as tree:
+        num_baskets = sum(
+            branch.num_baskets for branch in tree.itervalues(recursive=True)
+        )
+        assert num_baskets > 0
+
+        counter = _count_basket_reads(monkeypatch)
+        result = tree.num_entries_for("100 MB")
+
+        # The previous implementation read (and decompressed) every basket here.
+        assert counter["n"] == 0
+        assert result > 0
+
+
+def test_basket_uncompressed_bytes_value_is_unchanged(monkeypatch):
+    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"] as tree:
+        for branch in tree.itervalues(recursive=True):
+            for basket_num in range(branch.num_baskets):
+                # Cheap TKey-only path must match the full-read value
+                # (fKeylen + fObjlen), so step-size estimates do not change.
+                cheap = branch.basket_uncompressed_bytes(basket_num)
+                full = branch.basket(basket_num).uncompressed_bytes
+                assert cheap == full
+
+
+def test_partial_cache_hit_does_not_reread(monkeypatch):
+    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"] as tree:
+        reference = tree.arrays(["px1", "px2"], array_cache={})
+
+        cache = {}
+        tree.arrays(["px1"], array_cache=cache)
+
+        counter = _count_basket_reads(monkeypatch)
+        out = tree.arrays(["px1", "px2"], array_cache=cache)
+
+        # Only px2's basket should be read; px1 comes from the cache.
+        assert counter["n"] == 1
+
+        import awkward as ak
+
+        assert ak.all(out["px1"] == reference["px1"])
+        assert ak.all(out["px2"] == reference["px2"])
+
+
+def test_full_cache_hit_reads_nothing(monkeypatch):
+    with uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"] as tree:
+        cache = {}
+        tree.arrays(["px1", "px2"], array_cache=cache)
+
+        counter = _count_basket_reads(monkeypatch)
+        tree.arrays(["px1", "px2"], array_cache=cache)
+
+        assert counter["n"] == 0


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Three related read-performance fixes in `src/uproot/behaviors/TBranch.py`, all verified on `uproot-Zmumu.root` (from `skhep_testdata`) with a `Model_TBasket.read` spy counter.

### 1. `basket_uncompressed_bytes` did a full basket read for every normal basket

The branch condition was inverted relative to intent: `if 0 <= basket_num < self.num_baskets: return self.basket(basket_num).uncompressed_bytes` covers *all* valid baskets (normal and embedded), so every call performed a full `TBasket` read (chunk fetch + decompress + `Model_TBasket.read`). The cheap TKey-only path the docstring promises (`basket_key(...)`) was unreachable.

This is called per basket by `_hasbranches_num_entries_for`, so the default memory-based `iterate(step_size="100 MB")` and `num_entries_for()` read and **decompressed the entire selected range** before iteration even started (and made one round trip per basket on remote files).

Fix: normal baskets now read only the `TKey` via `basket_key(basket_num)`; embedded baskets (which have no `TKey`) keep the full read. The returned value is unchanged (`fKeylen + fObjlen`, matching `Model_TBasket.uncompressed_bytes`), so step-size estimates are identical.

Evidence (`num_entries_for("100 MB")` over all branches, 20 baskets total):

| | full basket reads | result |
|---|---|---|
| before | 20 | 696239 |
| after | 0 | 696239 |

Per-basket returned values were checked equal to the old full-read values for every basket.

### 2. Partial array-cache hits re-read cached branches

In `HasBranches.arrays`, branches already satisfied from `array_cache` were still added to `ranges_or_baskets` and re-read/re-decompressed. Only the all-hit case short-circuited. Fix: skip branches already present in `arrays` when building `ranges_or_baskets`. The completion logic (`len(arrays) == len(branchid_interpretation)`) is unaffected because those branches are already in `arrays`.

The `iterate` site uses a no-op `get_from_cache` and resets `arrays = {}` each step, and the single-branch `TBranch.array` site is already covered by the all-hit short-circuit, so neither needed changing.

Evidence (`arrays(['px1'])` then `arrays(['px1','px2'])`, same cache):

| | basket reads on 2nd call |
|---|---|
| before | 2 (re-reads px1 + reads px2) |
| after | 1 (reads px2 only) |

Returned arrays verified identical to an uncached reference.

### 3. Dead conditional in the cache-store loop

`if branch is not None:` was always true and the `array_cache[cache_key] = ...` assignment sat outside it (so a stale `cache_key` could be reused if `branch` ever were `None`). Removed the dead guard, keeping the assignment.

Also fixed the `num_entries_for` docstring, which incorrectly claimed the estimate uses compressed sizes (the implementation uses uncompressed sizes).

## Tests

Existing array/iterate/cache tests pass: `test_0017`, `test_0018`, `test_0043`, `test_0194`, `test_1573`, plus a broader smoke set. Regression tests added in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Part of #1646.
