### PR TITLE
fix: add typenames to form so Coffea can use them

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1722,6 +1722,8 @@ which has {entry_stop} entries"""
         base_form = _get_ttree_form(
             awkward, ttrees[0], common_keys, interp_options.get("ak_add_doc")
         )
+        if form_mapping is not None:
+            base_form.parameters["typenames"] = ttrees[0].typenames()
 
     if len(partition_args) == 0:
         divisions.append(0)
@@ -1811,6 +1813,8 @@ def _get_dak_array_delay_open(
         base_form = _get_ttree_form(
             awkward, obj, common_keys, interp_options.get("ak_add_doc")
         )
+        if form_mapping is not None:
+            base_form.parameters["typenames"] = obj.typenames()
 
     divisions = [0]
     partition_args = []


### PR DESCRIPTION
#1642 removed grouped branches from appearing in the form in dask mode (which makes sense and matches the eager mode). However, Coffea relied on those branches to extract typenames.

This PR adds the typenames as a parameter of the form, so that Coffea can use them. There will be an accompanying PR in Coffea.