### PR TITLE
fix: core model/streamer/deserialization bugs and hot-path performance

### DIFF
--- a/src/uproot/deserialization.py
+++ b/src/uproot/deserialization.py
@@ -25,6 +25,13 @@ scope = {
 
 np_uint8 = numpy.dtype("u1")
 
+# Plain-int copies of these constants, used in the hot deserialization path to
+# avoid creating numpy scalars and doing numpy bitwise ops on every object read.
+_kByteCountMask = int(uproot.const.kByteCountMask)
+_kStreamedMemberWise = int(uproot.const.kStreamedMemberWise)
+_kClassMask = int(uproot.const.kClassMask)
+_kNewClassTag = int(uproot.const.kNewClassTag)
+
 
 def _actually_compile(class_code, new_scope):
     exec(compile(class_code, "<dynamic>", "exec"), new_scope)
@@ -123,16 +130,15 @@ def numbytes_version(chunk, cursor, context, move=True):
       number; False otherwise.
     """
     num_bytes, version = cursor.fields(chunk, _numbytes_version_1, context, move=False)
-    num_bytes = numpy.int64(num_bytes)
 
-    if num_bytes & uproot.const.kByteCountMask:
+    if num_bytes & _kByteCountMask:
         # Note this extra 4 bytes: the num_bytes field doesn't count itself,
         # but we count the Model.start_cursor position from the point just
         # before these two fields (since num_bytes might not exist, it's a more
         # stable point than after num_bytes).
         #                                                           |
         #                                                           V
-        num_bytes = int(num_bytes & ~uproot.const.kByteCountMask) + 4
+        num_bytes = (num_bytes & ~_kByteCountMask) + 4
         if move:
             cursor.skip(_numbytes_version_1.size)
 
@@ -140,9 +146,9 @@ def numbytes_version(chunk, cursor, context, move=True):
         num_bytes = None
         version = cursor.field(chunk, _numbytes_version_2, context, move=move)
 
-    is_memberwise = version & uproot.const.kStreamedMemberWise
+    is_memberwise = bool(version & _kStreamedMemberWise)
     if is_memberwise:
-        version = version & ~uproot.const.kStreamedMemberWise
+        version = version & ~_kStreamedMemberWise
 
     return num_bytes, version, is_memberwise
 
@@ -222,9 +228,9 @@ def read_object_any(chunk, cursor, context, file, selffile, parent, as_class=Non
     # https://github.com/root-project/root/blob/c4aa801d24d0b1eeb6c1623fd18160ef2397ee54/io/io/src/TBufferFile.cxx#L2404
 
     beg = cursor.displacement()
-    bcnt = numpy.int64(cursor.field(chunk, _read_object_any_format1, context))
+    bcnt = cursor.field(chunk, _read_object_any_format1, context)
 
-    if (bcnt & uproot.const.kByteCountMask) == 0 or (bcnt == uproot.const.kNewClassTag):
+    if (bcnt & _kByteCountMask) == 0 or (bcnt == _kNewClassTag):
         vers = 0
         start = 0
         tag = bcnt
@@ -232,10 +238,9 @@ def read_object_any(chunk, cursor, context, file, selffile, parent, as_class=Non
     else:
         vers = 1
         start = cursor.displacement()
-        tag = numpy.int64(cursor.field(chunk, _read_object_any_format1, context))
-        bcnt = int(bcnt)
+        tag = cursor.field(chunk, _read_object_any_format1, context)
 
-    if tag & uproot.const.kClassMask == 0:
+    if tag & _kClassMask == 0:
         # reference object
 
         if tag == 0:
@@ -245,15 +250,15 @@ def read_object_any(chunk, cursor, context, file, selffile, parent, as_class=Non
             return parent  # return parent
 
         elif tag not in cursor.refs:
-            # copied from numbytes_version
-            if bcnt & uproot.const.kByteCountMask:
-                # Note this extra 4 bytes: the num_bytes field doesn't count itself,
-                # but we count the Model.start_cursor position from the point just
-                # before these two fields (since num_bytes might not exist, it's a more
-                # stable point than after num_bytes).
-                #                                                 |
-                #                                                 V
-                bcnt = int(bcnt & ~uproot.const.kByteCountMask) + 4
+            # Skip past this unresolved forward reference, matching ROOT's
+            # TBufferFile::CheckByteCount, which positions the buffer at
+            # startpos + bcnt + sizeof(UInt_t). Here ``beg`` is the position
+            # before the byte-count field (ROOT's startpos) and the trailing
+            # ``+ 4`` is sizeof(UInt_t); the stripped ``bcnt`` does not get an
+            # extra 4 (unlike numbytes_version, which measures from a different
+            # reference point).
+            if bcnt & _kByteCountMask:
+                bcnt = bcnt & ~_kByteCountMask
 
             # jump past this object
             cursor.move_to(cursor.origin + beg + bcnt + 4)
@@ -262,7 +267,7 @@ def read_object_any(chunk, cursor, context, file, selffile, parent, as_class=Non
         else:
             return cursor.refs[int(tag)]  # return object
 
-    elif tag == uproot.const.kNewClassTag:
+    elif tag == _kNewClassTag:
         # new class and object
 
         classname = cursor.classname(chunk, context)
@@ -289,7 +294,7 @@ def read_object_any(chunk, cursor, context, file, selffile, parent, as_class=Non
     else:
         # reference class, new object
 
-        ref = int(tag & ~uproot.const.kClassMask)
+        ref = tag & ~_kClassMask
 
         if as_class is None:
             if ref not in cursor.refs:

--- a/src/uproot/model.py
+++ b/src/uproot/model.py
@@ -19,6 +19,7 @@ version.
 
 from __future__ import annotations
 
+import functools
 import re
 import sys
 import threading
@@ -171,6 +172,7 @@ def classname_regularize(classname):
     return classname
 
 
+@functools.lru_cache(maxsize=1024)
 def classname_decode(encoded_classname):
     """
     Converts a Python (encoded) classname, such as ``Model_Some_3a3a_Thing``
@@ -277,15 +279,16 @@ def class_named(classname, version=None, custom_classes=None):
     """
     if custom_classes is None:
         classes = uproot.classes
-        where = "the 'custom_classes' dict"
-    else:
         where = "uproot.classes"
+    else:
+        classes = custom_classes
+        where = "the 'custom_classes' dict"
 
     cls = classes.get(classname)
     if cls is None:
         raise ValueError(f"no class named {classname} in {where}")
 
-    if version is not None and isinstance(cls, DispatchByVersion):
+    if version is not None and issubclass(cls, DispatchByVersion):
         versioned_cls = cls.class_of_version(version)
         if versioned_cls is not None:
             return versioned_cls
@@ -307,7 +310,7 @@ def has_class_named(classname, version=None, custom_classes=None):
     if cls is None:
         return False
 
-    if version is not None and isinstance(cls, DispatchByVersion):
+    if version is not None and issubclass(cls, DispatchByVersion):
         return cls.has_version(version)
     else:
         return True
@@ -1008,7 +1011,7 @@ class Model:
             cls = type(self)
         else:
             unversioned = uproot.classes.get(self.classname)
-            if issubclass(unversioned, DispatchByVersion):
+            if unversioned is not None and issubclass(unversioned, DispatchByVersion):
                 for versioned_cls in unversioned.known_versions.values():
                     if versioned_cls.writable:
                         cls = versioned_cls
@@ -1342,21 +1345,10 @@ class DispatchByVersion:
             forth_obj.add_node(forth_stash)
             forth_obj.push_active_node(forth_stash)
 
-        if versioned_cls is not None:
-            pass
-
-        elif version is not None:
+        # numbytes_version always returns an integer version, so if there is no
+        # known versioned class for it, one is generated for that version.
+        if versioned_cls is None:
             versioned_cls = cls.new_class(file, version)
-
-        elif context.get("in_TBranch", False):
-            versioned_cls = cls.new_class(file, "max")
-
-        else:
-            raise ValueError(
-                f"""Unknown version {version} for class {classname_decode(cls.__name__)[0]} that cannot be skipped """
-                """because its number of bytes is unknown.
-"""
-            )
 
         # versioned_cls.read starts with numbytes_version again because move=False (above)
         temp_var = cls.postprocess(

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -646,12 +646,15 @@ in file {file_path}""")
         :ref:`uproot.reading.ReadOnlyFile.object_cache` would still be
         accessible.
         """
-        if hasattr(self, "_source") and hasattr(self._source, "close"):
-            self._source.close()
-        if hasattr(self._decompression_executor, "shutdown"):
-            self._decompression_executor.shutdown()
-        if hasattr(self._interpretation_executor, "shutdown"):
-            self._interpretation_executor.shutdown()
+        source = getattr(self, "_source", None)
+        if hasattr(source, "close"):
+            source.close()
+        decompression_executor = getattr(self, "_decompression_executor", None)
+        if hasattr(decompression_executor, "shutdown"):
+            decompression_executor.shutdown()
+        interpretation_executor = getattr(self, "_interpretation_executor", None)
+        if hasattr(interpretation_executor, "shutdown"):
+            interpretation_executor.shutdown()
 
     def __del__(self):
         self.close()
@@ -678,12 +681,7 @@ in file {file_path}""")
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        if hasattr(self, "_source") and hasattr(self._source, "__exit__"):
-            self._source.__exit__(exception_type, exception_value, traceback)
-        if hasattr(self._decompression_executor, "shutdown"):
-            self._decompression_executor.shutdown()
-        if hasattr(self._interpretation_executor, "shutdown"):
-            self._interpretation_executor.shutdown()
+        self.close()
 
     @property
     def source(self):
@@ -812,12 +810,12 @@ in file {file_path}""")
             names = self.streamer_dependencies(classname, version=version)
         first = True
         for name, version in names:
-            for v, streamer in self.streamers[name].items():
-                if v == version:
-                    if not first:
-                        stream.write("\n")
-                    streamer.show(stream=stream)
-                    first = False
+            streamer = self.streamers[name].get(version)
+            if streamer is not None:
+                if not first:
+                    stream.write("\n")
+                streamer.show(stream=stream)
+                first = False
 
     @property
     def streamers(self):
@@ -1734,6 +1732,31 @@ class ReadOnlyDirectory(Mapping):
 
         Note that this does not read any data from the file.
         """
+        yield from self._iter(
+            "keys",
+            recursive=recursive,
+            cycle=cycle,
+            filter_name=filter_name,
+            filter_classname=filter_classname,
+        )
+
+    def _iter(
+        self,
+        what,
+        *,
+        recursive=True,
+        cycle=True,
+        filter_name=no_filter,
+        filter_classname=no_filter,
+    ):
+        """
+        Private generator shared by :ref:`uproot.reading.ReadOnlyDirectory.iterkeys`,
+        :ref:`uproot.reading.ReadOnlyDirectory.iteritems`, and
+        :ref:`uproot.reading.ReadOnlyDirectory.iterclassnames`. The ``what``
+        argument selects what is yielded: ``"keys"`` yields names (str),
+        ``"items"`` yields (name, object) pairs, and ``"classnames"`` yields
+        (name, classname) pairs.
+        """
         filter_name = uproot._util.regularize_filter(filter_name)
         filter_classname = uproot._util.regularize_filter(filter_classname)
         seen = set()
@@ -1743,21 +1766,34 @@ class ReadOnlyDirectory(Mapping):
             ):
                 out = key.name(cycle=cycle)
                 if out not in seen:
-                    yield out
+                    if what == "keys":
+                        yield out
+                    elif what == "items":
+                        yield out, key.get()
+                    else:
+                        yield out, key.fClassName
                 seen.add(out)
 
             if recursive and key.fClassName in ("TDirectory", "TDirectoryFile"):
-                for k1 in key.get().iterkeys(
+                for sub in key.get()._iter(
+                    what,
                     recursive=recursive,
                     cycle=cycle,
                     filter_name=no_filter,
                     filter_classname=filter_classname,
                 ):
+                    if what == "keys":
+                        k1 = sub
+                    else:
+                        k1, v = sub
                     k2 = f"{key.name(cycle=False)}/{k1}"
                     k3 = k2[: k2.index(";")] if ";" in k2 else k2
                     if filter_name is no_filter or filter_name(k3):
                         if k2 not in seen:
-                            yield k2
+                            if what == "keys":
+                                yield k2
+                            else:
+                                yield k2, v
                         seen.add(k2)
 
     def itervalues(
@@ -1816,31 +1852,13 @@ class ReadOnlyDirectory(Mapping):
         Note that this reads all objects that are selected by ``filter_name``
         and ``filter_classname``.
         """
-        filter_name = uproot._util.regularize_filter(filter_name)
-        filter_classname = uproot._util.regularize_filter(filter_classname)
-        seen = set()
-        for key in self._keys:
-            if (filter_name is no_filter or filter_name(key.fName)) and (
-                filter_classname is no_filter or filter_classname(key.fClassName)
-            ):
-                out = key.name(cycle=cycle)
-                if out not in seen:
-                    yield out, key.get()
-                seen.add(out)
-
-            if recursive and key.fClassName in ("TDirectory", "TDirectoryFile"):
-                for k1, v in key.get().iteritems(
-                    recursive=recursive,
-                    cycle=cycle,
-                    filter_name=no_filter,
-                    filter_classname=filter_classname,
-                ):
-                    k2 = f"{key.name(cycle=False)}/{k1}"
-                    k3 = k2[: k2.index(";")] if ";" in k2 else k2
-                    if filter_name is no_filter or filter_name(k3):
-                        if k2 not in seen:
-                            yield k2, v
-                        seen.add(k2)
+        yield from self._iter(
+            "items",
+            recursive=recursive,
+            cycle=cycle,
+            filter_name=filter_name,
+            filter_classname=filter_classname,
+        )
 
     def iterclassnames(
         self,
@@ -1866,31 +1884,13 @@ class ReadOnlyDirectory(Mapping):
 
         Note that this does not read any data from the file.
         """
-        filter_name = uproot._util.regularize_filter(filter_name)
-        filter_classname = uproot._util.regularize_filter(filter_classname)
-        seen = set()
-        for key in self._keys:
-            if (filter_name is no_filter or filter_name(key.fName)) and (
-                filter_classname is no_filter or filter_classname(key.fClassName)
-            ):
-                out = key.name(cycle=cycle)
-                if out not in seen:
-                    yield out, key.fClassName
-                seen.add(out)
-
-            if recursive and key.fClassName in ("TDirectory", "TDirectoryFile"):
-                for k1, v in key.get().iterclassnames(
-                    recursive=recursive,
-                    cycle=cycle,
-                    filter_name=no_filter,
-                    filter_classname=filter_classname,
-                ):
-                    k2 = f"{key.name(cycle=False)}/{k1}"
-                    k3 = k2[: k2.index(";")] if ";" in k2 else k2
-                    if filter_name is no_filter or filter_name(k3):
-                        if k2 not in seen:
-                            yield k2, v
-                        seen.add(k2)
+        yield from self._iter(
+            "classnames",
+            recursive=recursive,
+            cycle=cycle,
+            filter_name=filter_name,
+            filter_classname=filter_classname,
+        )
 
     def _ipython_key_completions_(self):
         """
@@ -2238,6 +2238,8 @@ class ReadOnlyDirectory(Mapping):
 _key_format_small = struct.Struct(">ihiIhhii")
 _key_format_big = struct.Struct(">ihiIhhqq")
 
+_string_classname = re.compile(r"(std\s*::\s*)?string\s*$")
+
 
 class ReadOnlyKey:
     """
@@ -2515,7 +2517,7 @@ class ReadOnlyKey:
             start_cursor = cursor.copy()
             context = {"breadcrumbs": (), "TKey": self}
 
-            if re.match(r"(std\s*::\s*)?string", self._fClassName):
+            if _string_classname.match(self._fClassName):
                 return cursor.string(chunk, context)
 
             cls = self._file.class_named(self._fClassName)

--- a/src/uproot/streamers.py
+++ b/src/uproot/streamers.py
@@ -16,8 +16,6 @@ import numpy
 import uproot
 import uproot._awkwardforth as af
 
-COUNT_NAMES = []
-
 _canonical_typename_patterns = [
     (re.compile(r"\bChar_t\b"), "char"),
     (re.compile(r"\bUChar_t\b"), "unsigned char"),
@@ -75,66 +73,59 @@ def _sanitize_string(s):
     )
 
 
+_ftype_to_dtype_map = {
+    uproot.const.kBool: "numpy.dtype(numpy.bool_)",
+    uproot.const.kChar: "numpy.dtype('i1')",
+    uproot.const.kUChar: "numpy.dtype('u1')",
+    uproot.const.kCharStar: "numpy.dtype('u1')",
+    uproot.const.kShort: "numpy.dtype('>i2')",
+    uproot.const.kUShort: "numpy.dtype('>u2')",
+    uproot.const.kInt: "numpy.dtype('>i4')",
+    uproot.const.kBits: "numpy.dtype('>u4')",
+    uproot.const.kUInt: "numpy.dtype('>u4')",
+    uproot.const.kCounter: "numpy.dtype('>u4')",
+    uproot.const.kLong: "numpy.dtype('>i8')",
+    uproot.const.kULong: "numpy.dtype('>u8')",
+    uproot.const.kLong64: "numpy.dtype('>i8')",
+    uproot.const.kULong64: "numpy.dtype('>u8')",
+    uproot.const.kFloat: "numpy.dtype('>f4')",
+    uproot.const.kFloat16: "numpy.dtype('>f4')",
+    uproot.const.kDouble: "numpy.dtype('>f8')",
+    uproot.const.kDouble32: "numpy.dtype('>f8')",
+}
+
+
 def _ftype_to_dtype(fType):
-    if fType == uproot.const.kBool:
-        return "numpy.dtype(numpy.bool_)"
-    elif fType == uproot.const.kChar:
-        return "numpy.dtype('i1')"
-    elif fType in (uproot.const.kUChar, uproot.const.kCharStar):
-        return "numpy.dtype('u1')"
-    elif fType == uproot.const.kShort:
-        return "numpy.dtype('>i2')"
-    elif fType == uproot.const.kUShort:
-        return "numpy.dtype('>u2')"
-    elif fType == uproot.const.kInt:
-        return "numpy.dtype('>i4')"
-    elif fType in (uproot.const.kBits, uproot.const.kUInt, uproot.const.kCounter):
-        return "numpy.dtype('>u4')"
-    elif fType == uproot.const.kLong:
-        return "numpy.dtype('>i8')"
-    elif fType == uproot.const.kULong:
-        return "numpy.dtype('>u8')"
-    elif fType == uproot.const.kLong64:
-        return "numpy.dtype('>i8')"
-    elif fType == uproot.const.kULong64:
-        return "numpy.dtype('>u8')"
-    elif fType in (uproot.const.kFloat, uproot.const.kFloat16):
-        return "numpy.dtype('>f4')"
-    elif fType in (uproot.const.kDouble, uproot.const.kDouble32):
-        return "numpy.dtype('>f8')"
-    else:
-        return None
+    return _ftype_to_dtype_map.get(fType)
+
+
+_ftype_to_struct_map = {
+    uproot.const.kBool: "?",
+    uproot.const.kChar: "b",
+    uproot.const.kUChar: "B",
+    uproot.const.kCharStar: "B",
+    uproot.const.kShort: "h",
+    uproot.const.kUShort: "H",
+    uproot.const.kInt: "i",
+    uproot.const.kBits: "I",
+    uproot.const.kUInt: "I",
+    uproot.const.kCounter: "I",
+    uproot.const.kLong: "q",
+    uproot.const.kULong: "Q",
+    uproot.const.kLong64: "q",
+    uproot.const.kULong64: "Q",
+    uproot.const.kFloat: "f",
+    uproot.const.kFloat16: "f",
+    uproot.const.kDouble: "d",
+    uproot.const.kDouble32: "d",
+}
 
 
 def _ftype_to_struct(fType):
-    if fType == uproot.const.kBool:
-        return "?"
-    elif fType == uproot.const.kChar:
-        return "b"
-    elif fType in (uproot.const.kUChar, uproot.const.kCharStar):
-        return "B"
-    elif fType == uproot.const.kShort:
-        return "h"
-    elif fType == uproot.const.kUShort:
-        return "H"
-    elif fType == uproot.const.kInt:
-        return "i"
-    elif fType in (uproot.const.kBits, uproot.const.kUInt, uproot.const.kCounter):
-        return "I"
-    elif fType == uproot.const.kLong:
-        return "q"
-    elif fType == uproot.const.kULong:
-        return "Q"
-    elif fType == uproot.const.kLong64:
-        return "q"
-    elif fType == uproot.const.kULong64:
-        return "Q"
-    elif fType in (uproot.const.kFloat, uproot.const.kFloat16):
-        return "f"
-    elif fType in (uproot.const.kDouble, uproot.const.kDouble32):
-        return "d"
-    else:
-        raise NotImplementedError(fType)
+    try:
+        return _ftype_to_struct_map[fType]
+    except KeyError:
+        raise NotImplementedError(fType) from None
 
 
 def _copy_bytes(chunk, start, stop, cursor, context):
@@ -216,9 +207,10 @@ class Model_TStreamerInfo(uproot.model.Model):
         Returns Python code as a string that, when evaluated, would be a suitable
         :doc:`uproot.model.VersionedModel` for this class and version.
         """
+        count_names = []
         for element in self.elements:  # (self is a TStreamerInfo)
             if element.has_member("fCountName"):
-                COUNT_NAMES.append(element.member("fCountName"))
+                count_names.append(element.member("fCountName"))
         read_members = [
             "    def read_members(self, chunk, cursor, context, file):",
             "        if self.is_memberwise:",
@@ -286,6 +278,7 @@ class Model_TStreamerInfo(uproot.model.Model):
                 base_names_versions,
                 member_names,
                 class_flags,
+                count_names,
             )
 
         read_members.extend(
@@ -635,6 +628,7 @@ class Model_TStreamerArtificial(Model_TStreamerElement):
         base_names_versions,
         member_names,
         class_flags,
+        count_names,
     ):
         read_member_n.append(f"        if member_index == {i}:")
 
@@ -706,6 +700,7 @@ class Model_TStreamerBase(Model_TStreamerElement):
         base_names_versions,
         member_names,
         class_flags,
+        count_names,
     ):
         read_member_n.append(f"        if member_index == {i}:")
 
@@ -764,6 +759,7 @@ class Model_TStreamerBase(Model_TStreamerElement):
         streamer_versions = streamers.get(self.name)
         if streamer_versions is not None:
             base_version = self.base_version
+            streamer = None
             if len(streamer_versions) == 0:
                 pass
             elif base_version == "max" or base_version not in streamer_versions:
@@ -813,6 +809,7 @@ class Model_TStreamerBasicPointer(Model_TStreamerElement):
         base_names_versions,
         member_names,
         class_flags,
+        count_names,
     ):
         read_member_n.append(f"        if member_index == {i}:")
 
@@ -934,6 +931,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
         base_names_versions,
         member_names,
         class_flags,
+        count_names,
     ):
         read_member_n.append(f"        if member_index == {i}:")
         if self.typename == "Double32_t":
@@ -992,7 +990,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                             "            forth_obj.add_node(nested_forth_stash)",
                         ]
                     )
-                    if fields[-1][0] in COUNT_NAMES:
+                    if fields[-1][0] in count_names:
                         read_members.extend(
                             [
                                 f'            nested_forth_stash.init_code.append(f"variable var_{_sanitize_string(fields[-1][0])}\\n")',
@@ -1010,14 +1008,14 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                 else:
                     # AwkwardForth testing E: test_0637's 01,02,05,08,09,11,12,13,15,16,29,35,39,45,46,47,49,50,56
                     read_members.append("        if forth_obj is not None:")
-                    for i in range(len(formats[-1])):
+                    for j in range(len(formats[-1])):
                         read_members.extend(
                             [
                                 "           key = key_number ; key_number += 1",
                                 '           form_key = f"node{key}-data"',
-                                f'           nested_forth_stash = af.Node(f"node{{key}}", field_name={fields[-1][i]!r}, form_details={{ "class": "NumpyArray", "primitive": "{af.struct_to_dtype_name[formats[-1][i]]}", "inner_shape": [], "parameters": {{}}, "form_key": f"node{{key}}"}})',
-                                f'           nested_forth_stash.header_code.append(f"output {{form_key}} {af.struct_to_dtype_name[formats[-1][i]]}\\n")',
-                                f'           nested_forth_stash.pre_code.append(f"stream !{formats[-1][i]}-> {{form_key}}\\n")',
+                                f'           nested_forth_stash = af.Node(f"node{{key}}", field_name={fields[-1][j]!r}, form_details={{ "class": "NumpyArray", "primitive": "{af.struct_to_dtype_name[formats[-1][j]]}", "inner_shape": [], "parameters": {{}}, "form_key": f"node{{key}}"}})',
+                                f'           nested_forth_stash.header_code.append(f"output {{form_key}} {af.struct_to_dtype_name[formats[-1][j]]}\\n")',
+                                f'           nested_forth_stash.pre_code.append(f"stream !{formats[-1][j]}-> {{form_key}}\\n")',
                                 "           forth_obj.add_node(nested_forth_stash)",
                             ]
                         )
@@ -1051,13 +1049,13 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                 ]
             )
 
-            dtypes.append(_ftype_to_dtype(self.fType))
-
             read_member_n.extend(
                 [
                     f"            self._members[{self.name!r}] = cursor.array(chunk, {self.array_length}, self._dtype{len(dtypes)}, context)",
                 ]
             )
+
+            dtypes.append(_ftype_to_dtype(self.fType))
 
         if self.array_length == 0 and self.typename not in ("Double32_t", "Float16_t"):
             strided_interpretation.append(
@@ -1208,6 +1206,7 @@ class Model_TStreamerLoop(Model_TStreamerElement):
         base_names_versions,
         member_names,
         class_flags,
+        count_names,
     ):
         # untested as of PR #629
         read_members.extend(
@@ -1311,6 +1310,7 @@ class Model_TStreamerSTL(Model_TStreamerElement):
         base_names_versions,
         member_names,
         class_flags,
+        count_names,
     ):
         read_member_n.append(f"        if member_index == {i}:")
 
@@ -1432,6 +1432,7 @@ class TStreamerPointerTypes:
         base_names_versions,
         member_names,
         class_flags,
+        count_names,
     ):
         read_member_n.append(f"        if member_index == {i}:")
 
@@ -1580,6 +1581,7 @@ class TStreamerObjectTypes:
         base_names_versions,
         member_names,
         class_flags,
+        count_names,
     ):
         read_member_n.append(f"        if member_index == {i}:")
 

--- a/tests/test_1659_core_model_streamer_fixes.py
+++ b/tests/test_1659_core_model_streamer_fixes.py
@@ -1,0 +1,120 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""
+Regression tests for the core model/streamer/deserialization fixes in PR #1659.
+"""
+
+import re
+
+import pytest
+
+import uproot
+import uproot.streamers
+
+
+def test_has_class_named_unknown_version():
+    # Previously returned True because isinstance(cls, DispatchByVersion) was
+    # always False, so the version branch was never taken.
+    assert uproot.has_class_named("TH1F") is True
+    assert uproot.has_class_named("TH1F", 999) is False
+    assert uproot.has_class_named("Does::Not::Exist") is False
+
+
+def test_class_named_known():
+    cls = uproot.model.class_named("TH1F")
+    assert cls.__name__ == "Model_TH1F"
+
+
+def test_class_named_custom_classes_assigned():
+    # Previously raised NameError because `classes` was never assigned when
+    # custom_classes was not None.
+    with pytest.raises(ValueError) as excinfo:
+        uproot.model.class_named("TH1F", custom_classes={})
+    assert "custom_classes" in str(excinfo.value)
+
+
+def test_class_named_where_message_default():
+    with pytest.raises(ValueError) as excinfo:
+        uproot.model.class_named("Does::Not::Exist")
+    assert "uproot.classes" in str(excinfo.value)
+
+
+def _make_basic_type_array_element(name, fType, array_length, typename):
+    element = uproot.streamers.Model_TStreamerBasicType.empty()
+    element._instance_version = 4
+    element._members = {
+        "fName": name,
+        "fTitle": "",
+        "fType": fType,
+        "fSize": 0,
+        "fArrayLength": array_length,
+        "fArrayDim": 1,
+        "fTypeName": typename,
+    }
+    return element
+
+
+def test_fixed_array_dtype_index_consistent():
+    # For a fixed-size-array TStreamerBasicType member, the same _dtypeN index
+    # must be referenced in both read_members and read_member_n. Previously the
+    # dtypes.append happened between the two emissions, so read_member_n used
+    # _dtype{N+1} (off-by-one).
+    element = _make_basic_type_array_element(
+        "fArray", uproot.const.kInt, 5, "int"
+    )
+
+    class _FakeStreamerInfo:
+        name = "SyntheticClass"
+
+    read_members = []
+    read_member_n = []
+    dtypes = []
+    element.class_code(
+        _FakeStreamerInfo(),  # streamerinfo (only used for messages here)
+        0,  # i
+        [element],  # elements
+        read_members,
+        read_member_n,
+        [],  # strided_interpretation
+        [],  # awkward_form
+        [],  # fields
+        [],  # formats
+        dtypes,
+        [],  # formats_memberwise
+        [],  # containers
+        [],  # base_names_versions
+        [],  # member_names
+        {},  # class_flags
+        [],  # count_names
+    )
+
+    rm = "\n".join(read_members)
+    rmn = "\n".join(read_member_n)
+
+    rm_indices = set(
+        re.findall(r"cursor\.array\(chunk, \d+, self\._dtype(\d+)", rm)
+    )
+    rmn_indices = set(
+        re.findall(r"cursor\.array\(chunk, \d+, self\._dtype(\d+)", rmn)
+    )
+
+    assert rm_indices == {"0"}
+    assert rmn_indices == {"0"}
+    # exactly one dtype was registered for this single array member
+    assert len(dtypes) == 1
+
+
+def test_count_names_not_leaked_between_class_code_calls():
+    # COUNT_NAMES used to be a module-level list shared across all class_code
+    # invocations; the symbol should no longer exist as a module global.
+    assert not hasattr(uproot.streamers, "COUNT_NAMES")
+
+
+def test_string_classname_anchored():
+    # "stringWrapper" must not be treated as std::string.
+    pattern = uproot.reading._string_classname
+    assert pattern.match("string")
+    assert pattern.match("std::string")
+    assert pattern.match("std :: string")
+    assert pattern.match("stringWrapper") is None
+    assert pattern.match("StringThing") is None

--- a/tests/test_1659_core_model_streamer_fixes.py
+++ b/tests/test_1659_core_model_streamer_fixes.py
@@ -59,9 +59,7 @@ def test_fixed_array_dtype_index_consistent():
     # must be referenced in both read_members and read_member_n. Previously the
     # dtypes.append happened between the two emissions, so read_member_n used
     # _dtype{N+1} (off-by-one).
-    element = _make_basic_type_array_element(
-        "fArray", uproot.const.kInt, 5, "int"
-    )
+    element = _make_basic_type_array_element("fArray", uproot.const.kInt, 5, "int")
 
     class _FakeStreamerInfo:
         name = "SyntheticClass"
@@ -91,12 +89,8 @@ def test_fixed_array_dtype_index_consistent():
     rm = "\n".join(read_members)
     rmn = "\n".join(read_member_n)
 
-    rm_indices = set(
-        re.findall(r"cursor\.array\(chunk, \d+, self\._dtype(\d+)", rm)
-    )
-    rmn_indices = set(
-        re.findall(r"cursor\.array\(chunk, \d+, self\._dtype(\d+)", rmn)
-    )
+    rm_indices = set(re.findall(r"cursor\.array\(chunk, \d+, self\._dtype(\d+)", rm))
+    rmn_indices = set(re.findall(r"cursor\.array\(chunk, \d+, self\._dtype(\d+)", rmn))
 
     assert rm_indices == {"0"}
     assert rmn_indices == {"0"}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1646.

Fixes several verified correctness bugs and hot-path performance issues in the core reading machinery (model, streamers, deserialization, reading).

## src/uproot/model.py
- `class_named`: three bugs fixed - (a) `classes = custom_classes` was never assigned (NameError when `custom_classes` was given), (b) the two `where` description strings were swapped between branches, (c) `isinstance(cls, DispatchByVersion)` tested a class object (always False) -> now `issubclass`.
- `has_class_named`: same `isinstance`->`issubclass` fix; `uproot.has_class_named("TH1F", 999)` now correctly returns `False` (was `True`).
- `_to_writable`: guard `unversioned is not None` before `issubclass(...)` so a missing class raises the intended `NotImplementedError` instead of `TypeError`.
- `classname_decode`: added `functools.lru_cache(maxsize=1024)` - it runs 3 regexes per call and is invoked per deserialized object via `Model.classname`.
- `DispatchByVersion.read`: `numbytes_version` always returns an integer version, so the `version is not None` branch was always taken and the `in_TBranch`/`ValueError` fallbacks were dead. Simplified to generating a versioned class whenever none is known.

## src/uproot/streamers.py
- `COUNT_NAMES`: was a module-global list that grew forever and was shared across all files/classes, leaking count names into unrelated codegen. Now collected locally per `Model_TStreamerInfo.class_code()` and threaded through the element `class_code` helpers via a new `count_names` parameter.
- `Model_TStreamerBasicType.class_code` (fixed-size-array branch): the `dtypes.append(...)` happened between the `read_members` emission (referencing `_dtypeN`) and the `read_member_n` emission, so `read_member_n` referenced `_dtype{N+1}`. Moved the append after both emissions (matches `Model_TStreamerBasicPointer`). Verified the generated `_dtypeN` indices now match between `read_members` and `read_member_n` across all streamers in a sample file.
- Renamed the forth-loop variable `i` -> `j` so it no longer shadows the `class_code` `i` parameter.
- `Model_TStreamerBase._dependencies`: initialize `streamer = None` to avoid `NameError` when `streamer_versions` is empty.
- `_ftype_to_dtype`/`_ftype_to_struct`: converted the elif chains to module-level dict lookups.

## src/uproot/deserialization.py
- Hoisted plain-int copies of `kByteCountMask`/`kStreamedMemberWise`/`kClassMask`/`kNewClassTag` and removed per-read `numpy.int64` wrapping and numpy bitwise ops in `numbytes_version` and `read_object_any` (values are < 2^32 and nonnegative).
- `read_object_any` unresolved-reference skip: the masked byte count had `+ 4` applied twice (once when stripping the mask, once in `move_to`), landing at `beg + raw + 8`. I fetched ROOT's `TBufferFile.cxx` at the commit referenced in the code comments: `CheckByteCount` positions at `fBuffer + startpos + bcnt + sizeof(UInt_t)`, with `startpos` captured in `ReadObjectAny` before the byte-count field (= uproot's `beg`) and `bcnt` stripped of the mask with no extra +4. So the correct target is `origin + beg + raw + 4`. Removed the spurious `+ 4` from the mask-stripping step.

## src/uproot/reading.py
- `ReadOnlyFile.close`/`__exit__`: use `getattr(..., None)` guards so an early `__init__` failure does not produce `AttributeError` noise from `__del__`; `__exit__` now delegates to `self.close()`.
- Anchored and hoisted the `std::string` classname regex (`...string\s*$`) so `"stringWrapper"` is no longer treated as `std::string`; compiled once at module level instead of per `ReadOnlyKey.get`.
- `show_streamers`: replaced the inner `for v, streamer ... if v == version` scan (which also shadowed `version`) with `.get(version)`.
- Factored the three near-identical `iterkeys`/`iteritems`/`iterclassnames` generators into a single private `_iter` parameterized on what to yield; public signatures and docstrings unchanged.

## Testing
- Targeted reading/streamer/forth tests pass.
- Full suite (excluding network/xrootd, which require unavailable services): 901 passed, 44 skipped (missing ROOT/XRootD/network), 0 failures.
- `prek -a` clean on touched files.

Nothing was skipped; finding 12 (the RISKY double-+4) was verified against ROOT source before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
