### PR TITLE
fix: entry-range arithmetic in iterate/concatenate and basket selection

### DIFF
--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -400,6 +400,7 @@ def concatenate(
                 arrays = library.global_index(arrays, global_start)
             except uproot.exceptions.KeyInFileError:
                 if allow_missing:
+                    global_start = global_stop
                     continue
                 else:
                     raise
@@ -1021,7 +1022,7 @@ class HasFields(Mapping):
                 filter_typename=filter_typename,
                 filter_field=filter_field,
                 entry_start=start,
-                entry_stop=start + step_size,
+                entry_stop=min(start + step_size, entry_stop),
                 library=library,
                 backend=backend,
                 interpreter=interpreter,

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -430,6 +430,7 @@ def concatenate(
                 arrays = library.global_index(arrays, global_start)
             except uproot.exceptions.KeyInFileError:
                 if allow_missing:
+                    global_start = global_stop
                     continue
                 else:
                     raise
@@ -2777,7 +2778,9 @@ in file {self._file.file_path}"""
         out = []
         start = entry_offsets[0]
         for basket_num, stop in enumerate(entry_offsets[1:]):
-            if entry_start < stop and start <= entry_stop:
+            if entry_start < stop and (
+                start < entry_stop or entry_start == entry_stop == start
+            ):
                 if 0 <= basket_num < self._num_normal_baskets:
                     byte_start = self.member("fBasketSeek")[basket_num]
                     byte_stop = byte_start + self.basket_compressed_bytes(basket_num)
@@ -3566,7 +3569,9 @@ def _hasbranches_num_entries_for(
             entry_offsets = branch.entry_offsets
             start = entry_offsets[0]
             for basket_num, stop in enumerate(entry_offsets[1:]):
-                if entry_start < stop and start <= entry_stop:
+                if entry_start < stop and (
+                    start < entry_stop or entry_start == entry_stop == start
+                ):
                     total_bytes += branch.basket_uncompressed_bytes(basket_num)
                 start = stop
 

--- a/src/uproot/interpretation/jagged.py
+++ b/src/uproot/interpretation/jagged.py
@@ -291,7 +291,7 @@ class AsJagged(uproot.interpretation.Interpretation):
                     before += off[local_stop] - off[local_start]
                     contents.append(cnt[off[local_start] : off[local_stop]])
 
-                elif start <= entry_stop <= stop:
+                elif start < entry_stop <= stop:
                     local_start = 0
                     local_stop = entry_stop - start
                     off, cnt = basket_offsets[basket_num], basket_content[basket_num]
@@ -301,7 +301,7 @@ class AsJagged(uproot.interpretation.Interpretation):
                     before += off[local_stop] - off[local_start]
                     contents.append(cnt[off[local_start] : off[local_stop]])
 
-                elif entry_start < stop and start <= entry_stop:
+                elif entry_start < stop and start < entry_stop:
                     off, cnt = basket_offsets[basket_num], basket_content[basket_num]
                     offsets[start - entry_start : stop - entry_start + 1] = (
                         before - off[0] + off

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -96,13 +96,13 @@ class Numerical(uproot.interpretation.Interpretation):
                     basket_array = basket_arrays[basket_num]
                     output[: stop - entry_start] = basket_array[local_start:local_stop]
 
-                elif start <= entry_stop <= stop:
+                elif start < entry_stop <= stop:
                     local_start = 0
                     local_stop = entry_stop - start
                     basket_array = basket_arrays[basket_num]
                     output[start - entry_start :] = basket_array[local_start:local_stop]
 
-                elif entry_start < stop and start <= entry_stop:
+                elif entry_start < stop and start < entry_stop:
                     basket_array = basket_arrays[basket_num]
                     output[start - entry_start : stop - entry_start] = basket_array
 

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -480,12 +480,12 @@ input stream
                 local_stop = stop - start
                 to_append = basket_arrays[basket_num][local_start:local_stop]
 
-            elif start <= entry_stop <= stop:
+            elif start < entry_stop <= stop:
                 local_start = 0
                 local_stop = entry_stop - start
                 to_append = basket_arrays[basket_num][local_start:local_stop]
 
-            elif entry_start < stop and start <= entry_stop:
+            elif entry_start < stop and start < entry_stop:
                 to_append = basket_arrays[basket_num]
 
             if to_append is not None and has_any_awkward_types:

--- a/src/uproot/interpretation/strings.py
+++ b/src/uproot/interpretation/strings.py
@@ -423,7 +423,7 @@ class AsStrings(uproot.interpretation.Interpretation):
                         before += off[local_stop] - off[local_start]
                         contents.append(cnt[off[local_start] : off[local_stop]])
 
-                    elif start <= entry_stop <= stop:
+                    elif start < entry_stop <= stop:
                         local_start = 0
                         local_stop = entry_stop - start
                         off, cnt = (
@@ -438,7 +438,7 @@ class AsStrings(uproot.interpretation.Interpretation):
                         before += off[local_stop] - off[local_start]
                         contents.append(cnt[off[local_start] : off[local_stop]])
 
-                    elif entry_start < stop and start <= entry_stop:
+                    elif entry_start < stop and start < entry_stop:
                         off, cnt = (
                             basket_offsets[basket_num],
                             basket_content[basket_num],

--- a/tests/test_1656_entry_range_arithmetic.py
+++ b/tests/test_1656_entry_range_arithmetic.py
@@ -12,9 +12,7 @@ def _write_multi_basket_tree(path, num_baskets=3, basket_size=10):
     with uproot.recreate(path) as f:
         f.mktree("t", {"x": "int64"})
         for i in range(num_baskets):
-            f["t"].extend(
-                {"x": numpy.arange(i * basket_size, (i + 1) * basket_size)}
-            )
+            f["t"].extend({"x": numpy.arange(i * basket_size, (i + 1) * basket_size)})
 
 
 def test_basket_selection_no_extra_basket_on_boundary(tmp_path):
@@ -64,9 +62,7 @@ def test_basket_boundary_reads_are_correct(tmp_path):
 
         # empty ranges (including on boundaries) yield empty arrays
         for start, stop in [(0, 0), (10, 10), (15, 15), (30, 30)]:
-            assert (
-                branch.array(entry_start=start, entry_stop=stop).tolist() == []
-            )
+            assert branch.array(entry_start=start, entry_stop=stop).tolist() == []
 
 
 def test_basket_boundary_jagged_and_strings(tmp_path):

--- a/tests/test_1656_entry_range_arithmetic.py
+++ b/tests/test_1656_entry_range_arithmetic.py
@@ -129,7 +129,7 @@ def test_rntuple_iterate_clamps_entry_stop(tmp_path):
     path = str(tmp_path / "nt.root")
     with uproot.recreate(path) as f:
         f.mkrntuple("nt", {"x": numpy.dtype("int64")})
-        f["nt"].extend({"x": numpy.arange(50000)})
+        f["nt"].extend({"x": numpy.arange(50000, dtype=numpy.int64)})
 
     with uproot.open(path)["nt"] as nt:
         total = 0

--- a/tests/test_1656_entry_range_arithmetic.py
+++ b/tests/test_1656_entry_range_arithmetic.py
@@ -1,0 +1,156 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import numpy
+import pytest
+
+import uproot
+
+awkward = pytest.importorskip("awkward")
+
+
+def _write_multi_basket_tree(path, num_baskets=3, basket_size=10):
+    with uproot.recreate(path) as f:
+        f.mktree("t", {"x": "int64"})
+        for i in range(num_baskets):
+            f["t"].extend(
+                {"x": numpy.arange(i * basket_size, (i + 1) * basket_size)}
+            )
+
+
+def test_basket_selection_no_extra_basket_on_boundary(tmp_path):
+    """
+    When ``entry_stop`` lands exactly on a basket boundary, the basket
+    collector must not select a trailing basket that contributes zero
+    entries.
+    """
+    path = str(tmp_path / "multi.root")
+    _write_multi_basket_tree(path)
+
+    with uproot.open(path) as f:
+        branch = f["t"]["x"]
+        assert branch.entry_offsets == [0, 10, 20, 30]
+
+        # entry_stop on a boundary must not pull in the next basket
+        assert [n for n, _ in branch.entries_to_ranges_or_baskets(0, 10)] == [0]
+        assert [n for n, _ in branch.entries_to_ranges_or_baskets(0, 20)] == [0, 1]
+        assert [n for n, _ in branch.entries_to_ranges_or_baskets(10, 20)] == [1]
+        assert [n for n, _ in branch.entries_to_ranges_or_baskets(0, 30)] == [
+            0,
+            1,
+            2,
+        ]
+        # non-boundary ranges still touch the right baskets
+        assert [n for n, _ in branch.entries_to_ranges_or_baskets(5, 20)] == [0, 1]
+        assert [n for n, _ in branch.entries_to_ranges_or_baskets(7, 23)] == [
+            0,
+            1,
+            2,
+        ]
+
+
+def test_basket_boundary_reads_are_correct(tmp_path):
+    """
+    Results must be correct (and unchanged for non-boundary ranges) after the
+    basket-selection fix.
+    """
+    path = str(tmp_path / "multi.root")
+    _write_multi_basket_tree(path)
+
+    with uproot.open(path) as f:
+        branch = f["t"]["x"]
+        for start, stop in [(0, 10), (0, 15), (5, 20), (10, 20), (0, 30), (7, 23)]:
+            result = branch.array(entry_start=start, entry_stop=stop).tolist()
+            assert result == list(range(start, stop))
+
+        # empty ranges (including on boundaries) yield empty arrays
+        for start, stop in [(0, 0), (10, 10), (15, 15), (30, 30)]:
+            assert (
+                branch.array(entry_start=start, entry_stop=stop).tolist() == []
+            )
+
+
+def test_basket_boundary_jagged_and_strings(tmp_path):
+    """
+    Jagged and string interpretations must also handle exact boundaries.
+    """
+    path = str(tmp_path / "jag.root")
+    with uproot.recreate(path) as f:
+        f.mktree("t", {"j": "var * int64", "s": "string"})
+        for i in range(3):
+            f["t"].extend(
+                {
+                    "j": awkward.Array(
+                        [[i * 10 + k] * ((k % 3) + 1) for k in range(10)]
+                    ),
+                    "s": [f"str{i * 10 + k}" for k in range(10)],
+                }
+            )
+
+    with uproot.open(path) as f:
+        jagged = f["t"]["j"]
+        strings = f["t"]["s"]
+        for start, stop in [(0, 10), (5, 20), (10, 20), (0, 30), (7, 23)]:
+            assert len(jagged.array(entry_start=start, entry_stop=stop)) == (
+                stop - start
+            )
+            result = strings.array(entry_start=start, entry_stop=stop).tolist()
+            assert result == [f"str{k}" for k in range(start, stop)]
+
+
+def test_concatenate_allow_missing_keeps_offsets(tmp_path):
+    """
+    ``concatenate(..., allow_missing=True)`` must keep the global entry
+    offsets aligned when a file is skipped because of a missing branch.
+    """
+    files = []
+    for i in range(3):
+        path = str(tmp_path / f"file{i}.root")
+        with uproot.recreate(path) as f:
+            if i == 1:
+                f.mktree("t", {"zzz": "int64"})
+                f["t"].extend({"zzz": numpy.arange(10)})
+            else:
+                f.mktree("t", {"x": "int64"})
+                f["t"].extend({"x": numpy.arange(i * 10, (i + 1) * 10)})
+        files.append(path + ":t")
+
+    arrays = uproot.concatenate(
+        files,
+        expressions=["x"],
+        entry_start=5,
+        entry_stop=25,
+        allow_missing=True,
+    )
+    # file0[5:10] = 5..9 and file2[20:25] = 20..24; file1 is skipped
+    assert arrays["x"].tolist() == [5, 6, 7, 8, 9, 20, 21, 22, 23, 24]
+
+
+def test_rntuple_iterate_clamps_entry_stop(tmp_path):
+    """
+    ``RNTuple.iterate`` must clamp the per-step ``entry_stop`` to the
+    user-requested ``entry_stop``.
+    """
+    path = str(tmp_path / "nt.root")
+    with uproot.recreate(path) as f:
+        f.mkrntuple("nt", {"x": numpy.dtype("int64")})
+        f["nt"].extend({"x": numpy.arange(50000)})
+
+    with uproot.open(path)["nt"] as nt:
+        total = 0
+        ranges = []
+        for arrays, report in nt.iterate(
+            step_size=30000, entry_stop=40000, report=True
+        ):
+            total += len(arrays)
+            ranges.append((report.start, report.stop))
+        assert total == 40000
+        assert ranges == [(0, 30000), (30000, 40000)]
+
+        # entry_start together with entry_stop must also be respected
+        total = sum(
+            len(arrays)
+            for arrays in nt.iterate(
+                step_size=15000, entry_start=10000, entry_stop=40000
+            )
+        )
+        assert total == 30000


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR fixes three coupled entry-range arithmetic bugs in `iterate`, `concatenate`, and basket selection.

## 1. Off-by-one extra basket on exact `entry_stop` boundaries

When `entry_stop` landed exactly on a basket boundary, the basket collector read, decompressed, and interpreted one extra basket contributing zero entries.

Reproducer (3 baskets of 10 entries, offsets `[0,10,20,30]`):
```python
b.entries_to_ranges_or_baskets(0, 10)  # selected baskets [0, 1], should be [0]
```

The condition `start <= entry_stop` in `entries_to_ranges_or_baskets` and `_hasbranches_num_entries_for` (`src/uproot/behaviors/TBranch.py`) selected a basket whose `start == entry_stop`. The matching per-basket trim loops in the interpretations (`numerical.py`, `jagged.py`, `strings.py`, `objects.py`) had the same `start <= entry_stop <= stop` / `start <= entry_stop` boundary conditions.

Because the interpretation expects exactly the baskets the collector supplied, both sides are fixed together (`start < entry_stop`), and the degenerate empty-range case (`entry_start == entry_stop`) is handled explicitly so empty reads still work. `custom.py` uses a `numpy.where`-based selection that does not have this off-by-one, so it was left unchanged.

After the fix, ranges are minimal and results are byte-identical for non-boundary ranges.

## 2. `concatenate(..., allow_missing=True)` shifted offsets after a skipped file

When `hasbranches.arrays` raised `KeyInFileError` (a requested branch missing from one file) and the loop `continue`d, it skipped advancing `global_start = global_stop`, so every subsequent file was read at offsets shifted by the skipped file's entry count.

Reproducer (3 files x 10 entries, middle file missing branch `x`, `entry_start=5`, `entry_stop=25`):
- Before: 15 entries returned (values 5-9, 20-29, including out-of-range 25-29)
- After: 10 entries (values 5-9, 20-24), correct

Fixed by advancing `global_start = global_stop` in the `allow_missing` continue path, in both `TBranch.concatenate` and `RNTuple.concatenate`.

## 3. `RNTuple.HasFields.iterate` did not clamp per-step `entry_stop`

`iterate` passed `entry_stop=start + step_size` per step without clamping to the user's `entry_stop` (only clamped to `num_entries` inside `arrays()`).

Reproducer (50000-entry RNTuple):
```python
nt.iterate(step_size=30000, entry_stop=40000)  # yielded 50000 entries, should be 40000
```

Fixed with `entry_stop=min(start + step_size, entry_stop)`. With `report=True` the ranges now come out as `[(0, 30000), (30000, 40000)]`.

## Testing

- `prek -a --quiet`: clean
- Existing suites pass: `tests/test_0034*`, `tests/test_0017*`, `test_0016_interpretations`, `test_0043_iterate_function`, `test_0044_concatenate_function`, `test_0067_common_entry_offsets`, `test_0194_fix_lost_cuts_in_iterate`, `test_0335_empty_ttree_division_by_zero`, `test_1573_out_of_bounds_slicing`, `test_1630_rntuple_iterate_report`, `test_1406_improved_rntuple_methods`, `test_1250_rntuple_improvements`, plus a wide keyword sweep (`iterate/concatenate/basket/interpret/string/jagged/entry`): all pass.

Regression tests will be added in a follow-up commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Part of #1646.
