### PR TITLE
fix: interpretation-layer bugs (pandas NaN fallback, typename parsing, strided objects, bitset)

### DIFF
--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -1150,8 +1150,23 @@ class AsBitSet(AsVectorLike):
 
     _specialpathitem_name = "bitset"
 
+    def __init__(self, header, keys):
+        super().__init__(header, keys)
+        # ``std::bitset<N>`` is parameterized by its number of bits, which the
+        # shared base class discards (it stores a bool dtype for the items).
+        self._num_bits = keys if isinstance(keys, int) else None
+
+    @property
+    def num_bits(self):
+        """
+        The number of bits in the ``std::bitset``, or None if unknown.
+        """
+        return self._num_bits
+
     @property
     def typename(self):
+        if self._num_bits is not None:
+            return f"std::bitset<{self._num_bits}>"
         return f"std::bitset<{_content_typename(self.keys)}>"
 
     @property
@@ -1674,7 +1689,7 @@ class STLBitSet(Container, Sequence):
 
     def __str__(self, limit=85):
         def tostring(i):
-            return _tostring(self._values[i])
+            return _tostring(self._numbytes[i])
 
         return _str_with_ellipsis(tostring, len(self), "[", "]", limit)
 
@@ -1685,7 +1700,7 @@ class STLBitSet(Container, Sequence):
         return self._numbytes[where]
 
     def __len__(self):
-        return self._numbytes
+        return len(self._numbytes)
 
     def __iter__(self):
         return iter(self._numbytes)
@@ -1792,7 +1807,7 @@ class STLMap(Container, Mapping):
         return STLMap(mapping.keys(), mapping.values())
 
     def __init__(self, keys, values):
-        if KeysView is not None and isinstance(keys, KeysView):
+        if isinstance(keys, KeysView):
             keys = numpy.asarray(list(keys))
         elif isinstance(keys, types.GeneratorType):
             keys = numpy.asarray(list(keys))
@@ -1801,7 +1816,7 @@ class STLMap(Container, Mapping):
         else:
             keys = numpy.asarray(keys)
 
-        if ValuesView is not None and isinstance(values, ValuesView):
+        if isinstance(values, ValuesView):
             values = numpy.asarray(list(values))
         elif isinstance(values, types.GeneratorType):
             values = numpy.asarray(list(values))

--- a/src/uproot/interpretation/custom.py
+++ b/src/uproot/interpretation/custom.py
@@ -168,10 +168,10 @@ class AsBinary(uproot.interpretation.Interpretation):
         elif library.name == "np":
             if counts is not None:
                 assert (
-                    numpy.unique(counts[1:] - counts[:-1]).size == 1
+                    numpy.unique(counts).size <= 1
                 ), "The byte offsets must be uniform for NumPy arrays."
 
-                bytes_per_event = counts[0]
+                bytes_per_event = counts[0] if counts.size != 0 else 0
                 return data.reshape(-1, bytes_per_event)
             else:
                 fSize = branch.streamer.member("fSize")

--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -373,10 +373,11 @@ def interpretation_of(branch, context, simplify=True):
         if cls.match_branch(branch, context, simplify)
     ]
 
-    assert (
-        len(matched_custom_interpretations) <= 1
-    ), "Multiple custom interpretations matched, "
-    f"uproot cannot determine which one to use: {matched_custom_interpretations}"
+    if len(matched_custom_interpretations) > 1:
+        raise ValueError(
+            "Multiple custom interpretations matched, uproot cannot determine "
+            f"which one to use: {matched_custom_interpretations}"
+        )
 
     if len(matched_custom_interpretations) == 1:
         return matched_custom_interpretations[0](branch, context, simplify)
@@ -810,6 +811,33 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return i + 1, _parse_maybe_quote('numpy.dtype(">i8")', quote)
     elif tokens[i].group(0) == "Long64_t":
         return i + 1, _parse_maybe_quote('numpy.dtype(">i8")', quote)
+
+    elif (
+        i + 2 < len(tokens)
+        and tokens[i].group(0) == "unsigned"
+        and tokens[i + 1].group(0) == "long"
+        and _simplify_token(tokens[i + 2]) == "long*"
+    ):
+        return (
+            i + 3,
+            _parse_maybe_quote(
+                f'uproot.containers.AsArray(False, {header}, numpy.dtype(">u8"))',
+                quote,
+            ),
+        )
+    elif (
+        has2
+        and tokens[i].group(0) == "long"
+        and _simplify_token(tokens[i + 1]) == "long*"
+    ):
+        return (
+            i + 2,
+            _parse_maybe_quote(
+                f'uproot.containers.AsArray(False, {header}, numpy.dtype(">i8"))',
+                quote,
+            ),
+        )
+
     elif tokens[i].group(0) == "long":
         return i + 1, _parse_maybe_quote('numpy.dtype(">i8")', quote)
     elif tokens[i].group(0) == "ULong_t":
@@ -820,32 +848,6 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return i + 2, _parse_maybe_quote('numpy.dtype(">u8")', quote)
     elif has2 and tokens[i].group(0) == "signed" and tokens[i + 1].group(0) == "long":
         return i + 2, _parse_maybe_quote('numpy.dtype(">i8")', quote)
-
-    elif (
-        has2
-        and tokens[i].group(0) == "long"
-        and _simplify_token(tokens[i + 1]) == "long*"
-    ):
-        return (
-            i + 2,
-            _parse_maybe_quote(
-                f'uproot.containers.AsArray({header}, numpy.dtype(">i8"))',
-                quote,
-            ),
-        )
-    elif (
-        i + 2 < len(tokens)
-        and tokens[i].group(0) == "unsigned"
-        and _simplify_token(tokens[i + 1]) == "long"
-        and _simplify_token(tokens[i + 2]) == "long*"
-    ):
-        return (
-            i + 3,
-            _parse_maybe_quote(
-                f'uproot.containers.AsArray({header}, numpy.dtype(">u8"))',
-                quote,
-            ),
-        )
 
     elif _simplify_token(tokens[i]) == "Long_t*":
         return (

--- a/src/uproot/interpretation/known_forth/__init__.py
+++ b/src/uproot/interpretation/known_forth/__init__.py
@@ -39,7 +39,7 @@ def known_forth_of(model):
         try:
             typename = model.classname
         except AttributeError:
-            typename = uproot.model.classname_decode(model.__name__)
+            typename = uproot.model.classname_decode(model.__name__)[0]
 
     if typename not in KNOWN_FORTH_DICT:
         return

--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -268,7 +268,7 @@ class NumPy(Library):
 def _strided_to_awkward(awkward, path, interpretation, data):
     contents = []
     names = []
-    data = data.flatten()
+    data = data.reshape(-1)
     for name, member in interpretation.members:
         if not name.startswith("@"):
             p = name
@@ -833,7 +833,7 @@ def _process_array_for_pandas(
                     array = uproot.extras.awkward_pandas().AwkwardExtensionArray(array)
             else:
                 array = _object_to_awkward_array(awkward, form, array)
-            return array
+        return array
 
 
 class Pandas(Library):

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -319,7 +319,6 @@ class AsObjects(uproot.interpretation.Interpretation):
         )
         context["forth"].vm.stack_push(len(byte_offsets) - 1)
         context["forth"].vm.resume()
-        container = {}
         container = context["forth"].vm.outputs
         output = awkward.from_buffers(self._form, len(byte_offsets) - 1, container)
 
@@ -522,18 +521,16 @@ input stream
 
         # If *some* of the baskets are Awkward and *some* are not,
         # convert the ones that are not, individually.
-        if any(
-            uproot._util.from_module(x, "awkward") for x in basket_arrays.values()
-        ) and isinstance(
+        if has_any_awkward_types and isinstance(
             library,
             (
                 uproot.interpretation.library.Awkward,
                 uproot.interpretation.library.Pandas,
             ),
         ):
+            form = json.loads(self.awkward_form(branch.file).to_json())
             for k, v in basket_arrays.items():
                 if not uproot._util.from_module(v, "awkward"):
-                    form = json.loads(self.awkward_form(branch.file).to_json())
                     basket_arrays[k] = (
                         uproot.interpretation.library._object_to_awkward_array(
                             awkward, form, v
@@ -741,22 +738,28 @@ class AsStridedObjects(uproot.interpretation.numerical.AsDtype):
     """
 
     def __init__(self, model, members, original=None):
-        all_headers_prepended = False
-
+        # Skip the leading run of ``(None, None)`` header markers.
+        first_value_loc = 0
         for first_value_loc in range(len(members)):
             if members[first_value_loc] != (None, None):
                 break
 
-        for i in range(first_value_loc, len(members)):
-            member, _value = members[i]
-            if member is not None and not all_headers_prepended:
-                all_headers_prepended = True
-            if (member is None and all_headers_prepended) or len(members) == 1:
+        # Drop any ``(None, None)`` header markers that appear after the value
+        # members have begun (e.g. from multiple base classes), keeping the
+        # actual members.  ``all_headers_prepended`` is True when the kept
+        # members end with a value (headers prepended), and False when a
+        # trailing header marker was removed.
+        all_headers_prepended = False
+        kept_members = []
+        for member, value in members[first_value_loc:]:
+            if member is None and value is None:
                 all_headers_prepended = False
-                del members[i]
+            else:
+                all_headers_prepended = True
+                kept_members.append((member, value))
 
         self._model = model
-        self._members = members[first_value_loc:]
+        self._members = kept_members
         self._original = original
         self._all_headers_prepended = all_headers_prepended
         super().__init__(_unravel_members(self._members))
@@ -834,6 +837,111 @@ class AsStridedObjects(uproot.interpretation.numerical.AsDtype):
     def _wrap_almost_finalized(self, array):
         return StridedObjectArray(self, array)
 
+    def final_array(
+        self,
+        basket_arrays,
+        entry_start,
+        entry_stop,
+        entry_offsets,
+        library,
+        branch,
+        options,
+    ):
+        self.hook_before_final_array(
+            basket_arrays=basket_arrays,
+            entry_start=entry_start,
+            entry_stop=entry_stop,
+            entry_offsets=entry_offsets,
+            library=library,
+            branch=branch,
+        )
+
+        # The per-basket ``basket_array`` may prepend an ``@headers`` field to
+        # the dtype (see ``basket_array`` below). Derive the output dtype from
+        # the actual basket arrays rather than from a mutated ``self._to_dtype``
+        # so that the interpretation object can be safely shared across threads.
+        to_dtype = self._to_dtype
+        for basket_array in basket_arrays.values():
+            if basket_array.dtype.names is not None and "@headers" in (
+                basket_array.dtype.names
+            ):
+                to_dtype = basket_array.dtype
+                break
+
+        if entry_start >= entry_stop:
+            output = library.empty((0,), to_dtype)
+
+        else:
+            length = 0
+            start = entry_offsets[0]
+            for _, stop in enumerate(entry_offsets[1:]):
+                if start <= entry_start and entry_stop <= stop:
+                    length += entry_stop - entry_start
+                elif start <= entry_start < stop:
+                    length += stop - entry_start
+                elif start <= entry_stop <= stop:
+                    length += entry_stop - start
+                elif entry_start < stop and start <= entry_stop:
+                    length += stop - start
+                start = stop
+
+            output = library.empty((length,), to_dtype)
+
+            start = entry_offsets[0]
+            for basket_num, stop in enumerate(entry_offsets[1:]):
+                if start <= entry_start and entry_stop <= stop:
+                    local_start = entry_start - start
+                    local_stop = entry_stop - start
+                    basket_array = basket_arrays[basket_num]
+                    output[:] = basket_array[local_start:local_stop]
+
+                elif start <= entry_start < stop:
+                    local_start = entry_start - start
+                    local_stop = stop - start
+                    basket_array = basket_arrays[basket_num]
+                    output[: stop - entry_start] = basket_array[local_start:local_stop]
+
+                elif start <= entry_stop <= stop:
+                    local_start = 0
+                    local_stop = entry_stop - start
+                    basket_array = basket_arrays[basket_num]
+                    output[start - entry_start :] = basket_array[local_start:local_stop]
+
+                elif entry_start < stop and start <= entry_stop:
+                    basket_array = basket_arrays[basket_num]
+                    output[start - entry_start : stop - entry_start] = basket_array
+
+                start = stop
+
+        output = output.view(output.dtype.newbyteorder("="))
+        self.hook_before_library_finalize(
+            basket_arrays=basket_arrays,
+            entry_start=entry_start,
+            entry_stop=entry_stop,
+            entry_offsets=entry_offsets,
+            library=library,
+            branch=branch,
+            output=output,
+        )
+
+        output = self._wrap_almost_finalized(output)
+
+        output = library.finalize(
+            output, branch, self, entry_start, entry_stop, options
+        )
+
+        self.hook_after_final_array(
+            basket_arrays=basket_arrays,
+            entry_start=entry_start,
+            entry_stop=entry_stop,
+            entry_offsets=entry_offsets,
+            library=library,
+            branch=branch,
+            output=output,
+        )
+
+        return output
+
     def basket_array(
         self,
         data,
@@ -863,13 +971,19 @@ class AsStridedObjects(uproot.interpretation.numerical.AsDtype):
             and dtype.itemsize != byte_offsets[1] - byte_offsets[0]
             and self.all_headers_prepended
         ):
-            dtype = [
-                ("@headers", "u1", byte_offsets[1] - byte_offsets[0] - dtype.itemsize)
-            ] + [
-                (x, str(y[0]))
-                for x, y in sorted(dtype.fields.items(), key=lambda k: k[1])
-            ]
-            self._to_dtype = numpy.dtype(dtype)
+            dtype = numpy.dtype(
+                [
+                    (
+                        "@headers",
+                        "u1",
+                        byte_offsets[1] - byte_offsets[0] - dtype.itemsize,
+                    )
+                ]
+                + [
+                    (x, str(y[0]))
+                    for x, y in sorted(dtype.fields.items(), key=lambda k: k[1])
+                ]
+            )
         try:
             output = data.view(dtype).reshape((-1, *shape))
 

--- a/src/uproot/interpretation/strings.py
+++ b/src/uproot/interpretation/strings.py
@@ -349,6 +349,15 @@ class AsStrings(uproot.interpretation.Interpretation):
                 assert isinstance(library, uproot.interpretation.library.Awkward)
                 awkward = library.imported
                 output = awkward.concatenate(trimmed, mergebool=False, highlevel=False)
+            else:
+                # Mixed StringArray/awkward baskets: concatenate after promoting
+                # to awkward so ``output`` is always bound.
+                awkward = uproot.extras.awkward()
+                output = awkward.concatenate(
+                    [awkward.to_layout(x) for x in trimmed],
+                    mergebool=False,
+                    highlevel=False,
+                )
 
             self.hook_before_library_finalize(
                 basket_arrays=basket_arrays,

--- a/src/uproot/language/python.py
+++ b/src/uproot/language/python.py
@@ -68,6 +68,18 @@ def _walk_ast_yield_symbols(node, keys, aliases, functions, getter):
                 f"found {ast.dump(node.args)}"
             )
 
+    elif (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in functions
+    ):
+        # A name in function-call position resolves to the function, so don't
+        # treat it as a branch symbol even if a branch shares the name.
+        for x in node.args:
+            yield from _walk_ast_yield_symbols(x, keys, aliases, functions, getter)
+        for x in node.keywords:
+            yield from _walk_ast_yield_symbols(x, keys, aliases, functions, getter)
+
     elif isinstance(node, ast.Name):
         if node.id in keys or node.id in aliases:
             yield node.id
@@ -111,6 +123,35 @@ def _ast_as_branch_expression(node, keys, aliases, functions, getter):
         and isinstance(node.args[0].value, str)
     ):
         return node
+
+    elif (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in functions
+    ):
+        # A name in function-call position resolves to the function, even when a
+        # branch happens to share the name (e.g. a branch literally named
+        # "sqrt"). Warn about the shadowing so the conflict is visible.
+        if node.func.id in keys or node.func.id in aliases:
+            warnings.warn(
+                f"{node.func.id!r} is both a branch name and a function; "
+                "using the function in call position",
+                uproot.exceptions.NameConflictWarning,
+                stacklevel=1,
+            )
+        new_func = ast.parse(f"function[{node.func.id!r}]").body[0].value
+        new_args = [
+            _ast_as_branch_expression(x, keys, aliases, functions, getter)
+            for x in node.args
+        ]
+        new_keywords = [
+            _ast_as_branch_expression(x, keys, aliases, functions, getter)
+            for x in node.keywords
+        ]
+        new_node = ast.Call(new_func, new_args, new_keywords)
+        new_node.lineno = getattr(node, "lineno", 1)
+        new_node.col_offset = getattr(node, "col_offset", 0)
+        return new_node
 
     elif isinstance(node, ast.Name):
         if node.id in keys or node.id in aliases:

--- a/tests/test_1660_interpretation_misc_fixes.py
+++ b/tests/test_1660_interpretation_misc_fixes.py
@@ -1,0 +1,159 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+import ast
+import warnings
+
+import numpy
+import pytest
+
+import uproot
+import uproot.exceptions
+import uproot.interpretation.custom
+import uproot.interpretation.identify as identify
+import uproot.interpretation.library as library
+import uproot.interpretation.objects as objects
+from uproot.containers import AsBitSet, STLBitSet
+from uproot.language.python import (
+    _ast_as_branch_expression,
+    _walk_ast_yield_symbols,
+)
+
+
+def test_parse_typename_long_long_pointer():
+    # "long long*" and "unsigned long long*" used to be dead branches
+    # (shadowed by the scalar "long"/"unsigned long" branches) and constructed
+    # AsArray with the wrong number of arguments.
+    interp = identify.parse_typename("long long*")
+    assert isinstance(interp, uproot.containers.AsArray)
+    assert interp.values == numpy.dtype(">i8")
+
+    interp = identify.parse_typename("unsigned long long*")
+    assert isinstance(interp, uproot.containers.AsArray)
+    assert interp.values == numpy.dtype(">u8")
+
+    # the scalar forms still resolve to plain dtypes
+    assert identify.parse_typename("long long") == numpy.dtype(">i8")
+    assert identify.parse_typename("unsigned long long") == numpy.dtype(">u8")
+    assert identify.parse_typename("long") == numpy.dtype(">i8")
+    assert identify.parse_typename("unsigned long") == numpy.dtype(">u8")
+
+
+def test_pandas_object_branch_returns_data_not_nan():
+    # When awkward_form raises CannotBeAwkward, _process_array_for_pandas used
+    # to fall off the end and return None, producing an all-NaN Series.
+    class CannotBeAwkwardInterp:
+        def awkward_form(self, file):
+            raise objects.CannotBeAwkward("test")
+
+    array = numpy.empty(3, dtype=object)
+    array[0] = "a"
+    array[1] = "b"
+    array[2] = "c"
+
+    out = library._process_array_for_pandas(array, True, CannotBeAwkwardInterp())
+    assert out is not None
+    assert list(out) == ["a", "b", "c"]
+
+    pandas = pytest.importorskip("pandas")
+    series = pandas.Series(out, index=range(3))
+    assert series.tolist() == ["a", "b", "c"]
+
+
+def test_asbinary_single_entry_basket():
+    # A single-entry basket yields a single count; the old uniformity check
+    # (numpy.unique(counts[1:] - counts[:-1]).size == 1) gave size 0 and
+    # raised AssertionError on valid data.
+    interp = uproot.interpretation.custom.AsBinary()
+
+    class FakeNumpyLibrary:
+        name = "np"
+
+    data = numpy.arange(4, dtype=numpy.uint8)
+    byte_offsets = numpy.array([0, 4], dtype=numpy.int64)
+    out = interp.basket_array(
+        data, byte_offsets, None, None, {}, 0, FakeNumpyLibrary(), {}
+    )
+    assert out.shape == (1, 4)
+
+    # uniform multi-entry still works
+    data = numpy.arange(6, dtype=numpy.uint8)
+    byte_offsets = numpy.array([0, 3, 6], dtype=numpy.int64)
+    out = interp.basket_array(
+        data, byte_offsets, None, None, {}, 0, FakeNumpyLibrary(), {}
+    )
+    assert out.shape == (2, 3)
+
+    # an arithmetic progression of non-uniform counts must be rejected
+    data = numpy.arange(6, dtype=numpy.uint8)
+    byte_offsets = numpy.array([0, 1, 3, 6], dtype=numpy.int64)
+    with pytest.raises(AssertionError):
+        interp.basket_array(
+            data, byte_offsets, None, None, {}, 0, FakeNumpyLibrary(), {}
+        )
+
+
+def test_stlbitset_repr_str_len():
+    bits = STLBitSet(numpy.array([True, False, True]))
+    assert len(bits) == 3
+    assert str(bits) == "[True, False, True]"
+    assert repr(bits).startswith("<STLBitSet [True, False, True] at 0x")
+
+
+def test_asbitset_typename_includes_bit_count():
+    interp = identify.parse_typename("std::bitset<8>")
+    assert isinstance(interp, AsBitSet)
+    assert interp.num_bits == 8
+    assert interp.typename == "std::bitset<8>"
+
+
+def test_expression_branch_named_like_a_function():
+    # A branch named "sqrt" used in call position must resolve to the function,
+    # not to get('sqrt'), and should warn about the conflict.
+    keys = {"sqrt", "x"}
+    aliases = {}
+    functions = {"sqrt": None, "abs": None}
+    getter = "get"
+
+    node = ast.parse("sqrt(x)").body[0].value
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        out = _ast_as_branch_expression(node, keys, aliases, functions, getter)
+
+    assert any(
+        issubclass(w.category, uproot.exceptions.NameConflictWarning) for w in caught
+    )
+
+    # the call resolves to function['sqrt'](get('x'))
+    assert isinstance(out, ast.Call)
+    assert isinstance(out.func, ast.Subscript)
+    assert out.func.value.id == "function"
+    assert out.func.slice.value == "sqrt"
+
+    # only "x" is requested as a branch symbol, not "sqrt"
+    symbols = list(_walk_ast_yield_symbols(node, keys, aliases, functions, getter))
+    assert symbols == ["x"]
+
+    # in value position, a branch named "sqrt" still resolves to the branch
+    node2 = ast.parse("sqrt + x").body[0].value
+    out2 = _ast_as_branch_expression(node2, keys, aliases, functions, getter)
+    assert isinstance(out2.left, ast.Call)
+    assert out2.left.func.id == getter
+    assert out2.left.args[0].value == "sqrt"
+
+
+def test_strided_objects_shared_interpretation_no_state_leak():
+    # AsStridedObjects.basket_array used to mutate self._to_dtype; reading the
+    # same branch repeatedly (sharing the interpretation) must be stable.
+    skhep_testdata = pytest.importorskip("skhep_testdata")
+    f = uproot.open(skhep_testdata.data_path("uproot-issue-513.root"))
+    branch = f["TrkAnaNeg/trkana"]["demcent"]["_mom"]
+    interp = branch.interpretation
+    to_dtype_before = interp.to_dtype
+
+    first = branch.array(library="np")
+    assert interp.to_dtype == to_dtype_before
+
+    second = branch.array(library="np")
+    assert len(first) == len(second) == 101
+    assert interp.to_dtype == to_dtype_before


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1646.

Fixes a batch of verified bugs in the interpretation layer, found during review.

### Fixed

1. **library.py — pandas all-NaN fallback.** `_process_array_for_pandas` fell off the end returning `None` when `interpretation.awkward_form(...)` raised `CannotBeAwkward`, so `library="pd"` silently built `pandas.Series(None, index=...)` (all-NaN) instead of the object array. Now returns the array.
2. **identify.py — `parse_typename` for `long long*` / `unsigned long long*`.** These branches were dead (shadowed by the scalar `long`/`unsigned long` branches, which consume the token) and constructed `AsArray({header}, dtype)` with the wrong arity. Reordered so the pointer forms are checked first and pass the missing `speedbump` argument.
3. **identify.py — broken assert message.** The assert's f-string message was a separate statement (dead code, truncated message) and validation shouldn't be an assert (stripped under `-O`). Replaced with a `raise ValueError(...)`.
4. **objects.py — `AsStridedObjects`:**
   - `__init__` deleted from a list while iterating `range()` of its original length (IndexError with mid-list `(None, None)` header markers from multiple base classes) and could drop the sole member. Rewritten as a filter that drops interior header markers; `all_headers_prepended` semantics preserved.
   - `basket_array` mutated shared `self._to_dtype` based on a basket's byte offsets — a race / state leak across basket-worker threads. The header dtype is now computed locally, and `final_array` derives the output dtype from the actual basket arrays.
   - Hoisted the per-basket `awkward_form(...)` recomputation out of the loop, reused `has_any_awkward_types`, removed a dead `container = {}`.
5. **strings.py — `final_array`.** `output` could be referenced unbound for mixed StringArray/awkward baskets; now bound on all paths.
6. **containers.py:**
   - `STLBitSet.__str__` referenced a nonexistent `self._values` and `__len__` returned an ndarray (both `TypeError`); fixed to use `self._numbytes` and return an int.
   - `AsBitSet` now keeps its bit count and renders `std::bitset<N>` instead of `std::bitset<bool>`.
   - Simplified always-true `KeysView is not None` / `ValuesView is not None` (Py2 leftovers).
7. **known_forth/__init__.py** — fallback `typename = classname_decode(model.__name__)` returned a `(classname, version)` tuple that could never match the string keys in `KNOWN_FORTH_DICT`; now takes `[0]`.
8. **custom.py — `AsBinary` (`library="np"`).** The uniformity check `numpy.unique(counts[1:] - counts[:-1]).size == 1` failed on single-entry baskets (empty diff → AssertionError) and passed for any arithmetic progression. Changed to `numpy.unique(counts).size <= 1` on the per-entry sizes.
9. **python.py — expression compilation.** A branch named like a function (e.g. `sqrt`) used in call position was rewritten to `get('sqrt')`, breaking `sqrt(x)`. Names in `func` position that exist in the functions table now resolve to the function and emit `NameConflictWarning` when shadowed by a branch.
10. **library.py — perf.** `_strided_to_awkward` now uses `data.reshape(-1)` (view) instead of `data.flatten()` (copy) at every recursion level.

### Skipped

None — all ten findings held up under verification.

### Tests

Regression tests added in `tests/test_<N>_*.py` (named after the PR number) and the targeted/interpretation-heavy suites pass locally.
