### PR TITLE
fix: RNTuple footer leak on extend, broken WritableNTuple.compression, directory __delitem__ KeyError

### DIFF
--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -497,7 +497,7 @@ class NTuple_Footer(CascadeLeaf):
         super().__init__(location, None)
 
     def __repr__(self):
-        return f"{type(self).__name__}(extension_field_record_frames = {self.extension_field_record_frames}, column_group_record_frames = {self.extension_column_record_frames}, cluster_summary_record_frames={self.extension_column_record_frames}, cluster_group_record_frames{self.cluster_group_record_frames}, metadata_block_envelope_link = {self.metadata_block_envelope_links})"
+        return f"{type(self).__name__}(extension_field_record_frames={self.extension_field_record_frames}, extension_column_record_frames={self.extension_column_record_frames}, cluster_group_record_frames={self.cluster_group_record_frames})"
 
     def serialize(self):
         out = []
@@ -756,19 +756,6 @@ class NTuple_Anchor(CascadeLeaf):
         return out
 
 
-class Ntuple_PageLink:
-    def __init__(self, num_bytes, offset):
-        self.num_bytes = num_bytes
-        self.offset = offset
-
-    def serialize(self):
-        outbytes = _rntuple_locator_size_format.pack(self.num_bytes, self.offset)
-        return outbytes
-
-    def __repr__(self):
-        return f"{type(self).__name__}({self.num_bytes}, {self.offset})"
-
-
 class NTuple(CascadeNode):
     """
     Writes a RNTuple, including all fields, columns, and (upon ``extend``) pages.
@@ -828,16 +815,8 @@ class NTuple(CascadeNode):
         return self._key.title
 
     @property
-    def branch_types(self):
-        return self._branch_types
-
-    @property
     def freesegments(self):
         return self._freesegments
-
-    @property
-    def field_name(self):
-        return self._field_name
 
     @property
     def location(self):
@@ -956,7 +935,10 @@ class NTuple(CascadeNode):
 
         old_footer_key = self._footer_key
         self._freesegments.release(
-            old_footer_key.location, old_footer_key.location + old_footer_key.allocation
+            old_footer_key.location,
+            old_footer_key.location
+            + old_footer_key.num_bytes
+            + old_footer_key.compressed_bytes,
         )
         footer_raw_data = self._footer.serialize()
         self._footer_key = self.add_rblob(sink, footer_raw_data, len(footer_raw_data))
@@ -1041,9 +1023,6 @@ class NTuple(CascadeNode):
         #### Anchor end ##############################
 
         self._freesegments.write(sink)
-
-    def write_updates(self, sink):
-        sink.flush()
 
 
 def _to_packed_form(form):

--- a/src/uproot/writing/_cascadetree.py
+++ b/src/uproot/writing/_cascadetree.py
@@ -415,10 +415,6 @@ class Tree:
         return self._key.title
 
     @property
-    def branch_types(self):
-        return self._branch_types
-
-    @property
     def freesegments(self):
         return self._freesegments
 

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -1056,6 +1056,14 @@ class WritableDirectory(MutableMapping):
 
     def _del(self, name, cycle):
         key = self._cascading.data.get_key(name, cycle)
+        if key is None:
+            raise uproot.exceptions.KeyInFileError(
+                name,
+                cycle="any" if cycle is None else cycle,
+                keys=self._cascading.data.key_names,
+                file_path=self.file_path,
+                object_path=self.object_path,
+            )
         start = key.seek_location
         stop = start + key.num_bytes + key.compressed_bytes
         self._cascading.freesegments.release(start, stop)
@@ -2127,72 +2135,18 @@ class WritableNTuple:
     def compression(self):
         """
         Compression algorithm and level (:doc:`uproot.compression.Compression` or None)
-        for new blobs added to the RNTuple.
+        used when writing pages to this RNTuple.
 
-        This property can be changed and doesn't have to be the same as the compression
-        of the file, which allows you to write different objects with different
-        compression settings.
-
-        The following are equivalent:
-
-        .. code-block:: python
-
-            my_directory["tree"]["branch1"].compression = uproot.ZLIB(1)
-            my_directory["tree"]["branch2"].compression = uproot.LZMA(9)
-
-        and
-
-        .. code-block:: python
-
-            my_directory["tree"].compression = {"branch1": uproot.ZLIB(1),
-                                                "branch2": uproot.LZMA(9)}
+        RNTuple compression is file-wide and is taken from the file header; individual
+        per-column compression is not yet supported.
         """
-        out = {}
-        last = None
-        for datum in self._cascading._branch_data:
-            if datum["kind"] != "record":
-                last = out[datum["fName"]] = datum["compression"]
-        if all(x == last for x in out.values()):
-            return last
-        else:
-            return out
+        return self._cascading._freesegments.fileheader.compression
 
     @compression.setter
     def compression(self, value):
-        if value is None or isinstance(value, uproot.compression.Compression):
-            for datum in self._cascading._branch_data:
-                if datum["kind"] != "record":
-                    datum["compression"] = value
-
-        elif (
-            isinstance(value, Mapping)
-            and all(
-                isinstance(k, str)
-                and (v is None or isinstance(v, uproot.compression.Compression))
-                for k, v in value.items()
-            )
-            and all(
-                datum["fName"] in value
-                for datum in self._cascading._branch_data
-                if datum["kind"] != "record"
-            )
-            and len(value)
-            == len(
-                [
-                    datum
-                    for datum in self._cascading._branch_data
-                    if datum["kind"] != "record"
-                ]
-            )
-        ):
-            for datum in self._cascading._branch_data:
-                if datum["kind"] != "record":
-                    datum["compression"] = value[datum["fName"]]
-
-        else:
-            raise TypeError(
-                "compression must be None, a uproot.compression.Compression object, like uproot.ZLIB(4) or uproot.ZSTD(0), or a mapping of branch names to such objects"
-            )
+        raise NotImplementedError(
+            "per-RNTuple compression is not yet supported; set compression on the file instead"
+        )
 
     @property
     def num_entries(self) -> int:

--- a/tests/test_1650_rntuple_writing_bugfixes.py
+++ b/tests/test_1650_rntuple_writing_bugfixes.py
@@ -1,81 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
 
-"""
-Regression tests for PR #1650: RNTuple footer leak on extend, broken
-WritableNTuple.compression, directory __delitem__ KeyError.
-"""
-
 from __future__ import annotations
 
 import numpy as np
 import pytest
 
 import uproot
-import uproot.exceptions
-
-
-def test_rntuple_extend_no_freesegments_leak(tmp_path):
-    """
-    Every call to WritableNTuple.extend() must fully release the old footer
-    region (key header + payload), not just the key header.
-
-    Before the fix, NTuple.extend released only old_footer_key.allocation
-    (= num_bytes, ~70 bytes) instead of num_bytes + compressed_bytes.
-    Repeated extends left the footer payload stranded in FreeSegments,
-    causing permanent file bloat.
-
-    We verify the fix by checking that the file size after N extends is
-    within a reasonable bound and that the file is still readable.
-    """
-    fname = tmp_path / "rntuple_extend_leak.root"
-    f = uproot.recreate(fname)
-    f["t"] = {"x": np.array([1.0, 2.0, 3.0], dtype="f4")}
-    ntuple = f["t"]
-    n_extends = 10
-    for i in range(n_extends):
-        ntuple.extend({"x": np.array([float(i), float(i + 1)], dtype="f4")})
-    f.close()
-
-    # File must be readable and contain all entries
-    with uproot.open(fname) as rf:
-        arr = rf["t"]["x"].array()
-        assert len(arr) == 3 + n_extends * 2
-
-    # Sanity check: file should not grow unboundedly.
-    # Without the fix, each extend leaked ~footer_size bytes that could never
-    # be reused.  A simple bound: file should be under 20 kB for this tiny dataset.
-    size = fname.stat().st_size
-    assert size < 20_000, f"File unexpectedly large ({size} bytes), possible leak"
-
-
-def test_writable_ntuple_compression_getter(tmp_path):
-    """
-    WritableNTuple.compression must return the file-level compression object
-    without raising AttributeError (which it did before the fix because it
-    referenced self._cascading._branch_data which does not exist on NTuple).
-    """
-    fname = tmp_path / "ntuple_compression.root"
-    f = uproot.recreate(fname, compression=uproot.ZLIB(1))
-    f["t"] = {"x": np.array([1.0], dtype="f4")}
-    ntuple = f["t"]
-    comp = ntuple.compression
-    assert comp is not None
-    assert isinstance(comp, uproot.compression.Compression)
-    f.close()
-
-
-def test_writable_ntuple_compression_setter_raises(tmp_path):
-    """
-    WritableNTuple.compression setter must raise NotImplementedError (not
-    AttributeError) since per-RNTuple compression is not yet supported.
-    """
-    fname = tmp_path / "ntuple_compression_set.root"
-    f = uproot.recreate(fname)
-    f["t"] = {"x": np.array([1.0], dtype="f4")}
-    ntuple = f["t"]
-    with pytest.raises(NotImplementedError):
-        ntuple.compression = uproot.ZLIB(1)
-    f.close()
 
 
 def test_writable_directory_delitem_nonexistent_raises_key_error(tmp_path):
@@ -92,18 +22,4 @@ def test_writable_directory_delitem_nonexistent_raises_key_error(tmp_path):
     f["t"] = {"x": np.array([1, 2, 3], dtype="i4")}
     with pytest.raises(KeyError):
         del f["nonexistent_key"]
-    f.close()
-
-
-def test_writable_directory_delitem_nonexistent_is_key_in_file_error(tmp_path):
-    """
-    The error raised for deleting a nonexistent key should specifically be
-    uproot.exceptions.KeyInFileError (a KeyError subclass), matching the
-    behaviour of __getitem__ (_get method).
-    """
-    fname = tmp_path / "del_nonexistent2.root"
-    f = uproot.recreate(fname)
-    f["t"] = {"x": np.array([1], dtype="i4")}
-    with pytest.raises(uproot.exceptions.KeyInFileError):
-        del f["does_not_exist"]
     f.close()

--- a/tests/test_1650_rntuple_writing_bugfixes.py
+++ b/tests/test_1650_rntuple_writing_bugfixes.py
@@ -1,0 +1,109 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""
+Regression tests for PR #1650: RNTuple footer leak on extend, broken
+WritableNTuple.compression, directory __delitem__ KeyError.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import uproot
+import uproot.exceptions
+
+
+def test_rntuple_extend_no_freesegments_leak(tmp_path):
+    """
+    Every call to WritableNTuple.extend() must fully release the old footer
+    region (key header + payload), not just the key header.
+
+    Before the fix, NTuple.extend released only old_footer_key.allocation
+    (= num_bytes, ~70 bytes) instead of num_bytes + compressed_bytes.
+    Repeated extends left the footer payload stranded in FreeSegments,
+    causing permanent file bloat.
+
+    We verify the fix by checking that the file size after N extends is
+    within a reasonable bound and that the file is still readable.
+    """
+    fname = tmp_path / "rntuple_extend_leak.root"
+    f = uproot.recreate(fname)
+    f["t"] = {"x": np.array([1.0, 2.0, 3.0], dtype="f4")}
+    ntuple = f["t"]
+    n_extends = 10
+    for i in range(n_extends):
+        ntuple.extend({"x": np.array([float(i), float(i + 1)], dtype="f4")})
+    f.close()
+
+    # File must be readable and contain all entries
+    with uproot.open(fname) as rf:
+        arr = rf["t"]["x"].array()
+        assert len(arr) == 3 + n_extends * 2
+
+    # Sanity check: file should not grow unboundedly.
+    # Without the fix, each extend leaked ~footer_size bytes that could never
+    # be reused.  A simple bound: file should be under 20 kB for this tiny dataset.
+    size = fname.stat().st_size
+    assert size < 20_000, f"File unexpectedly large ({size} bytes), possible leak"
+
+
+def test_writable_ntuple_compression_getter(tmp_path):
+    """
+    WritableNTuple.compression must return the file-level compression object
+    without raising AttributeError (which it did before the fix because it
+    referenced self._cascading._branch_data which does not exist on NTuple).
+    """
+    fname = tmp_path / "ntuple_compression.root"
+    f = uproot.recreate(fname, compression=uproot.ZLIB(1))
+    f["t"] = {"x": np.array([1.0], dtype="f4")}
+    ntuple = f["t"]
+    comp = ntuple.compression
+    assert comp is not None
+    assert isinstance(comp, uproot.compression.Compression)
+    f.close()
+
+
+def test_writable_ntuple_compression_setter_raises(tmp_path):
+    """
+    WritableNTuple.compression setter must raise NotImplementedError (not
+    AttributeError) since per-RNTuple compression is not yet supported.
+    """
+    fname = tmp_path / "ntuple_compression_set.root"
+    f = uproot.recreate(fname)
+    f["t"] = {"x": np.array([1.0], dtype="f4")}
+    ntuple = f["t"]
+    with pytest.raises(NotImplementedError):
+        ntuple.compression = uproot.ZLIB(1)
+    f.close()
+
+
+def test_writable_directory_delitem_nonexistent_raises_key_error(tmp_path):
+    """
+    Deleting a nonexistent key from a WritableDirectory must raise a KeyError
+    subclass (uproot.exceptions.KeyInFileError), not AttributeError.
+
+    Before the fix, _del() called key.seek_location without checking whether
+    get_key() returned None, resulting in:
+        AttributeError: 'NoneType' object has no attribute 'seek_location'
+    """
+    fname = tmp_path / "del_nonexistent.root"
+    f = uproot.recreate(fname)
+    f["t"] = {"x": np.array([1, 2, 3], dtype="i4")}
+    with pytest.raises(KeyError):
+        del f["nonexistent_key"]
+    f.close()
+
+
+def test_writable_directory_delitem_nonexistent_is_key_in_file_error(tmp_path):
+    """
+    The error raised for deleting a nonexistent key should specifically be
+    uproot.exceptions.KeyInFileError (a KeyError subclass), matching the
+    behaviour of __getitem__ (_get method).
+    """
+    fname = tmp_path / "del_nonexistent2.root"
+    f = uproot.recreate(fname)
+    f["t"] = {"x": np.array([1], dtype="i4")}
+    with pytest.raises(uproot.exceptions.KeyInFileError):
+        del f["does_not_exist"]
+    f.close()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What was broken

### 1. RNTuple `extend()` leaked footer-sized regions into FreeSegments on every call
`NTuple.extend` in `_cascadentuple.py` called `freesegments.release(start, start + old_footer_key.allocation)`, but `Key.allocation` is just `Key.num_bytes` (the ~70-byte key record header). The full allocated region is `num_bytes + compressed_bytes`. Every call to `extend()` left the footer payload stranded in FreeSegments, causing permanent file bloat proportional to the number of extends. This parallels the TTree path in `_cascadetree.py:487` which correctly uses `num_bytes + compressed_bytes`.

**Reproducer:** Create an RNTuple and call `extend()` 10 times — the file is larger than it needs to be and FreeSegments entries accumulate. After the fix the freed region is fully reclaimed.

### 2. `WritableNTuple.compression` getter/setter raised `AttributeError`
The property was copy-pasted verbatim from `WritableTree` but `NTuple` has no `_branch_data`; it always raised `AttributeError: 'NTuple' object has no attribute '_branch_data'`. The getter now returns the actual file-level compression from `self._cascading._freesegments.fileheader.compression`. The setter raises `NotImplementedError` with a clear message since per-RNTuple compression is not currently supported by the cascading implementation.

**Reproducer:**
```python
with uproot.recreate("f.root") as f:
    f['t'] = {'x': np.array([1.0], 'f4')}
    print(f['t'].compression)  # was AttributeError, now returns ZLIB(1)
```

### 3. `WritableDirectory.__delitem__` raised `AttributeError` for nonexistent keys
`_del` called `key.seek_location` without checking whether `get_key()` returned `None`. Deleting a nonexistent key raised `AttributeError: 'NoneType' object has no attribute 'seek_location'` instead of a `KeyError` subclass as the `MutableMapping` contract requires. Now raises `uproot.exceptions.KeyInFileError` (a `KeyError` subclass), exactly like `_get`.

**Reproducer:**
```python
with uproot.recreate("f.root") as f:
    f['t'] = {'x': np.array([1], 'i4')}
    del f['nonexistent']  # was AttributeError, now KeyInFileError
```

### 4. Dead/broken code removed
- `Ntuple_PageLink` class: unreferenced anywhere; its `serialize` packed two values into a single-field struct → guaranteed `struct.error`.
- `NTuple.branch_types` and `NTuple.field_name` properties: referenced `self._branch_types` / `self._field_name` which are never set on `NTuple` → guaranteed `AttributeError`.
- `NTuple_Footer.__repr__`: referenced nonexistent `self.metadata_block_envelope_links` → guaranteed `AttributeError`.
- `NTuple.write_updates`: a one-line stub (`sink.flush()`) that is never called from anywhere.
- `Tree.branch_types` in `_cascadetree.py`: referenced `self._branch_types` which is never set (branch types are stored in `_branch_data`).

## What changed
- `src/uproot/writing/_cascadentuple.py`: fix footer release extent; remove 5 dead/broken code items
- `src/uproot/writing/_cascadetree.py`: remove `Tree.branch_types` dead property
- `src/uproot/writing/writable.py`: fix `WritableNTuple.compression`; fix `WritableDirectory._del` null check

## Skipped
Nothing was skipped. All 4 categories of findings were verified and fixed.

## Test results
29 tests passed, 6 skipped (ROOT not installed) across the relevant test files.


Part of #1646.
