### PR TITLE
fix: RNTuple page deserialization copies, split-column sizing, and cluster-index pairing

### DIFF
--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -12,7 +12,7 @@ import struct
 import sys
 from collections import Counter, defaultdict
 from itertools import groupby
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import awkward as ak
 import numpy
@@ -139,6 +139,7 @@ in file {self.file.file_path}"""
         self._alias_column_records = None
         self._related_ids_ = None
         self._column_records_dict_ = None
+        self._field_metadata_cache = {}
         self._num_entries = None
         self._length = None
 
@@ -648,8 +649,7 @@ in file {self.file.file_path}"""
             col_id = self._column_records_dict[cfid][0].idx
             keyname = f"column-{col_id}"
             #  this only has one child
-            if this_id in self._related_ids:
-                child_id = self._related_ids[this_id][0]
+            child_id = self._related_ids[this_id][0]
             inner = self.field_form(child_id, keys, ak_add_doc=ak_add_doc)
             idx_type = (
                 "i32" if self._column_records_dict[cfid][0].nbits == 32 else "i64"
@@ -860,7 +860,13 @@ in file {self.file.file_path}"""
         # because for offsets there is an extra zero added at the start.
         res[: starts[0]] = 0
 
-        for i, cluster_idx in enumerate(range(cluster_start, cluster_stop)):
+        # ``starts`` only contains entries for non-negative cluster indices
+        # (see _expected_array_length_starts_dtype), so skip negative ones here
+        # to keep the pairing between ``starts[i]`` and the cluster index aligned.
+        i = 0
+        for cluster_idx in range(cluster_start, cluster_stop):
+            if cluster_idx < 0:
+                continue
             stop = starts[i + 1] if i + 1 < len(starts) else None
             self.read_cluster_pages(
                 cluster_idx,
@@ -869,6 +875,7 @@ in file {self.file.file_path}"""
                 destination=res[starts[i] : stop],
                 array_cache=array_cache,
             )
+            i += 1
 
         self.combine_cluster_arrays(res, starts, field_metadata)
 
@@ -1067,13 +1074,11 @@ in file {self.file.file_path}"""
             # If compressed, skip 9 byte header
             if page_is_compressed:
                 # If LZ4, page contains additional 8-byte checksum
-                offset = (
-                    int(loc.offset + 9)
-                    if algorithm_str != "LZ4"
-                    else int(loc.offset + 9 + 8)
-                )
-                comp_buff = cupy.empty(n_bytes - 9, dtype="b")
-                filehandle.pread(comp_buff, size=int(n_bytes - 9), file_offset=offset)
+                header_size = 9 if algorithm_str != "LZ4" else 9 + 8
+                offset = int(loc.offset + header_size)
+                read_size = int(n_bytes - header_size)
+                comp_buff = cupy.empty(read_size, dtype="b")
+                filehandle.pread(comp_buff, size=read_size, file_offset=offset)
 
             # If uncompressed, read directly into out_buff
             else:
@@ -1127,7 +1132,14 @@ in file {self.file.file_path}"""
             res[: starts[0]] = 0
             # Get uncompressed array for key for all clusters
             col_decompressed_buffers = clusters_datas._grab_field_output(ncol)
-            for i, cluster_i in enumerate(cluster_range):
+            # ``starts`` only contains entries for non-negative cluster indices
+            # (see _expected_array_length_starts_dtype), so skip negative ones
+            # here to keep the pairing between ``starts[i]`` and the cluster
+            # index aligned.
+            i = 0
+            for cluster_i in cluster_range:
+                if cluster_i < 0:
+                    continue
                 stop = starts[i + 1] if i + 1 < len(starts) else total_length
                 cluster_buffer = col_decompressed_buffers[cluster_i]
                 cluster_buffer = self.gpu_deserialize_pages(
@@ -1140,6 +1152,7 @@ in file {self.file.file_path}"""
                     res[starts[i] : stop] = res[starts[i] : stop].view(
                         field_metadata.dtype
                     )[: stop - starts[i]]
+                i += 1
 
             self.combine_cluster_arrays(res, starts, field_metadata)
             col_arrays[key_nr] = res
@@ -1227,9 +1240,22 @@ in file {self.file.file_path}"""
         library = numpy if array_library_string == "numpy" else uproot.extras.cupy()
         num_elements = len(destination)
 
-        content = library.copy(destination)
+        # Plain columns need no transform; the raw data is already in place.
+        if not (
+            field_metadata.split
+            or field_metadata.isbit
+            or field_metadata.dtype_str in ("real32trunc", "real32quant")
+        ):
+            return
+
         if field_metadata.split:
-            content = content.view(library.uint8)
+            # The raw data only occupies the first num_elements * itemsize(dtype)
+            # bytes of destination (destination may be the wider dtype_result when
+            # the field has multiple column representations), so operate on just
+            # that portion to avoid mixing in garbage tail bytes.
+            content = library.copy(
+                destination.view(field_metadata.dtype)[:num_elements]
+            ).view(library.uint8)
             length = content.shape[0]
             if field_metadata.nbits == 16:
                 # AAAAABBBBB needs to become
@@ -1259,7 +1285,9 @@ in file {self.file.file_path}"""
                 res[5::8] = content[length * 5 // 8 : length * 6 // 8]
                 res[6::8] = content[length * 6 // 8 : length * 7 // 8]
                 res[7::8] = content[length * 7 // 8 : length * 8 // 8]
-            content = res.view(field_metadata.dtype)
+            destination.view(field_metadata.dtype)[:num_elements] = res.view(
+                field_metadata.dtype
+            )
 
         if field_metadata.isbit:
             content = library.unpackbits(
@@ -1276,8 +1304,6 @@ in file {self.file.file_path}"""
                 content <<= 32 - field_metadata.nbits
             # TODO: check why this needs to be trimmed
             destination.view(numpy.uint32)[:] = content[:num_elements]
-        else:
-            destination[:] = content
 
     def get_field_metadata(self, ncol):
         """
@@ -1287,6 +1313,9 @@ in file {self.file.file_path}"""
         Returns a uproot.models.RNTuple.FieldClusterMetadata which provides
         metadata needed for processing payload data associated with column ncol.
         """
+        cached = self._field_metadata_cache.get(ncol)
+        if cached is not None:
+            return cached
         dtype_byte = self.column_records[ncol].type
         dtype_str = uproot.const.rntuple_col_num_to_dtype_dict[dtype_byte]
         isbit = dtype_str == "bit"
@@ -1345,6 +1374,7 @@ in file {self.file.file_path}"""
             isbit,
             nbits,
         )
+        self._field_metadata_cache[ncol] = field_metadata
         return field_metadata
 
     def combine_cluster_arrays(self, array, starts, field_metadata):
@@ -1382,7 +1412,6 @@ def _extract_bits(packed, nbits):
     packed = packed.view(dtype=library.uint32)
     total_bits = packed.size * 32
     n_values = total_bits // nbits
-    result = library.empty(n_values, dtype=library.uint32)
 
     # Indices into packed array
     bit_positions = library.arange(n_values, dtype=library.uint32) * nbits
@@ -2030,7 +2059,7 @@ def _cupy_insert0(arr):
     return out_arr
 
 
-CupyArray = any
+CupyArray = Any
 
 
 @dataclasses.dataclass
@@ -2117,9 +2146,9 @@ class ClusterRefs:
     payload datas and for accessing field payload datas across multiple clusters.
     """
 
-    clusters: [int] = dataclasses.field(default_factory=list)
+    clusters: list[int] = dataclasses.field(default_factory=list)
     columns: list[str] = dataclasses.field(default_factory=list)
-    refs: dict[int:FieldRefsCluster] = dataclasses.field(default_factory=dict)
+    refs: dict[int, FieldRefsCluster] = dataclasses.field(default_factory=dict)
 
     def _add_cluster(self, Cluster):
         for nCol in Cluster.fieldpayloads.keys():

--- a/tests/test_1652_rntuple_model_fixes.py
+++ b/tests/test_1652_rntuple_model_fixes.py
@@ -1,0 +1,148 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import uproot
+from uproot.models.RNTuple import (
+    FieldClusterMetadata,
+    Model_ROOT_3a3a_RNTuple,
+    _extract_bits,
+)
+
+skhep_testdata = pytest.importorskip("skhep_testdata")
+
+
+def _byte_split(values):
+    """Byte-split an array the way RNTuple stores split-encoded columns."""
+    num = len(values)
+    raw = values.view(np.uint8).reshape(num, values.dtype.itemsize)
+    out = np.empty(num * values.dtype.itemsize, np.uint8)
+    for b in range(values.dtype.itemsize):
+        out[b * num : (b + 1) * num] = raw[:, b]
+    return out
+
+
+def _make_metadata(**kwargs):
+    defaults = dict(
+        ncol=0,
+        dtype_byte=0x18,
+        dtype_str="float32",
+        dtype=np.dtype("float32"),
+        dtype_toread=np.dtype("float32"),
+        dtype_result=np.dtype("float32"),
+        split=False,
+        zigzag=False,
+        delta=False,
+        isbit=False,
+        nbits=32,
+    )
+    defaults.update(kwargs)
+    return FieldClusterMetadata(**defaults)
+
+
+def _deserialize(destination, field_metadata):
+    obj = Model_ROOT_3a3a_RNTuple.__new__(Model_ROOT_3a3a_RNTuple)
+    Model_ROOT_3a3a_RNTuple.deserialize_page_decompressed_buffer(
+        obj, destination, field_metadata
+    )
+
+
+def test_split_column_into_wider_destination():
+    # Regression for split-column sizing when the raw dtype (float32) is
+    # narrower than dtype_result (float64), as happens with multiple column
+    # representations. The raw data only occupies the first num*4 bytes of the
+    # float64-wide destination; the split unshuffle must not pull in the
+    # garbage tail bytes (which previously caused a broadcast failure).
+    values = np.array([1.5, -2.25, 3.0, 42.0], dtype=np.float32)
+    num = len(values)
+    destination = np.zeros(num, dtype=np.float64)
+    destination.view(np.uint8)[: num * 4] = _byte_split(values)
+
+    field_metadata = _make_metadata(
+        split=True,
+        dtype=np.dtype("float32"),
+        dtype_result=np.dtype("float64"),
+    )
+    _deserialize(destination, field_metadata)
+
+    np.testing.assert_allclose(destination.view(np.float32)[:num], values)
+
+
+def test_split_column_same_dtype_roundtrip():
+    # The common split case where dtype == dtype_result must be unchanged.
+    values = np.array([1.5, -2.25, 3.0, 42.0, -7.5], dtype=np.float32)
+    num = len(values)
+    destination = np.zeros(num, dtype=np.float32)
+    destination.view(np.uint8)[:] = _byte_split(values)
+
+    field_metadata = _make_metadata(split=True)
+    _deserialize(destination, field_metadata)
+
+    np.testing.assert_allclose(destination, values)
+
+
+def test_plain_column_is_left_untouched():
+    # Plain columns need no transform; the data is already in place and should
+    # be returned without an extra round-trip copy.
+    values = np.array([1, 2, 3, 4], dtype=np.int64)
+    destination = values.copy()
+
+    field_metadata = _make_metadata(
+        dtype_byte=0x09,
+        dtype_str="int64",
+        dtype=np.dtype("int64"),
+        dtype_toread=np.dtype("int64"),
+        dtype_result=np.dtype("int64"),
+        nbits=64,
+    )
+    _deserialize(destination, field_metadata)
+
+    np.testing.assert_array_equal(destination, values)
+
+
+def test_extract_bits_roundtrip():
+    # _extract_bits should faithfully unpack nbits-wide values; this also guards
+    # against the removed dead allocation reintroducing a bug.
+    nbits = 12
+    original = np.array([0, 1, 4095, 1234, 2048], dtype=np.uint32)
+    n = len(original)
+    total_bits = n * nbits
+    packed_words = int(np.ceil(total_bits / 32))
+    bitstream = np.zeros(packed_words * 32, dtype=np.uint8)
+    for i, v in enumerate(original):
+        for b in range(nbits):
+            if (v >> b) & 1:
+                bit_index = i * nbits + b
+                bitstream[bit_index] = 1
+    packed = np.packbits(bitstream, bitorder="little").view(np.uint32)
+
+    result = _extract_bits(packed, nbits)
+    np.testing.assert_array_equal(result[:n], original)
+
+
+def test_custom_floats_roundtrip_still_passes():
+    # Safety net for the real32trunc / real32quant deserialization paths.
+    filename = skhep_testdata.data_path("test_float_types_rntuple_v1-0-0-0.root")
+    with uproot.open(filename) as f:
+        arrays = f["ntuple"].arrays()
+        assert len(arrays) > 0
+
+
+def test_split_zigzag_ints_roundtrip_still_passes():
+    # Safety net for the split + zigzag integer deserialization path.
+    filename = skhep_testdata.data_path("test_int_5e4_rntuple_v1-0-0-0.root")
+    with uproot.open(filename) as f:
+        arrays = f["ntuple"].arrays()
+        assert len(arrays) > 0
+
+
+def test_multiple_representations_still_passes():
+    # Safety net for the suppressed-columns / multiple-representations path
+    # which involves dtype != dtype_result handling.
+    filename = skhep_testdata.data_path(
+        "test_multiple_representations_rntuple_v1-0-0-0.root"
+    )
+    with uproot.open(filename) as f:
+        arrays = f["ntuple"].arrays()
+        assert np.allclose(arrays.real, [1, 2, 3])

--- a/tests/test_1652_rntuple_model_fixes.py
+++ b/tests/test_1652_rntuple_model_fixes.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 
-import uproot
 from uproot.models.RNTuple import (
     FieldClusterMetadata,
     Model_ROOT_3a3a_RNTuple,
@@ -69,38 +68,6 @@ def test_split_column_into_wider_destination():
     np.testing.assert_allclose(destination.view(np.float32)[:num], values)
 
 
-def test_split_column_same_dtype_roundtrip():
-    # The common split case where dtype == dtype_result must be unchanged.
-    values = np.array([1.5, -2.25, 3.0, 42.0, -7.5], dtype=np.float32)
-    num = len(values)
-    destination = np.zeros(num, dtype=np.float32)
-    destination.view(np.uint8)[:] = _byte_split(values)
-
-    field_metadata = _make_metadata(split=True)
-    _deserialize(destination, field_metadata)
-
-    np.testing.assert_allclose(destination, values)
-
-
-def test_plain_column_is_left_untouched():
-    # Plain columns need no transform; the data is already in place and should
-    # be returned without an extra round-trip copy.
-    values = np.array([1, 2, 3, 4], dtype=np.int64)
-    destination = values.copy()
-
-    field_metadata = _make_metadata(
-        dtype_byte=0x09,
-        dtype_str="int64",
-        dtype=np.dtype("int64"),
-        dtype_toread=np.dtype("int64"),
-        dtype_result=np.dtype("int64"),
-        nbits=64,
-    )
-    _deserialize(destination, field_metadata)
-
-    np.testing.assert_array_equal(destination, values)
-
-
 def test_extract_bits_roundtrip():
     # _extract_bits should faithfully unpack nbits-wide values; this also guards
     # against the removed dead allocation reintroducing a bug.
@@ -119,30 +86,3 @@ def test_extract_bits_roundtrip():
 
     result = _extract_bits(packed, nbits)
     np.testing.assert_array_equal(result[:n], original)
-
-
-def test_custom_floats_roundtrip_still_passes():
-    # Safety net for the real32trunc / real32quant deserialization paths.
-    filename = skhep_testdata.data_path("test_float_types_rntuple_v1-0-0-0.root")
-    with uproot.open(filename) as f:
-        arrays = f["ntuple"].arrays()
-        assert len(arrays) > 0
-
-
-def test_split_zigzag_ints_roundtrip_still_passes():
-    # Safety net for the split + zigzag integer deserialization path.
-    filename = skhep_testdata.data_path("test_int_5e4_rntuple_v1-0-0-0.root")
-    with uproot.open(filename) as f:
-        arrays = f["ntuple"].arrays()
-        assert len(arrays) > 0
-
-
-def test_multiple_representations_still_passes():
-    # Safety net for the suppressed-columns / multiple-representations path
-    # which involves dtype != dtype_result handling.
-    filename = skhep_testdata.data_path(
-        "test_multiple_representations_rntuple_v1-0-0-0.root"
-    )
-    with uproot.open(filename) as f:
-        arrays = f["ntuple"].arrays()
-        assert np.allclose(arrays.real, [1, 2, 3])


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1646.

Fixes several bugs and inefficiencies in the RNTuple model (`src/uproot/models/RNTuple.py`).

### Performance
- **`deserialize_page_decompressed_buffer`** previously did an unconditional `library.copy(destination)` at the top and `destination[:] = content` at the bottom for *every* page, including plain columns that need no transform (the common case) — a full round-trip copy per page in the hottest CPU loop (`read_page`). It now returns early for plain columns and only allocates scratch inside the branches that actually need it (split / bit / real32trunc / real32quant).

### Bugs
- **Split-column sizing**: when the raw `dtype` differs from `dtype_result` (multiple column representations of different widths, e.g. split-real32 read into a wider destination via the suppressed-columns machinery), the split branch computed `length` from the full `dtype_result`-sized buffer, byte-unshuffling garbage tail bytes and then failing the final broadcast. It now operates on `destination.view(dtype)[:num_elements]`.
- **Cluster-index pairing**: `_expected_array_length_starts_dtype` skips `cluster_idx < 0` when building `starts`, but `read_cluster_range` and `gpu_deserialize_decompressed_content` enumerated `range(cluster_start, cluster_stop)` and paired `starts[i]` with the i-th value. When `cluster_start == -1` (callers in `behaviors/RNTuple.py` explicitly anticipate it), negative Python indexing read the last cluster and shifted every pairing. Both read loops now skip negative indices the same way.
- **GPU LZ4 page read size** (untested-on-GPU; verified by code reading): for LZ4 the read `offset` skips a 9-byte block header plus an 8-byte checksum, but the read size stayed `n_bytes - 9`, reading 8 bytes past the page. Read size is now `n_bytes - header_size` (i.e. `n_bytes - 17` for LZ4).

### Cleanups
- Removed a dead `library.empty(...)` allocation in `_extract_bits` (immediately overwritten by `library.where(...)`).
- `CupyArray = any` aliased the builtin `any`; now `Any` from `typing`. Fixed invalid annotations `clusters: [int]` → `list[int]` and `refs: dict[int:FieldRefsCluster]` → `dict[int, FieldRefsCluster]`.
- Removed the provably-always-true `if this_id in self._related_ids:` guard around `child_id` in the `field_form` COLLECTION branch so future changes surface a clear error instead of `NameError`.
- Added a small per-instance memo for `get_field_metadata` keyed by `ncol`.

### Testing
All CPU RNTuple round-trip tests pass (plain, split, bit-packed bool, zigzag, real32trunc/quant, and the multiple-representations/suppressed-column path in `test_1347`). The GPU LZ4 fix could not be exercised (no CUDA available) and is marked untested-on-GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
