### PR TITLE
chore: exclude awkward and skhep-testdata from delay requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,3 +192,4 @@ write_to = "src/uproot/_version.py"
 
 [tool.uv]
 exclude-newer = "7 days"
+exclude-newer-package = {awkward = false, awkward-cpp = false, scikit-hep-testdata = false}


### PR DESCRIPTION
Awkward and skhep-testdata are closely tied to Uproot, so we often need to use the latest releases. Additionally, they are both under our control. So I'm excluding them from the `uv` are requirement.

I'll merge this without a review, so that other PRs can proceed.