### PR TITLE
fix: Add missing class mapping for ROOT::TString

### DIFF
--- a/src/uproot/models/TString.py
+++ b/src/uproot/models/TString.py
@@ -105,3 +105,5 @@ in file {self.file.file_path}"""
 
 
 uproot.classes["TString"] = Model_TString
+uproot.classes["ROOT::TString"] = Model_TString
+uproot.classes["ROOT::ROOT::TString"] = Model_TString


### PR DESCRIPTION
## Summary

Fixes issue #8 by adding the missing model mapping for `ROOT.TString` to support nested reading within a `TTree`.

## Problem

The model mappings at the bottom of `uproot/models/TString.py` were missing entries for scoped C++ `TString` aliases (e.g. `ROOT::TString`). This led to `uproot` failing to map and read these nested objects properly.

## Solution

Registered the missing C++ scope mappings at the end of `uproot/models/TString.py`:
- `uproot.classes["ROOT::TString"] = Model_TString`
- `uproot.classes["ROOT::ROOT::TString"] = Model_TString`
