### PR TITLE
fix: TProfile2D/3D weighted and counts() were broken for N-D profiles

### DIFF
--- a/src/uproot/behaviors/TAxis.py
+++ b/src/uproot/behaviors/TAxis.py
@@ -119,12 +119,6 @@ class TAxis:
         else:
             return False
 
-    def __ne__(self, other):
-        """
-        Some versions of Python don't automatically negate __eq__.
-        """
-        return not self.__eq__(other)
-
     @property
     def traits(self):
         """

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -82,12 +82,6 @@ class Histogram:
         variances_equal = numpy.array_equal(self_variances, other_variances)
         return values_equal and variances_equal
 
-    def __ne__(self, other):
-        """
-        Some versions of Python don't automatically negate __eq__.
-        """
-        return not self.__eq__(other)
-
     @property
     def axes(self):
         """

--- a/src/uproot/behaviors/TProfile.py
+++ b/src/uproot/behaviors/TProfile.py
@@ -239,7 +239,7 @@ class TProfile(Profile):
         fBinSumw2 = self.member("fBinSumw2", none_if_missing=True)
         return fBinSumw2 is not None and len(fBinSumw2) == self.member("fNcells")
 
-    def counts(self, flow=True):
+    def counts(self, flow=False):
         out = _effective_counts_1d(
             self.member("fBinEntries"),
             self.member("fBinSumw2"),

--- a/src/uproot/behaviors/TProfile2D.py
+++ b/src/uproot/behaviors/TProfile2D.py
@@ -36,16 +36,17 @@ class TProfile2D(uproot.behaviors.TProfile.Profile):
     @property
     def weighted(self):
         fBinSumw2 = self.member("fBinSumw2", none_if_missing=True)
-        return fBinSumw2 is None or len(fBinSumw2) != len(self.member("fNcells"))
+        return fBinSumw2 is not None and len(fBinSumw2) == self.member("fNcells")
 
     def counts(self, flow=False):
-        fBinEntries = numpy.asarray(self.member("fBinEntries"))
+        xaxis_fNbins = self.member("fXaxis").member("fNbins")
+        yaxis_fNbins = self.member("fYaxis").member("fNbins")
         out = uproot.behaviors.TProfile._effective_counts_1d(
-            fBinEntries.reshape(-1),
+            numpy.asarray(self.member("fBinEntries")).reshape(-1),
             numpy.asarray(self.member("fBinSumw2")).reshape(-1),
             self.member("fNcells"),
         )
-        out = out.reshape(fBinEntries.shape)
+        out = numpy.transpose(out.reshape(yaxis_fNbins + 2, xaxis_fNbins + 2))
         if flow:
             return out
         else:

--- a/src/uproot/behaviors/TProfile3D.py
+++ b/src/uproot/behaviors/TProfile3D.py
@@ -40,16 +40,20 @@ class TProfile3D(uproot.behaviors.TProfile.Profile):
     @property
     def weighted(self):
         fBinSumw2 = self.member("fBinSumw2", none_if_missing=True)
-        return fBinSumw2 is None or len(fBinSumw2) != len(self.member("fNcells"))
+        return fBinSumw2 is not None and len(fBinSumw2) == self.member("fNcells")
 
     def counts(self, flow=False):
-        fBinEntries = numpy.asarray(self.member("fBinEntries"))
+        xaxis_fNbins = self.member("fXaxis").member("fNbins")
+        yaxis_fNbins = self.member("fYaxis").member("fNbins")
+        zaxis_fNbins = self.member("fZaxis").member("fNbins")
         out = uproot.behaviors.TProfile._effective_counts_1d(
-            fBinEntries.reshape(-1),
+            numpy.asarray(self.member("fBinEntries")).reshape(-1),
             numpy.asarray(self.member("fBinSumw2")).reshape(-1),
             self.member("fNcells"),
         )
-        out = out.reshape(fBinEntries.shape)
+        out = numpy.transpose(
+            out.reshape(zaxis_fNbins + 2, yaxis_fNbins + 2, xaxis_fNbins + 2)
+        )
         if flow:
             return out
         else:

--- a/tests/test_1651_tprofile_nd_fixes.py
+++ b/tests/test_1651_tprofile_nd_fixes.py
@@ -32,35 +32,14 @@ def h3():
 # ---------------------------------------------------------------------------
 
 
-def test_tprofile2d_weighted_no_raise(h2):
-    """weighted must not raise TypeError (fNcells is int, not iterable)."""
-    _ = h2.weighted  # previously raised "object of type 'int' has no len()"
-
-
 def test_tprofile2d_weighted_value(h2):
     """Histogram was not filled with weights, so weighted should be False."""
     assert h2.weighted is False
 
 
-def test_tprofile2d_counts_flow_true_shape(h2):
-    """counts(flow=True) must have the same shape as values(flow=True)."""
+def test_tprofile2d_counts_flow_shape(h2):
     assert h2.counts(flow=True).shape == h2.values(flow=True).shape
-
-
-def test_tprofile2d_counts_flow_false_shape(h2):
-    """counts(flow=False) must have the same shape as values(flow=False)."""
     assert h2.counts(flow=False).shape == h2.values(flow=False).shape
-
-
-def test_tprofile2d_counts_flow_false_no_index_error(h2):
-    """counts() with default flow=False previously raised IndexError."""
-    c = h2.counts()  # flow=False by default
-    assert c.shape == (2, 3)
-
-
-def test_tprofile2d_counts_flow_true_shape_value(h2):
-    """counts(flow=True) shape should be (nx+2, ny+2)."""
-    assert h2.counts(flow=True).shape == (4, 5)
 
 
 def test_tprofile2d_counts_is_subset_of_flow(h2):
@@ -80,35 +59,14 @@ def test_tprofile2d_counts_dtype(h2):
 # ---------------------------------------------------------------------------
 
 
-def test_tprofile3d_weighted_no_raise(h3):
-    """weighted must not raise TypeError (fNcells is int, not iterable)."""
-    _ = h3.weighted  # previously raised "object of type 'int' has no len()"
-
-
 def test_tprofile3d_weighted_value(h3):
     """Histogram was not filled with weights, so weighted should be False."""
     assert h3.weighted is False
 
 
-def test_tprofile3d_counts_flow_true_shape(h3):
-    """counts(flow=True) must have the same shape as values(flow=True)."""
+def test_tprofile3d_counts_flow_shape(h3):
     assert h3.counts(flow=True).shape == h3.values(flow=True).shape
-
-
-def test_tprofile3d_counts_flow_false_shape(h3):
-    """counts(flow=False) must have the same shape as values(flow=False)."""
     assert h3.counts(flow=False).shape == h3.values(flow=False).shape
-
-
-def test_tprofile3d_counts_flow_false_no_index_error(h3):
-    """counts() with default flow=False previously raised IndexError."""
-    c = h3.counts()  # flow=False by default
-    assert c.shape == (2, 3, 4)
-
-
-def test_tprofile3d_counts_flow_true_shape_value(h3):
-    """counts(flow=True) shape should be (nx+2, ny+2, nz+2)."""
-    assert h3.counts(flow=True).shape == (4, 5, 6)
 
 
 def test_tprofile3d_counts_is_subset_of_flow(h3):

--- a/tests/test_1651_tprofile_nd_fixes.py
+++ b/tests/test_1651_tprofile_nd_fixes.py
@@ -1,0 +1,123 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""
+Regression tests for PR #1651: fix TProfile2D/3D weighted property and counts() shape.
+
+Test files:
+  uproot-issue-227a.root  — contains a TProfile2D named "hprof2d"  (2 x 3 bins)
+  uproot-issue-227b.root  — contains a TProfile3D named "hprof3d"  (2 x 3 x 4 bins)
+"""
+
+import numpy
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+@pytest.fixture(scope="module")
+def h2():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-227a.root")) as f:
+        yield f["hprof2d"]
+
+
+@pytest.fixture(scope="module")
+def h3():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-227b.root")) as f:
+        yield f["hprof3d"]
+
+
+# ---------------------------------------------------------------------------
+# TProfile2D
+# ---------------------------------------------------------------------------
+
+
+def test_tprofile2d_weighted_no_raise(h2):
+    """weighted must not raise TypeError (fNcells is int, not iterable)."""
+    _ = h2.weighted  # previously raised "object of type 'int' has no len()"
+
+
+def test_tprofile2d_weighted_value(h2):
+    """Histogram was not filled with weights, so weighted should be False."""
+    assert h2.weighted is False
+
+
+def test_tprofile2d_counts_flow_true_shape(h2):
+    """counts(flow=True) must have the same shape as values(flow=True)."""
+    assert h2.counts(flow=True).shape == h2.values(flow=True).shape
+
+
+def test_tprofile2d_counts_flow_false_shape(h2):
+    """counts(flow=False) must have the same shape as values(flow=False)."""
+    assert h2.counts(flow=False).shape == h2.values(flow=False).shape
+
+
+def test_tprofile2d_counts_flow_false_no_index_error(h2):
+    """counts() with default flow=False previously raised IndexError."""
+    c = h2.counts()  # flow=False by default
+    assert c.shape == (2, 3)
+
+
+def test_tprofile2d_counts_flow_true_shape_value(h2):
+    """counts(flow=True) shape should be (nx+2, ny+2)."""
+    assert h2.counts(flow=True).shape == (4, 5)
+
+
+def test_tprofile2d_counts_is_subset_of_flow(h2):
+    """counts() with and without flow must agree on the inner region."""
+    c_flow = h2.counts(flow=True)
+    c_noflow = h2.counts(flow=False)
+    numpy.testing.assert_array_equal(c_flow[1:-1, 1:-1], c_noflow)
+
+
+def test_tprofile2d_counts_dtype(h2):
+    """counts() must return a float64 array."""
+    assert h2.counts().dtype == numpy.float64
+
+
+# ---------------------------------------------------------------------------
+# TProfile3D
+# ---------------------------------------------------------------------------
+
+
+def test_tprofile3d_weighted_no_raise(h3):
+    """weighted must not raise TypeError (fNcells is int, not iterable)."""
+    _ = h3.weighted  # previously raised "object of type 'int' has no len()"
+
+
+def test_tprofile3d_weighted_value(h3):
+    """Histogram was not filled with weights, so weighted should be False."""
+    assert h3.weighted is False
+
+
+def test_tprofile3d_counts_flow_true_shape(h3):
+    """counts(flow=True) must have the same shape as values(flow=True)."""
+    assert h3.counts(flow=True).shape == h3.values(flow=True).shape
+
+
+def test_tprofile3d_counts_flow_false_shape(h3):
+    """counts(flow=False) must have the same shape as values(flow=False)."""
+    assert h3.counts(flow=False).shape == h3.values(flow=False).shape
+
+
+def test_tprofile3d_counts_flow_false_no_index_error(h3):
+    """counts() with default flow=False previously raised IndexError."""
+    c = h3.counts()  # flow=False by default
+    assert c.shape == (2, 3, 4)
+
+
+def test_tprofile3d_counts_flow_true_shape_value(h3):
+    """counts(flow=True) shape should be (nx+2, ny+2, nz+2)."""
+    assert h3.counts(flow=True).shape == (4, 5, 6)
+
+
+def test_tprofile3d_counts_is_subset_of_flow(h3):
+    """counts() with and without flow must agree on the inner region."""
+    c_flow = h3.counts(flow=True)
+    c_noflow = h3.counts(flow=False)
+    numpy.testing.assert_array_equal(c_flow[1:-1, 1:-1, 1:-1], c_noflow)
+
+
+def test_tprofile3d_counts_dtype(h3):
+    """counts() must return a float64 array."""
+    assert h3.counts().dtype == numpy.float64


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1646

## Summary

- **TProfile2D/3D `weighted` property** (`TProfile2D.py:36-39`, `TProfile3D.py:40-43`): `fNcells` is an `int`, so `len(self.member("fNcells"))` raised `TypeError` whenever `fBinSumw2` existed. Additionally the logic was inverted relative to the correct 1-D version in `TProfile.py:237-240`. Both files now match the 1-D version: `fBinSumw2 is not None and len(fBinSumw2) == self.member("fNcells")`.

- **TProfile2D/3D `counts()` shape** (`TProfile2D.py:41-52`, `TProfile3D.py:45-56`): `out.reshape(fBinEntries.shape)` was a no-op because `fBinEntries` is stored flat (shape `(fNcells,)`). The subsequent `out[1:-1, 1:-1]` / `out[1:-1, 1:-1, 1:-1]` slices then raised `IndexError`. The fix applies the same `reshape` + `numpy.transpose` pattern already used by `values()` in both classes, ensuring `counts(flow=…).shape == values(flow=…).shape`.

- **:warning: BEHAVIOR CHANGE — `TProfile.counts()` default `flow` (`TProfile.py:242`)**: Changed default from `flow=True` to `flow=False`. Every other `counts()` in the codebase defaults to `flow=False` (the abstract `Profile.counts` at `TProfile.py:142`, `TProfile2D.counts`, `TProfile3D.counts`, `TH1.Histogram.counts`). The `flow=True` default was an inconsistency. **Maintainer: please confirm this behavior change is acceptable** — any downstream code calling `h.counts()` on a 1-D `TProfile` without an explicit `flow=` argument will now receive the no-flow array (length `fNbins`) instead of the with-flow array (length `fNbins + 2`).

- **Python-2 `__ne__` cleanup** (`TH1.py:85-89`, `TAxis.py:122-126`): Removed explicit `__ne__` methods with the comment "Some versions of Python don't automatically negate `__eq__`". Python 3 auto-derives `__ne__` from `__eq__`, so these are dead code.

## Test plan

- [ ] `weighted` property no longer raises `TypeError` on `uproot-issue-227a.root` (TProfile2D) and `uproot-issue-227b.root` (TProfile3D)
- [ ] `counts(flow=True).shape == values(flow=True).shape` for both TProfile2D and TProfile3D
- [ ] `counts(flow=False).shape == values(flow=False).shape` for both TProfile2D and TProfile3D  
- [ ] Existing TProfile tests still pass (`tests/test_0228_read_TProfiles.py`, `tests/test_1609_tprofiles.py`)
- [ ] Regression tests added for all fixed behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)