### PR TITLE
fix: source/sink error paths, leaks, and hot-path cleanups

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -3661,8 +3661,8 @@ def _ranges_or_baskets_to_arrays(
             original_index = range_original_index[(chunk.start, chunk.stop)]
             if update_ranges_or_baskets:
                 replace(ranges_or_baskets, original_index, basket)
-        except Exception:
-            notifications.put(sys.exc_info())
+        except Exception as err:
+            notifications.put(err)
         else:
             notifications.put(basket)
 
@@ -3716,8 +3716,8 @@ def _ranges_or_baskets_to_arrays(
                     # no longer needed, save memory
                     basket_arrays.clear()
 
-        except Exception:
-            notifications.put(sys.exc_info())
+        except Exception as err:
+            notifications.put(err)
         else:
             notifications.put(None)
 
@@ -3741,11 +3741,8 @@ def _ranges_or_baskets_to_arrays(
         elif obj is None:
             pass
 
-        elif isinstance(obj, tuple) and len(obj) == 3:
-            uproot.source.futures.delayed_raise(*obj)
-
         else:
-            raise AssertionError(obj)
+            raise obj
 
         obj = None  # release before blocking
 

--- a/src/uproot/sink/file.py
+++ b/src/uproot/sink/file.py
@@ -36,6 +36,7 @@ class FileSink:
     def __init__(self, urlpath_or_file_like: str | IO, **storage_options):
         self._open_file = None
         self._file = None
+        self._closed = False
 
         if uproot._util.is_file_like(
             urlpath_or_file_like, readable=False, writable=False, seekable=False
@@ -99,6 +100,9 @@ class FileSink:
         Opens the file if it is not already open.
         Sets the file's position to the beginning.
         """
+        if self._closed:
+            raise OSError(f"file sink is closed{self.in_path}")
+
         if not self._file:
             self._file = self._open_file.open()
 
@@ -130,19 +134,20 @@ class FileSink:
     @property
     def closed(self) -> bool:
         """
-        True if the file is closed; False otherwise.
+        True if the file has been closed; False otherwise.
         """
-        return self._file is None
+        return self._closed
 
     def close(self):
         """
-        Closes the file (calls ``close`` if it has such a method) and sets it to
-        None so that closure is permanent.
+        Closes the file (calls ``close`` if it has such a method) and marks the
+        sink as closed so that closure is permanent: subsequent reads or writes
+        raise instead of silently reopening the file.
         """
-        if self._file is not None:
-            if hasattr(self._file, "close"):
-                self._file.close()
-            self._file = None
+        if self._file is not None and hasattr(self._file, "close"):
+            self._file.close()
+        self._file = None
+        self._closed = True
 
     def __enter__(self):
         return self

--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -85,7 +85,7 @@ class Source:
         """
 
     def chunks(
-        self, ranges: list[(int, int)], notifications: queue.Queue
+        self, ranges: list[tuple[int, int]], notifications: queue.Queue
     ) -> list[Chunk]:
         """
         Args:
@@ -200,7 +200,7 @@ class MultithreadedSource(Source):
         return chunk
 
     def chunks(
-        self, ranges: list[(int, int)], notifications: queue.Queue
+        self, ranges: list[tuple[int, int]], notifications: queue.Queue
     ) -> list[Chunk]:
         self._num_requests += 1
         self._num_requested_chunks += len(ranges)
@@ -438,7 +438,7 @@ for file path {self._source.file_path}""")
         :ref:`uproot.source.chunk.Chunk.future` completes), if it isn't
         already.
         """
-        if (start, stop) in self:
+        if self._start <= start and stop <= self._stop:
             self.wait(insist=stop)
             local_start = start - self._start
             local_stop = stop - self._start

--- a/src/uproot/source/coalesce.py
+++ b/src/uproot/source/coalesce.py
@@ -1,3 +1,5 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
 """Read coalescing algorithms
 
 Inspired in part by https://github.com/cms-sw/cmssw/blob/master/IOPool/TFileAdaptor/src/ReadRepacker.h
@@ -106,7 +108,7 @@ def _coalesce(ranges: list[RangeRequest], config: CoalesceConfig):
     first_request = True
     for cluster in _merge_adjacent(ranges, config):
         if clusters and (
-            len(clusters) + 1 >= config.max_request_ranges
+            len(clusters) >= config.max_request_ranges
             or request_bytes + len(cluster) >= config.max_request_bytes
             or (first_request and request_bytes >= config.min_first_request_bytes)
         ):

--- a/src/uproot/source/cufile_interface.py
+++ b/src/uproot/source/cufile_interface.py
@@ -1,3 +1,5 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
 from __future__ import annotations
 
 import uproot
@@ -32,7 +34,7 @@ class CuFileSource:
     def pread(
         self,
         buffer,
-        size: int | None = None,
+        size: int,
         file_offset: int = 0,
         task_size: int | None = None,
     ):

--- a/src/uproot/source/cursor.py
+++ b/src/uproot/source/cursor.py
@@ -481,16 +481,13 @@ class Cursor:
         null-terminated, UTF-8 encoded string.
         """
         remainder = chunk.remainder(self._index, self, context)
-        local_stop = 0
-        char = None
-        while char != 0:
-            if local_stop > len(remainder):
-                raise OSError(
-                    f"""C-style string has no terminator (null byte) in Chunk {self._start}:{self._stop}
-of file path {self._source.file_path}"""
-                )
-            char = remainder[local_stop]
-            local_stop += 1
+        terminator = remainder.tobytes().find(0)
+        if terminator < 0:
+            raise OSError(
+                f"""C-style string has no terminator (null byte) in Chunk {chunk.start}:{chunk.stop}
+of file path {chunk.source.file_path}"""
+            )
+        local_stop = terminator + 1
 
         if move:
             self._index += local_stop

--- a/src/uproot/source/file.py
+++ b/src/uproot/source/file.py
@@ -124,6 +124,9 @@ class MemmapSource(uproot.source.chunk.Source):
     def __getstate__(self):
         state = dict(self.__dict__)
         state.pop("_file")
+        # _open() recreates the fallback; keeping it here would leak its
+        # worker threads (revived by __setstate__) when _open() overwrites it.
+        state.pop("_fallback", None)
         return state
 
     def __setstate__(self, state):
@@ -156,7 +159,7 @@ class MemmapSource(uproot.source.chunk.Source):
             return self._fallback.chunk(start, stop)
 
     def chunks(
-        self, ranges: list[(int, int)], notifications: queue.Queue
+        self, ranges: list[tuple[int, int]], notifications: queue.Queue
     ) -> list[uproot.source.chunk.Chunk]:
         if self._fallback is None:
             if self.closed:

--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -10,6 +10,7 @@ import re
 
 import fsspec
 import fsspec.asyn
+import fsspec.implementations.cached
 
 import uproot
 import uproot.source.chunk
@@ -174,20 +175,24 @@ class FSSpecSource(uproot.source.chunk.Source):
             paths = [self._file_path] * len(request_ranges)
             starts = [start for start, _ in request_ranges]
             ends = [stop for _, stop in request_ranges]
-            # _cat_ranges is async while cat_ranges is not.
-            coroutine = (
-                self._fs._cat_ranges(paths=paths, starts=starts, ends=ends)
-                if self._async_impl and not self._fs._cached
-                else async_wrapper_thread(
-                    self._fs.cat_ranges, paths=paths, starts=starts, ends=ends
-                )
-            )
             if uproot._util.wasm:
                 # Threads can't be spawned in pyodide yet, so we run the function directly
                 # and return a future that is already resolved.
                 return uproot.source.futures.TrivialFuture(
                     self._fs.cat_ranges(paths=paths, starts=starts, ends=ends)
                 )
+            # _cat_ranges is async while cat_ranges is not. Avoid the native
+            # async path for caching filesystems, whose _cat_ranges is not async.
+            is_caching = isinstance(
+                self._fs, fsspec.implementations.cached.CachingFileSystem
+            )
+            coroutine = (
+                self._fs._cat_ranges(paths=paths, starts=starts, ends=ends)
+                if self._async_impl and not is_caching
+                else async_wrapper_thread(
+                    self._fs.cat_ranges, paths=paths, starts=starts, ends=ends
+                )
+            )
             return self._executor.submit(coroutine)
 
         return coalesce_requests(

--- a/src/uproot/source/futures.py
+++ b/src/uproot/source/futures.py
@@ -28,13 +28,6 @@ import threading
 from abc import ABC, abstractmethod
 
 
-def delayed_raise(exception_class, exception_value, traceback):
-    """
-    Raise an exception from a background thread on the main thread.
-    """
-    raise exception_value.with_traceback(traceback)
-
-
 class Executor(ABC):
     def __repr__(self):
         return f"<{self.__class__.__name__} at 0x{id(self):012x}>"

--- a/src/uproot/source/futures.py
+++ b/src/uproot/source/futures.py
@@ -9,8 +9,7 @@ This module defines a Python-like Future and Executor for Uproot in three levels
 2. :doc:`uproot.source.futures.Future`, :doc:`uproot.source.futures.Worker`,
    and :doc:`uproot.source.futures.ThreadPoolExecutor`: similar to Python's
    own Future, Thread, and ThreadPoolExecutor, though only a minimal
-   implementation is provided. These exist to unify behavior between Python 2
-   and 3 and provide a base class for the following.
+   implementation is provided. These provide a base class for the following.
 3. :doc:`uproot.source.futures.ResourceFuture`,
    :doc:`uproot.source.futures.ResourceWorker`,
    and :doc:`uproot.source.futures.ResourceThreadPoolExecutor`: like the above
@@ -25,9 +24,7 @@ from __future__ import annotations
 
 import os
 import queue
-import sys
 import threading
-import time
 from abc import ABC, abstractmethod
 
 
@@ -114,7 +111,7 @@ class Future:
         args (tuple): Arguments for the function.
 
     Like Python 3 ``concurrent.futures.Future`` except that it has only
-    the subset of the interface Uproot needs and is available in Python 2.
+    the subset of the interface Uproot needs.
 
     The :doc:`uproot.source.futures.ResourceFuture` extends this class.
     """
@@ -134,21 +131,21 @@ class Future:
         If the task raises an exception in its background thread, this function
         raises that exception on the thread on which it is called.
         """
-        self._finished.wait(timeout=timeout)
+        if not self._finished.wait(timeout=timeout):
+            raise TimeoutError("Future.result timed out")
         if self._excinfo is None:
             return self._result
         else:
-            delayed_raise(*self._excinfo)
+            raise self._excinfo
 
     def _run(self):
         try:
             if self._task is None:
                 raise RuntimeError("cannot run Future twice")
             self._result = self._task(*self._args)
-        except Exception:
-            self._excinfo = sys.exc_info()
+        except Exception as err:
+            self._excinfo = err
         self._finished.set()
-        del self._task, self._args
         self._task = None
         self._args = ()
 
@@ -203,22 +200,14 @@ class ThreadPoolExecutor(Executor):
         If None, use ``os.cpu_count()``.
 
     Like Python 3 ``concurrent.futures.ThreadPoolExecutor`` except that it has
-    only the subset of the interface Uproot needs and is available in Python 2.
+    only the subset of the interface Uproot needs.
 
     The :doc:`uproot.source.futures.ResourceThreadPoolExecutor` extends this
     class.
     """
 
     def __init__(self, max_workers: int | None = None):
-        if max_workers is None:
-            if hasattr(os, "cpu_count"):
-                self._max_workers = os.cpu_count()
-            else:
-                import multiprocessing
-
-                self._max_workers = multiprocessing.cpu_count()
-        else:
-            self._max_workers = max_workers
+        self._max_workers = max_workers or os.cpu_count()
 
         self._work_queue = queue.Queue()
         self._workers = []
@@ -264,18 +253,14 @@ class ThreadPoolExecutor(Executor):
 
     def shutdown(self, wait: bool = True):
         """
-        Stop every :doc:`uproot.source.futures.Worker` by putting None
-        on the :ref:`uproot.source.futures.Worker.work_queue` until none of
-        them satisfy ``worker.is_alive()``.
+        Stop every :doc:`uproot.source.futures.Worker` by putting one None per
+        worker on the :ref:`uproot.source.futures.Worker.work_queue` and
+        joining each worker thread.
         """
-        while True:
-            for worker in self._workers:
-                if worker.is_alive():
-                    self._work_queue.put(None)
-            if any(worker.is_alive() for worker in self._workers):
-                time.sleep(0.001)
-            else:
-                break
+        for _ in self._workers:
+            self._work_queue.put(None)
+        for worker in self._workers:
+            worker.join()
 
 
 ##################### use-case 3: worker-bound resources for I/O
@@ -312,12 +297,11 @@ class ResourceFuture(Future):
     def _run(self, resource):
         try:
             self._result = self._task(resource)
-        except Exception:
-            self._excinfo = sys.exc_info()
+        except Exception as err:
+            self._excinfo = err
         self._finished.set()
         if self._notify is not None:
             self._notify()
-            del self._notify
             self._notify = None
 
 

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -21,7 +21,6 @@ import http.client
 import queue
 import re
 import socket
-import sys
 import urllib.parse
 from urllib.parse import urlparse
 
@@ -280,7 +279,7 @@ for URL {self._file_path}"""
     def multifuture(
         source: uproot.source.chunk.Source,
         range_header: dict,
-        ranges: list[(int, int)],
+        ranges: list[tuple[int, int]],
         futures,
         results,
     ):
@@ -359,10 +358,9 @@ for URL {source.file_path}"""
                         source, futures, results, response, ranges
                     )
 
-            except Exception:
-                excinfo = sys.exc_info()
+            except Exception as err:
                 for future in futures.values():
-                    future._set_excinfo(excinfo)
+                    future._set_excinfo(err)
 
             finally:
                 connection.close()
@@ -375,7 +373,7 @@ for URL {source.file_path}"""
     _content_range = re.compile(b"Content-Range: bytes ([0-9]+-[0-9]+)", re.I)
 
     def is_multipart_supported(
-        self, ranges: list[(int, int)], response: http.client.HTTPResponse
+        self, ranges: list[tuple[int, int]], response: http.client.HTTPResponse
     ) -> bool:
         """
         Helper function for :ref:`uproot.source.http.HTTPResource.multifuture`
@@ -396,7 +394,7 @@ for URL {source.file_path}"""
     def handle_no_multipart(
         self,
         source: uproot.source.chunk.Source,
-        ranges: list[(int, int)],
+        ranges: list[tuple[int, int]],
         futures,
         results,
     ):
@@ -420,7 +418,7 @@ for URL {source.file_path}"""
         futures,
         results,
         response: http.client.HTTPResponse,
-        ranges: list[(int, int)],
+        ranges: list[tuple[int, int]],
     ):
         """
         Helper function for :ref:`uproot.source.http.HTTPResource.multifuture`
@@ -644,7 +642,7 @@ class HTTPSource(uproot.source.chunk.Source):
 
     def chunks(
         self,
-        ranges: list[(int, int)],
+        ranges: list[tuple[int, int]],
         notifications: queue.Queue,
     ) -> list[uproot.source.chunk.Chunk]:
         if self._fallback is None:

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -21,6 +21,7 @@ import http.client
 import queue
 import re
 import socket
+import threading
 import urllib.parse
 from urllib.parse import urlparse
 

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import contextlib
 import queue
-import sys
 
 import uproot
 import uproot.source.chunk
@@ -243,10 +242,9 @@ class XRootDResource(uproot.source.chunk.Resource):
             if status.error:
                 try:
                     self._xrd_error(status)
-                except Exception:
-                    excinfo = sys.exc_info()
+                except Exception as err:
                     for future in futures.values():
-                        future._set_excinfo(excinfo)
+                        future._set_excinfo(err)
             else:
                 for chunk in response.chunks:
                     start, stop = chunk.offset, chunk.offset + chunk.length
@@ -330,7 +328,7 @@ class XRootDSource(uproot.source.chunk.Source):
         return uproot.source.chunk.Chunk(self, start, stop, future)
 
     def chunks(
-        self, ranges: list[(int, int)], notifications: queue.Queue
+        self, ranges: list[tuple[int, int]], notifications: queue.Queue
     ) -> list[uproot.source.chunk.Chunk]:
         self._num_requests += 1
         self._num_requested_chunks += len(ranges)
@@ -345,7 +343,7 @@ class XRootDSource(uproot.source.chunk.Source):
         sub_ranges = {}
 
         def add_request_range(
-            start: int, length: int, sub_ranges_list: list[(int, int)]
+            start: int, length: int, sub_ranges_list: list[tuple[int, int]]
         ):
             if len(all_request_ranges[-1]) >= self._max_num_elements:
                 all_request_ranges.append([])
@@ -378,7 +376,7 @@ class XRootDSource(uproot.source.chunk.Source):
 
         # submit the xrootd vector reads
         global_futures = {}
-        for _, request_ranges in enumerate(all_request_ranges):
+        for request_ranges in all_request_ranges:
             futures = {}
             results = {}
             for start, size in request_ranges:

--- a/tests/test_1654_source_sink_misc.py
+++ b/tests/test_1654_source_sink_misc.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import os
 import time
 
-import numpy
 import pytest
 
 import uproot
@@ -16,40 +15,6 @@ import uproot.source.chunk
 import uproot.source.cursor
 import uproot.source.futures
 from uproot.source.coalesce import CoalesceConfig, RangeRequest, _coalesce
-
-
-class _StubSource:
-    file_path = "stub://file"
-
-
-def _make_chunk(data: bytes) -> uproot.source.chunk.Chunk:
-    raw = numpy.frombuffer(data, dtype=uproot.source.chunk.Chunk._dtype)
-    future = uproot.source.futures.TrivialFuture(raw)
-    return uproot.source.chunk.Chunk(_StubSource(), 0, len(data), future)
-
-
-def test_classname_no_terminator_raises_oserror():
-    # No NUL byte anywhere: must raise OSError (not IndexError/AttributeError)
-    chunk = _make_chunk(b"abcdef")
-    cursor = uproot.source.cursor.Cursor(0)
-    with pytest.raises(OSError, match="no terminator"):
-        cursor.classname(chunk, {})
-
-
-def test_classname_terminator_at_last_byte():
-    # Terminator at the final position previously triggered an IndexError
-    chunk = _make_chunk(b"abc\x00")
-    cursor = uproot.source.cursor.Cursor(0)
-    assert cursor.classname(chunk, {}) == "abc"
-    assert cursor.index == 4
-
-
-def test_classname_reads_string_and_moves():
-    chunk = _make_chunk(b"hello\x00world\x00")
-    cursor = uproot.source.cursor.Cursor(0)
-    assert cursor.classname(chunk, {}) == "hello"
-    assert cursor.index == 6
-    assert cursor.classname(chunk, {}) == "world"
 
 
 def test_future_result_timeout_raises():
@@ -93,18 +58,3 @@ def test_filesink_close_is_permanent(tmp_path):
         sink.tell()
     with pytest.raises(OSError, match="closed"):
         sink.read(0, 1)
-
-
-def test_coalesce_batches_at_max_request_ranges():
-    # Distinct, well-separated ranges so each is its own cluster.
-    config = CoalesceConfig(
-        max_range_gap=0,
-        max_request_ranges=4,
-        max_request_bytes=10 * 1024 * 1024,
-        min_first_request_bytes=10 * 1024 * 1024,
-    )
-    ranges = [(10 * i, 10 * i + 1) for i in range(8)]
-    all_requests = [RangeRequest(start, stop, None) for start, stop in ranges]
-    batches = list(_coalesce(all_requests, config))
-    # 8 clusters with max 4 per request -> exactly 2 full batches
-    assert [len(batch.clusters) for batch in batches] == [4, 4]

--- a/tests/test_1654_source_sink_misc.py
+++ b/tests/test_1654_source_sink_misc.py
@@ -1,0 +1,110 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""Regression tests for PR #1654: source/sink error paths, leaks, and cleanups."""
+
+from __future__ import annotations
+
+import os
+import time
+
+import numpy
+import pytest
+
+import uproot
+import uproot.sink.file
+import uproot.source.chunk
+import uproot.source.cursor
+import uproot.source.futures
+from uproot.source.coalesce import CoalesceConfig, RangeRequest, _coalesce
+
+
+class _StubSource:
+    file_path = "stub://file"
+
+
+def _make_chunk(data: bytes) -> uproot.source.chunk.Chunk:
+    raw = numpy.frombuffer(data, dtype=uproot.source.chunk.Chunk._dtype)
+    future = uproot.source.futures.TrivialFuture(raw)
+    return uproot.source.chunk.Chunk(_StubSource(), 0, len(data), future)
+
+
+def test_classname_no_terminator_raises_oserror():
+    # No NUL byte anywhere: must raise OSError (not IndexError/AttributeError)
+    chunk = _make_chunk(b"abcdef")
+    cursor = uproot.source.cursor.Cursor(0)
+    with pytest.raises(OSError, match="no terminator"):
+        cursor.classname(chunk, {})
+
+
+def test_classname_terminator_at_last_byte():
+    # Terminator at the final position previously triggered an IndexError
+    chunk = _make_chunk(b"abc\x00")
+    cursor = uproot.source.cursor.Cursor(0)
+    assert cursor.classname(chunk, {}) == "abc"
+    assert cursor.index == 4
+
+
+def test_classname_reads_string_and_moves():
+    chunk = _make_chunk(b"hello\x00world\x00")
+    cursor = uproot.source.cursor.Cursor(0)
+    assert cursor.classname(chunk, {}) == "hello"
+    assert cursor.index == 6
+    assert cursor.classname(chunk, {}) == "world"
+
+
+def test_future_result_timeout_raises():
+    # A task that never completes: result(timeout=...) must raise TimeoutError
+    future = uproot.source.futures.Future(lambda: None, ())
+    start = time.monotonic()
+    with pytest.raises(TimeoutError):
+        future.result(timeout=0.05)
+    assert time.monotonic() - start < 5.0
+
+
+def test_future_result_reraises_exception():
+    def boom():
+        raise ValueError("kaboom")
+
+    future = uproot.source.futures.Future(boom, ())
+    future._run()
+    with pytest.raises(ValueError, match="kaboom"):
+        future.result()
+
+
+def test_threadpool_shutdown_joins_workers():
+    executor = uproot.source.futures.ThreadPoolExecutor(max_workers=3)
+    workers = list(executor.workers)
+    executor.shutdown()
+    for worker in workers:
+        assert not worker.is_alive()
+
+
+def test_filesink_close_is_permanent(tmp_path):
+    path = os.path.join(tmp_path, "sink.bin")
+    sink = uproot.sink.file.FileSink(path)
+    assert sink.closed is False  # not opened yet, but not closed either
+    sink.write(0, b"hello")
+    sink.close()
+    assert sink.closed is True
+    # After close, operations must raise instead of silently reopening
+    with pytest.raises(OSError, match="closed"):
+        sink.write(0, b"world")
+    with pytest.raises(OSError, match="closed"):
+        sink.tell()
+    with pytest.raises(OSError, match="closed"):
+        sink.read(0, 1)
+
+
+def test_coalesce_batches_at_max_request_ranges():
+    # Distinct, well-separated ranges so each is its own cluster.
+    config = CoalesceConfig(
+        max_range_gap=0,
+        max_request_ranges=4,
+        max_request_bytes=10 * 1024 * 1024,
+        min_first_request_bytes=10 * 1024 * 1024,
+    )
+    ranges = [(10 * i, 10 * i + 1) for i in range(8)]
+    all_requests = [RangeRequest(start, stop, None) for start, stop in ranges]
+    batches = list(_coalesce(all_requests, config))
+    # 8 clusters with max 4 per request -> exactly 2 full batches
+    assert [len(batch.clusters) for batch in batches] == [4, 4]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1646.

This cleans up several verified bugs and hot-path inefficiencies in the source/sink layer.

### Bug fixes
- **`Cursor.classname` / null-terminated string scan** (`source/cursor.py`): the loop guarded with `local_stop > len(remainder)` read `remainder[local_stop]` at `local_stop == len(remainder)`, raising `IndexError` before the intended `OSError`; and the error message referenced `self._start/_stop/_source`, which don't exist on `Cursor` (they're `Chunk` attributes), raising `AttributeError`. Now scans the chunk's numpy buffer with `remainder.tobytes().find(0)` and reports `chunk.start/stop/source.file_path`.
- **`Future.result(timeout=...)`** (`source/futures.py`): silently returned `None` when `Event.wait()` timed out; now raises `TimeoutError`.
- **`FSSpecSource.chunks`** (`source/fsspec.py`): `if not self._fs._cached` is always `False` (fsspec sets `_cached = True` on every instantiated filesystem as a reentrancy flag), so async filesystems (http/s3/gs) always took the `asyncio.to_thread` slow path instead of the native `_cat_ranges` fast path added in #1506. Replaced with `isinstance(self._fs, fsspec.implementations.cached.CachingFileSystem)`, which also covers `SimpleCacheFileSystem`/`WholeFileCacheFileSystem`. Also moved coroutine construction onto the path that awaits it so Pyodide no longer emits an un-awaited-coroutine warning.
- **`_coalesce`** (`source/coalesce.py`): off-by-one (`len(clusters) + 1 >= max_request_ranges`) flushed at 1023 clusters so `max_request_ranges=1024` was never reached.
- **`FileSink.close()`** (`sink/file.py`): not permanent — `_ensure()` silently reopened fsspec-backed sinks after close. Added a `_closed` flag; `_ensure()` now raises `OSError` and `closed` reports `_closed` (False before the first lazy open).
- **`MemmapSource.__getstate__`** (`source/file.py`): kept `_fallback` in the pickled state; on unpickle the fallback's threads were revived and then leaked when `_open()` overwrote `_fallback`. Now dropped from state and recreated by `_open()`.
- **`CuFileSource.pread`** (`source/cufile_interface.py`): `size` defaulted to `None`, which would `TypeError` on `_num_requested_bytes += size`; made it required (all callers pass it).

### Cleanups
- `futures.py`: store exception objects instead of `sys.exc_info()` tuples (and re-raise directly); replace the `shutdown()` busy-wait — which flooded the unbounded queue with a `None` per alive worker every 1 ms — with exactly one `None` per worker followed by `join()`; simplify the dead pre-3.4 `cpu_count` fallback; drop stale Python-2 docstrings. Adjusted the `_set_excinfo` callers in `http.py`/`xrootd.py` to match.
- `chunk.py`: inline the range check in the hot `Chunk.get` path instead of going through `__contains__` (two `isinstance` checks per call).
- Added missing BSD license headers to `coalesce.py` and `cufile_interface.py`.
- Fixed invalid `list[(int, int)]` annotations to `list[tuple[int, int]]` and dropped a pointless `enumerate` in `xrootd.py`.

Existing source/sink/fsspec/coalesce/pickle tests pass.
