### PR TITLE
fix: accidental dropping of AsGrouped

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -935,7 +935,10 @@ class TrivialFormMappingInfo(ImplementsFormMappingInfo):
         interpretation_executor,
         options: Any,
     ) -> Mapping[str, AwkArray]:
-        # First, let's read the arrays as a tuple (to associate with each key)
+        # Read the arrays as a top-level awkward RecordArray. Omitting how= (the
+        # default) ensures that AsGrouped branches are returned as proper awkward
+        # RecordArrays rather than Python tuples of sub-arrays (which how=tuple
+        # would produce), allowing awkward.to_buffers() to work correctly below.
         arrays = tree.arrays(
             keys,
             entry_start=start,
@@ -943,7 +946,6 @@ class TrivialFormMappingInfo(ImplementsFormMappingInfo):
             ak_add_doc=options["ak_add_doc"],
             decompression_executor=decompression_executor,
             interpretation_executor=interpretation_executor,
-            how=tuple,
         )
 
         if isinstance(tree, HasFields):
@@ -959,9 +961,9 @@ class TrivialFormMappingInfo(ImplementsFormMappingInfo):
         # subform, as they're derived from `branch.interpretation.awkward_form`
         # Therefore, we can correlate the subform keys using `expected_from_buffers`
         container = {}
-        for key, array in zip(keys, arrays, strict=True):
+        for key in keys:
             # First, convert the sub-array into buffers
-            ttree_subform, _length, ttree_container = awkward.to_buffers(array)
+            ttree_subform, _length, ttree_container = awkward.to_buffers(arrays[key])
 
             # Load the associated projection subform
             projection_subform = self._form.content(key)

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1649,15 +1649,23 @@ def _get_dak_array(
             )
         )
 
-    # Filter out AsGrouped branches: they are grouping containers without their own
-    # data buffers. This matches tree.arrays(expressions=None) which also skips them.
+    # Filter out AsGrouped branches whose children are already present separately in
+    # common_keys. Such branches are pure grouping containers with no data buffers of
+    # their own, and keeping them would produce a redundant layer in the form.
+    # AsGrouped branches whose children are NOT in common_keys are kept because they
+    # carry structural information (e.g. ElementLink records) that would otherwise be lost.
     if ttrees and not isinstance(ttrees[0], HasFields):
+        common_keys_set = set(common_keys)
         common_keys = [
             k
             for k in common_keys
             if not isinstance(
                 ttrees[0][k].interpretation,
                 uproot.interpretation.grouped.AsGrouped,
+            )
+            or not any(
+                child in common_keys_set
+                for child in ttrees[0][k].keys(recursive=True, full_paths=True)
             )
         ]
 
@@ -1799,15 +1807,23 @@ def _get_dak_array_delay_open(
             full_paths=full_paths,
             ignore_duplicates=True,
         )
-        # Filter out AsGrouped branches: they are grouping containers without their own
-        # data buffers. This matches tree.arrays(expressions=None) which also skips them.
+        # Filter out AsGrouped branches whose children are already present separately in
+        # common_keys. Such branches are pure grouping containers with no data buffers of
+        # their own, and keeping them would produce a redundant layer in the form.
+        # AsGrouped branches whose children are NOT in common_keys are kept because they
+        # carry structural information (e.g. ElementLink records) that would otherwise be lost.
         if not isinstance(obj, HasFields):
+            common_keys_set = set(common_keys)
             common_keys = [
                 k
                 for k in common_keys
                 if not isinstance(
                     obj[k].interpretation,
                     uproot.interpretation.grouped.AsGrouped,
+                )
+                or not any(
+                    child in common_keys_set
+                    for child in obj[k].keys(recursive=True, full_paths=True)
                 )
             ]
         base_form = _get_ttree_form(

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1673,7 +1673,7 @@ def _get_dak_array(
     # children also appear in common_keys:
     # - Case 1 (Parent matched, no leaves matched):    include parent grouped
     # - Case 2 (Parent not matched, some leaves matched):   skip parent, keep matched leaves individual
-    # - Case 3 (arent matched, all leaves matched):   skip parent, keep leaves individual
+    # - Case 3 (Parent matched, all leaves matched):   skip parent, keep leaves individual
     # - Case 4 (Parent matched, some leaves matched):  include parent grouped, suppress matched leaves
     if ttrees and not isinstance(ttrees[0], HasFields):
         common_keys_set = set(common_keys)
@@ -1685,7 +1685,13 @@ def _get_dak_array(
                 uproot.interpretation.grouped.AsGrouped,
             ):
                 continue
-            all_child_keys = ttrees[0][k].keys(recursive=True, full_paths=False)
+            if full_paths:
+                all_child_keys = [
+                    f"{k}/{ck}"
+                    for ck in ttrees[0][k].keys(recursive=True, full_paths=True)
+                ]
+            else:
+                all_child_keys = ttrees[0][k].keys(recursive=True, full_paths=False)
             matched_children = [c for c in all_child_keys if c in common_keys_set]
             if len(all_child_keys) > 0 and len(matched_children) == len(all_child_keys):
                 # Case 3: drop parent, keep individual children
@@ -1841,7 +1847,7 @@ def _get_dak_array_delay_open(
         # children also appear in common_keys (same logic as _get_dak_array):
         # - Case 1 (Parent matched, no leaves matched):    include parent grouped
         # - Case 2 (Parent not matched, some leaves matched):   skip parent, keep matched leaves individual
-        # - Case 3 (arent matched, all leaves matched):   skip parent, keep leaves individual
+        # - Case 3 (Parent matched, all leaves matched):   skip parent, keep leaves individual
         # - Case 4 (Parent matched, some leaves matched):  include parent grouped, suppress matched leaves
         if not isinstance(obj, HasFields):
             common_keys_set = set(common_keys)
@@ -1853,7 +1859,13 @@ def _get_dak_array_delay_open(
                     uproot.interpretation.grouped.AsGrouped,
                 ):
                     continue
-                all_child_keys = obj[k].keys(recursive=True, full_paths=True)
+                if full_paths:
+                    all_child_keys = [
+                        f"{k}/{ck}"
+                        for ck in obj[k].keys(recursive=True, full_paths=True)
+                    ]
+                else:
+                    all_child_keys = obj[k].keys(recursive=True, full_paths=False)
                 matched_children = [c for c in all_child_keys if c in common_keys_set]
                 if len(all_child_keys) > 0 and len(matched_children) == len(
                     all_child_keys

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -1651,24 +1651,34 @@ def _get_dak_array(
             )
         )
 
-    # Filter out AsGrouped branches whose children are already present separately in
-    # common_keys. Such branches are pure grouping containers with no data buffers of
-    # their own, and keeping them would produce a redundant layer in the form.
-    # AsGrouped branches whose children are NOT in common_keys are kept because they
-    # carry structural information (e.g. ElementLink records) that would otherwise be lost.
+    # Normalise AsGrouped branches in common_keys according to which of their
+    # children also appear in common_keys:
+    # - Case 1 (Parent matched, no leaves matched):    include parent grouped
+    # - Case 2 (Parent not matched, some leaves matched):   skip parent, keep matched leaves individual
+    # - Case 3 (arent matched, all leaves matched):   skip parent, keep leaves individual
+    # - Case 4 (Parent matched, some leaves matched):  include parent grouped, suppress matched leaves
     if ttrees and not isinstance(ttrees[0], HasFields):
         common_keys_set = set(common_keys)
-        common_keys = [
-            k
-            for k in common_keys
+        parent_keys_to_remove = set()
+        child_keys_to_suppress = set()
+        for k in common_keys:
             if not isinstance(
                 ttrees[0][k].interpretation,
                 uproot.interpretation.grouped.AsGrouped,
-            )
-            or not any(
-                child in common_keys_set
-                for child in ttrees[0][k].keys(recursive=True, full_paths=True)
-            )
+            ):
+                continue
+            all_child_keys = ttrees[0][k].keys(recursive=True, full_paths=False)
+            matched_children = [c for c in all_child_keys if c in common_keys_set]
+            if len(all_child_keys) > 0 and len(matched_children) == len(all_child_keys):
+                # Case 3: drop parent, keep individual children
+                parent_keys_to_remove.add(k)
+            elif matched_children:
+                # Case 4: keep parent, suppress the individually-matched children
+                child_keys_to_suppress.update(matched_children)
+        common_keys = [
+            k
+            for k in common_keys
+            if k not in parent_keys_to_remove and k not in child_keys_to_suppress
         ]
 
     step_sum = 0
@@ -1809,24 +1819,34 @@ def _get_dak_array_delay_open(
             full_paths=full_paths,
             ignore_duplicates=True,
         )
-        # Filter out AsGrouped branches whose children are already present separately in
-        # common_keys. Such branches are pure grouping containers with no data buffers of
-        # their own, and keeping them would produce a redundant layer in the form.
-        # AsGrouped branches whose children are NOT in common_keys are kept because they
-        # carry structural information (e.g. ElementLink records) that would otherwise be lost.
+        # Normalise AsGrouped branches in common_keys according to which of their
+        # children also appear in common_keys (same logic as _get_dak_array):
+        # - Case 1 (Parent matched, no leaves matched):    include parent grouped
+        # - Case 2 (Parent not matched, some leaves matched):   skip parent, keep matched leaves individual
+        # - Case 3 (arent matched, all leaves matched):   skip parent, keep leaves individual
+        # - Case 4 (Parent matched, some leaves matched):  include parent grouped, suppress matched leaves
         if not isinstance(obj, HasFields):
             common_keys_set = set(common_keys)
-            common_keys = [
-                k
-                for k in common_keys
+            parent_keys_to_remove = set()
+            child_keys_to_suppress = set()
+            for k in common_keys:
                 if not isinstance(
                     obj[k].interpretation,
                     uproot.interpretation.grouped.AsGrouped,
-                )
-                or not any(
-                    child in common_keys_set
-                    for child in obj[k].keys(recursive=True, full_paths=True)
-                )
+                ):
+                    continue
+                all_child_keys = obj[k].keys(recursive=True, full_paths=True)
+                matched_children = [c for c in all_child_keys if c in common_keys_set]
+                if len(all_child_keys) > 0 and len(matched_children) == len(
+                    all_child_keys
+                ):
+                    parent_keys_to_remove.add(k)
+                elif matched_children:
+                    child_keys_to_suppress.update(matched_children)
+            common_keys = [
+                k
+                for k in common_keys
+                if k not in parent_keys_to_remove and k not in child_keys_to_suppress
             ]
         base_form = _get_ttree_form(
             awkward, obj, common_keys, interp_options.get("ak_add_doc")

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -140,6 +140,24 @@ def dask(
     the function returns a Python dict of dask arrays. If ``library='ak'``, the
     function returns a single dask-awkward array.
 
+    .. note::
+
+        When any filter (``filter_name``, ``filter_typename``, or
+        ``filter_branch``) selects an *AsGrouped* branch (a pure-grouping
+        container with no data buffers of its own), the result depends on
+        which of its sub-branches are also selected:
+
+        * **Only the parent selected** — all sub-branches are returned grouped
+          as a single ``RecordArray``.
+        * **Only sub-branches selected (no parent)** — the selected sub-branches
+          are returned as separate flat fields.
+        * **Parent and all sub-branches selected** — the parent is dropped and
+          each sub-branch is returned as a separate flat field.
+        * **Parent and some sub-branches selected** — the complete grouped record
+          is returned for all sub-branches; the individually-selected
+          sub-branches are absorbed into the group and are not also returned
+          as flat fields.
+
     For example:
 
     .. code-block:: python

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1027,23 +1027,31 @@ class HasBranches(Mapping):
             ignore_duplicates=ignore_duplicates,
         )
 
-        # Filter out AsGrouped branches whose children are already present separately in
-        # keys. Such branches are pure grouping containers with no data buffers of their
-        # own, and keeping them would produce a redundant layer in the output.
-        # AsGrouped branches whose children are NOT in keys are kept because they carry
-        # structural information (e.g. ElementLink records) that would otherwise be lost.
+        # Normalise AsGrouped branches in keys according to which of their children
+        # also appear in keys (same case logic as _regularize_expressions):
+        # - Case 1 (Parent matched, no leaves matched):    include parent grouped
+        # - Case 2 (Parent not matched, some leaves matched):   skip parent, keep matched leaves individual
+        # - Case 3 (arent matched, all leaves matched):   skip parent, keep leaves individual
+        # - Case 4 (Parent matched, some leaves matched):  include parent grouped, suppress matched leaves
         keys_set = set(keys)
-        keys = [
-            k
-            for k in keys
+        parent_keys_to_remove = set()
+        child_keys_to_suppress = set()
+        for k in keys:
             if not isinstance(
                 self[k].interpretation,
                 uproot.interpretation.grouped.AsGrouped,
-            )
-            or not any(
-                child in keys_set
-                for child in self[k].keys(recursive=True, full_paths=True)
-            )
+            ):
+                continue
+            all_child_keys = self[k].keys(recursive=True, full_paths=False)
+            matched_children = [c for c in all_child_keys if c in keys_set]
+            if len(all_child_keys) > 0 and len(matched_children) == len(all_child_keys):
+                parent_keys_to_remove.add(k)
+            elif matched_children:
+                child_keys_to_suppress.update(matched_children)
+        keys = [
+            k
+            for k in keys
+            if k not in parent_keys_to_remove and k not in child_keys_to_suppress
         ]
 
         # we're dealing with a single branch here:
@@ -3264,6 +3272,30 @@ in file {} at {}""".format(
         expression_context.append((expression, c))
 
 
+def _collect_leaf_cache_keys(branch, result=None):
+    """Recursively collect TBranch cache keys of all non-AsGrouped descendants.
+
+    Used to classify how an AsGrouped branch should be handled when building
+    expression_context: whether ALL its leaves were matched (case 3 → skip) or
+    only some / none (case 1/4 → include grouped).  UnknownInterpretation leaves
+    are silently skipped because they cannot be read anyway.
+    """
+    if result is None:
+        result = set()
+    for subname in branch.interpretation.subbranches:
+        subbranch = branch[subname]
+        if isinstance(
+            subbranch.interpretation, uproot.interpretation.grouped.AsGrouped
+        ):
+            _collect_leaf_cache_keys(subbranch, result)
+        elif not isinstance(
+            subbranch.interpretation,
+            uproot.interpretation.identify.UnknownInterpretation,
+        ):
+            result.add(subbranch.cache_key)
+    return result
+
+
 def _regularize_expressions(
     hasbranches,
     expressions,
@@ -3281,8 +3313,10 @@ def _regularize_expressions(
     branchid_interpretation = {}
 
     if expressions is None:
-        included_cache_keys = set()
-        asgrouped_branches = []
+        # Collect all matched branches without adding to expression_context yet;
+        # we need to see all matches before deciding how to handle each AsGrouped.
+        matched_regular = []  # (branchname, branch) for non-AsGrouped, non-Unknown
+        asgrouped_branches = []  # (branchname, branch)
         for branchname, branch in hasbranches.iteritems(
             filter_name=filter_name,
             filter_typename=filter_typename,
@@ -3301,34 +3335,20 @@ def _regularize_expressions(
             ):
                 asgrouped_branches.append((branchname, branch))
             else:
-                branchname_expression = (
-                    branchname
-                    if branchname.isidentifier() and not iskeyword(branchname)
-                    else language.getter_of(branchname)
-                )
-                _regularize_expression(
-                    hasbranches,
-                    branchname_expression,
-                    keys,
-                    aliases,
-                    language,
-                    get_from_cache,
-                    arrays,
-                    expression_context,
-                    branchid_interpretation,
-                    (),
-                    False,
-                    branchname,
-                )
-                included_cache_keys.add(branch.cache_key)
+                matched_regular.append((branchname, branch))
 
-        # For AsGrouped branches that matched the filter but none of their children
-        # were included separately, include them as primary expressions. This lets
-        # _regularize_branchname pull in the sub-branches and assemble the record,
-        # so e.g. tree.arrays(filter_name="btaggingLink") returns the full record
-        # rather than an empty result.
+        # Classify each AsGrouped branch using its RECURSIVE leaf cache keys so
+        # that nested AsGrouped structures are handled correctly:
+        # - Case 1 (Parent matched, no leaves matched):    include parent grouped
+        # - Case 2 (Parent not matched, some leaves matched):   skip parent, keep matched leaves individual
+        # - Case 3 (arent matched, all leaves matched):   skip parent, keep leaves individual
+        # - Case 4 (Parent matched, some leaves matched):  include parent grouped, suppress matched leaves
+        all_regular_cache_keys = {b.cache_key for _, b in matched_regular}
+        children_to_suppress = set()  # leaf cache keys not to add individually
+        asgrouped_to_add = []  # (branchname, branch) AsGrouped parents to add grouped
+
         for branchname, branch in asgrouped_branches:
-            # Skip AsGrouped branches whose sub-interpretations include
+            # Skip AsGrouped branches whose direct sub-interpretations include
             # UnknownInterpretation: AsGrouped.cache_key would raise on them.
             if any(
                 isinstance(
@@ -3338,22 +3358,69 @@ def _regularize_expressions(
                 for interp in branch.interpretation.subbranches.values()
             ):
                 continue
+            leaf_cache_keys = _collect_leaf_cache_keys(branch)
+            matched_leaves = leaf_cache_keys & all_regular_cache_keys
+            if len(leaf_cache_keys) > 0 and len(matched_leaves) == len(leaf_cache_keys):
+                # Case 3: every leaf was matched individually → skip parent
+                pass
+            else:
+                # Case 1 (no leaves) or Case 4 (some leaves):
+                # include the parent grouped and suppress matched leaves to prevent
+                # them from also being added individually (would create duplicates).
+                children_to_suppress |= matched_leaves
+                asgrouped_to_add.append((branchname, branch))
+
+        # If a nested AsGrouped is also in asgrouped_to_add, its ancestor will
+        # handle it via _regularize_branchname.  Remove descendants to avoid
+        # processing them twice.
+        asgrouped_to_add_names = {name for name, _ in asgrouped_to_add}
+        asgrouped_to_add = [
+            (branchname, branch)
+            for branchname, branch in asgrouped_to_add
             if not any(
-                branch[subname].cache_key in included_cache_keys
-                for subname in branch.interpretation.subbranches
-            ):
-                _regularize_branchname(
-                    hasbranches,
-                    branchname,
-                    branch,
-                    branch.interpretation,
-                    get_from_cache,
-                    arrays,
-                    expression_context,
-                    branchid_interpretation,
-                    True,
-                    False,
-                )
+                branchname.startswith(parent_name + "/")
+                for parent_name in asgrouped_to_add_names
+            )
+        ]
+
+        # Add regular (non-AsGrouped) branches, skipping leaves subsumed by a parent.
+        for branchname, branch in matched_regular:
+            if branch.cache_key in children_to_suppress:
+                continue
+            branchname_expression = (
+                branchname
+                if branchname.isidentifier() and not iskeyword(branchname)
+                else language.getter_of(branchname)
+            )
+            _regularize_expression(
+                hasbranches,
+                branchname_expression,
+                keys,
+                aliases,
+                language,
+                get_from_cache,
+                arrays,
+                expression_context,
+                branchid_interpretation,
+                (),
+                False,
+                branchname,
+            )
+
+        # Add grouped AsGrouped parents (cases 1 and 4).
+        for branchname, branch in asgrouped_to_add:
+            _regularize_branchname(
+                hasbranches,
+                branchname,
+                branch,
+                branch.interpretation,
+                get_from_cache,
+                arrays,
+                expression_context,
+                branchid_interpretation,
+                True,
+                False,
+            )
 
     elif isinstance(expressions, str):
         _regularize_expression(

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -3281,6 +3281,8 @@ def _regularize_expressions(
     branchid_interpretation = {}
 
     if expressions is None:
+        included_cache_keys = set()
+        asgrouped_branches = []
         for branchname, branch in hasbranches.iteritems(
             filter_name=filter_name,
             filter_typename=filter_typename,
@@ -3288,13 +3290,17 @@ def _regularize_expressions(
             recursive=True,
             full_paths=False,
         ):
-            if not isinstance(
+            if isinstance(
                 branch.interpretation,
-                (
-                    uproot.interpretation.identify.UnknownInterpretation,
-                    uproot.interpretation.grouped.AsGrouped,
-                ),
+                uproot.interpretation.identify.UnknownInterpretation,
             ):
+                pass
+            elif isinstance(
+                branch.interpretation,
+                uproot.interpretation.grouped.AsGrouped,
+            ):
+                asgrouped_branches.append((branchname, branch))
+            else:
                 branchname_expression = (
                     branchname
                     if branchname.isidentifier() and not iskeyword(branchname)
@@ -3313,6 +3319,40 @@ def _regularize_expressions(
                     (),
                     False,
                     branchname,
+                )
+                included_cache_keys.add(branch.cache_key)
+
+        # For AsGrouped branches that matched the filter but none of their children
+        # were included separately, include them as primary expressions. This lets
+        # _regularize_branchname pull in the sub-branches and assemble the record,
+        # so e.g. tree.arrays(filter_name="btaggingLink") returns the full record
+        # rather than an empty result.
+        for branchname, branch in asgrouped_branches:
+            # Skip AsGrouped branches whose sub-interpretations include
+            # UnknownInterpretation: AsGrouped.cache_key would raise on them.
+            if any(
+                isinstance(
+                    interp,
+                    uproot.interpretation.identify.UnknownInterpretation,
+                )
+                for interp in branch.interpretation.subbranches.values()
+            ):
+                continue
+            if not any(
+                branch[subname].cache_key in included_cache_keys
+                for subname in branch.interpretation.subbranches
+            ):
+                _regularize_branchname(
+                    hasbranches,
+                    branchname,
+                    branch,
+                    branch.interpretation,
+                    get_from_cache,
+                    arrays,
+                    expression_context,
+                    branchid_interpretation,
+                    True,
+                    False,
                 )
 
     elif isinstance(expressions, str):

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1049,7 +1049,7 @@ class HasBranches(Mapping):
         # also appear in keys (same case logic as _regularize_expressions):
         # - Case 1 (Parent matched, no leaves matched):    include parent grouped
         # - Case 2 (Parent not matched, some leaves matched):   skip parent, keep matched leaves individual
-        # - Case 3 (arent matched, all leaves matched):   skip parent, keep leaves individual
+        # - Case 3 (Parent matched, all leaves matched):   skip parent, keep leaves individual
         # - Case 4 (Parent matched, some leaves matched):  include parent grouped, suppress matched leaves
         keys_set = set(keys)
         parent_keys_to_remove = set()
@@ -1060,7 +1060,12 @@ class HasBranches(Mapping):
                 uproot.interpretation.grouped.AsGrouped,
             ):
                 continue
-            all_child_keys = self[k].keys(recursive=True, full_paths=False)
+            if full_paths:
+                all_child_keys = [
+                    f"{k}/{ck}" for ck in self[k].keys(recursive=True, full_paths=True)
+                ]
+            else:
+                all_child_keys = self[k].keys(recursive=True, full_paths=False)
             matched_children = [c for c in all_child_keys if c in keys_set]
             if len(all_child_keys) > 0 and len(matched_children) == len(all_child_keys):
                 parent_keys_to_remove.add(k)
@@ -3312,6 +3317,18 @@ def _collect_leaf_cache_keys(branch, result=None):
     return result
 
 
+def _iter_branch_ancestors(branch):
+    """Yield each TBranch ancestor of *branch*, from parent up to the tree root.
+
+    Used by the nested-AsGrouped de-duplication step in ``_regularize_expressions``
+    to detect whether a branch's ancestor is already being added grouped.
+    """
+    p = getattr(branch, "parent", None)
+    while isinstance(p, TBranch):
+        yield p
+        p = getattr(p, "parent", None)
+
+
 def _regularize_expressions(
     hasbranches,
     expressions,
@@ -3357,7 +3374,7 @@ def _regularize_expressions(
         # that nested AsGrouped structures are handled correctly:
         # - Case 1 (Parent matched, no leaves matched):    include parent grouped
         # - Case 2 (Parent not matched, some leaves matched):   skip parent, keep matched leaves individual
-        # - Case 3 (arent matched, all leaves matched):   skip parent, keep leaves individual
+        # - Case 3 (Parent matched, all leaves matched):   skip parent, keep leaves individual
         # - Case 4 (Parent matched, some leaves matched):  include parent grouped, suppress matched leaves
         all_regular_cache_keys = {b.cache_key for _, b in matched_regular}
         children_to_suppress = set()  # leaf cache keys not to add individually
@@ -3388,14 +3405,15 @@ def _regularize_expressions(
 
         # If a nested AsGrouped is also in asgrouped_to_add, its ancestor will
         # handle it via _regularize_branchname.  Remove descendants to avoid
-        # processing them twice.
-        asgrouped_to_add_names = {name for name, _ in asgrouped_to_add}
+        # processing them twice.  We use object identity (not names from
+        # full_paths=False iteration, which carry no hierarchy info) to detect
+        # the ancestor relationship.
+        asgrouped_to_add_ids = {id(b) for _, b in asgrouped_to_add}
         asgrouped_to_add = [
             (branchname, branch)
             for branchname, branch in asgrouped_to_add
             if not any(
-                branchname.startswith(parent_name + "/")
-                for parent_name in asgrouped_to_add_names
+                id(p) in asgrouped_to_add_ids for p in _iter_branch_ancestors(branch)
             )
         ]
 

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -848,6 +848,24 @@ class HasBranches(Mapping):
 
         Returns a group of arrays from the ``TTree``.
 
+        .. note::
+
+            When any filter (``filter_name``, ``filter_typename``, or
+            ``filter_branch``) selects an *AsGrouped* branch (a pure-grouping
+            container with no data buffers of its own), the result depends on
+            which of its sub-branches are also selected:
+
+            * **Only the parent selected** — all sub-branches are returned grouped
+              as a single ``RecordArray``.
+            * **Only sub-branches selected (no parent)** — the selected sub-branches
+              are returned as separate flat fields.
+            * **Parent and all sub-branches selected** — the parent is dropped and
+              each sub-branch is returned as a separate flat field.
+            * **Parent and some sub-branches selected** — the complete grouped record
+              is returned for all sub-branches; the individually-selected
+              sub-branches are absorbed into the group and are not also returned
+              as flat fields.
+
         For example:
 
         .. code-block:: python

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1027,14 +1027,22 @@ class HasBranches(Mapping):
             ignore_duplicates=ignore_duplicates,
         )
 
-        # Filter out AsGrouped branches: they are grouping containers with no data
-        # buffers of their own. Their children appear separately in `keys` already.
+        # Filter out AsGrouped branches whose children are already present separately in
+        # keys. Such branches are pure grouping containers with no data buffers of their
+        # own, and keeping them would produce a redundant layer in the output.
+        # AsGrouped branches whose children are NOT in keys are kept because they carry
+        # structural information (e.g. ElementLink records) that would otherwise be lost.
+        keys_set = set(keys)
         keys = [
             k
             for k in keys
             if not isinstance(
                 self[k].interpretation,
                 uproot.interpretation.grouped.AsGrouped,
+            )
+            or not any(
+                child in keys_set
+                for child in self[k].keys(recursive=True, full_paths=True)
             )
         ]
 

--- a/tests/test_1642_read_AsGrouped_with_dask_or_virtual_array.py
+++ b/tests/test_1642_read_AsGrouped_with_dask_or_virtual_array.py
@@ -25,3 +25,59 @@ def test_read_AsGrouped_with_dask_or_virtual_array():
 
     dask_arr = uproot.dask(path).compute()
     assert awkward.array_equal(arr, dask_arr)
+
+
+def test_filter_name_on_AsGrouped_eager():
+    """
+    tree.arrays(filter_name=<AsGrouped branch name>) must return a non-empty
+    record containing the grouped sub-fields, not an empty result.
+
+    Previously, _regularize_expressions skipped ALL AsGrouped branches when
+    expressions=None, so filtering to a single AsGrouped branch produced an
+    empty record.
+    """
+    path = skhep_testdata.data_path("uproot-FCCDelphesOutput.root")
+    with uproot.open(path) as f:
+        tree = f["events"]
+        arr = tree.arrays(filter_name="genParticles")
+
+    assert arr.fields == ["genParticles"]
+    sub = arr["genParticles"]
+    assert "genParticles.core.pdgId" in sub.fields
+    assert "genParticles.core.p4.mass" in sub.fields
+    # Spot-check a known value in the first event
+    assert sub["genParticles.core.pdgId"][0][:3].tolist() == [11, -11, 11]
+
+
+def test_filter_name_on_AsGrouped_virtual():
+    """
+    tree.arrays(virtual=True, filter_name=<AsGrouped branch name>) must return
+    the same result as the eager path after materialisation.
+    """
+    path = skhep_testdata.data_path("uproot-FCCDelphesOutput.root")
+    with uproot.open(path) as f:
+        tree = f["events"]
+        arr = tree.arrays(filter_name="genParticles")
+        virtual_arr = tree.arrays(virtual=True, filter_name="genParticles")
+        assert awkward.array_equal(arr, awkward.materialize(virtual_arr))
+
+
+def test_filter_name_on_AsGrouped_dask():
+    """
+    uproot.dask(filter_name=<AsGrouped branch name>).compute() must return the
+    same result as the eager path and must not crash.
+
+    Previously, TrivialFormMappingInfo.load_buffers used how=tuple when calling
+    tree.arrays(), which for AsGrouped branches returns a Python tuple of
+    sub-arrays instead of an awkward RecordArray.  awkward.to_buffers() on that
+    Python tuple produced a mismatched form, causing an AssertionError.
+    """
+    path = skhep_testdata.data_path("uproot-FCCDelphesOutput.root")
+    with uproot.open(path) as f:
+        arr = f["events"].arrays(filter_name="genParticles")
+
+    dask_arr = uproot.dask(path + ":events", filter_name="genParticles")
+    computed = dask_arr.compute()
+
+    assert computed.fields == ["genParticles"]
+    assert awkward.array_equal(arr, computed)

--- a/tests/test_1642_read_AsGrouped_with_dask_or_virtual_array.py
+++ b/tests/test_1642_read_AsGrouped_with_dask_or_virtual_array.py
@@ -12,9 +12,8 @@ da = pytest.importorskip("dask.array")
 
 def test_read_AsGrouped_with_dask_or_virtual_array():
     """
-    ``RNTuple.iterate(report=True)`` must yield ``(arrays, Report)`` pairs,
-    matching the contract documented in its docstring and already provided
-    by ``TTree.iterate``.
+    Reading a TTree that contains an AsGrouped branch without any filter must
+    return consistent results across eager, virtual, and dask modes.
     """
     path = skhep_testdata.data_path("uproot-issue-1502.root")
     with uproot.open(path) as f:
@@ -25,59 +24,3 @@ def test_read_AsGrouped_with_dask_or_virtual_array():
 
     dask_arr = uproot.dask(path).compute()
     assert awkward.array_equal(arr, dask_arr)
-
-
-def test_filter_name_on_AsGrouped_eager():
-    """
-    tree.arrays(filter_name=<AsGrouped branch name>) must return a non-empty
-    record containing the grouped sub-fields, not an empty result.
-
-    Previously, _regularize_expressions skipped ALL AsGrouped branches when
-    expressions=None, so filtering to a single AsGrouped branch produced an
-    empty record.
-    """
-    path = skhep_testdata.data_path("uproot-FCCDelphesOutput.root")
-    with uproot.open(path) as f:
-        tree = f["events"]
-        arr = tree.arrays(filter_name="genParticles")
-
-    assert arr.fields == ["genParticles"]
-    sub = arr["genParticles"]
-    assert "genParticles.core.pdgId" in sub.fields
-    assert "genParticles.core.p4.mass" in sub.fields
-    # Spot-check a known value in the first event
-    assert sub["genParticles.core.pdgId"][0][:3].tolist() == [11, -11, 11]
-
-
-def test_filter_name_on_AsGrouped_virtual():
-    """
-    tree.arrays(virtual=True, filter_name=<AsGrouped branch name>) must return
-    the same result as the eager path after materialisation.
-    """
-    path = skhep_testdata.data_path("uproot-FCCDelphesOutput.root")
-    with uproot.open(path) as f:
-        tree = f["events"]
-        arr = tree.arrays(filter_name="genParticles")
-        virtual_arr = tree.arrays(virtual=True, filter_name="genParticles")
-        assert awkward.array_equal(arr, awkward.materialize(virtual_arr))
-
-
-def test_filter_name_on_AsGrouped_dask():
-    """
-    uproot.dask(filter_name=<AsGrouped branch name>).compute() must return the
-    same result as the eager path and must not crash.
-
-    Previously, TrivialFormMappingInfo.load_buffers used how=tuple when calling
-    tree.arrays(), which for AsGrouped branches returns a Python tuple of
-    sub-arrays instead of an awkward RecordArray.  awkward.to_buffers() on that
-    Python tuple produced a mismatched form, causing an AssertionError.
-    """
-    path = skhep_testdata.data_path("uproot-FCCDelphesOutput.root")
-    with uproot.open(path) as f:
-        arr = f["events"].arrays(filter_name="genParticles")
-
-    dask_arr = uproot.dask(path + ":events", filter_name="genParticles")
-    computed = dask_arr.compute()
-
-    assert computed.fields == ["genParticles"]
-    assert awkward.array_equal(arr, computed)

--- a/tests/test_1670_asgrouped_filter_cases.py
+++ b/tests/test_1670_asgrouped_filter_cases.py
@@ -1,0 +1,240 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""Tests for the four semantically distinct cases that arise when a filter_name
+matches an AsGrouped branch (parent), its children, or both.
+
+The four cases and their expected behaviour:
+
+  Case 1 — only parent matched:
+      Return all sub-branches grouped as a RecordArray under the parent's name.
+
+  Case 2 — only a subset of children matched (no parent):
+      Return the matched children individually as flat top-level fields.
+
+  Case 3 — parent AND all children matched:
+      Return all children individually (flat); the parent is dropped because
+      every leaf is already captured, so grouping would be redundant.
+
+  Case 4 — parent AND some (but not all) children matched:
+      Return ALL sub-branches grouped as a RecordArray under the parent's name;
+      the individually-matched children are absorbed into the group and are not
+      also returned as flat fields.
+
+All four cases are tested for eager (tree.arrays), virtual (tree.arrays
+virtual=True), and dask (uproot.dask) modes, and the three modes are verified
+to return identical arrays.
+"""
+
+import pytest
+import skhep_testdata
+import awkward
+
+import uproot
+
+dask = pytest.importorskip("dask")
+da = pytest.importorskip("dask.array")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def fcc_path():
+    return skhep_testdata.data_path("uproot-FCCDelphesOutput.root")
+
+
+def fcc_tree(f):
+    return f["events"]
+
+
+# ---------------------------------------------------------------------------
+# Case 1: only parent matched → all sub-branches grouped
+# ---------------------------------------------------------------------------
+
+
+def test_case1_only_parent_eager():
+    """filter_name matching only the AsGrouped parent returns all children grouped."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        arr = fcc_tree(f).arrays(filter_name="genParticles")
+
+    assert arr.fields == ["genParticles"]
+    sub = arr["genParticles"]
+    assert len(sub.fields) == 11
+    assert "genParticles.core.pdgId" in sub.fields
+    assert "genParticles.core.p4.mass" in sub.fields
+    assert sub["genParticles.core.pdgId"][0][:3].tolist() == [11, -11, 11]
+
+
+def test_case1_only_parent_virtual():
+    """Virtual mode matches eager mode for case 1."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        tree = fcc_tree(f)
+        arr = tree.arrays(filter_name="genParticles")
+        virtual_arr = tree.arrays(virtual=True, filter_name="genParticles")
+        assert awkward.array_equal(arr, awkward.materialize(virtual_arr))
+
+
+def test_case1_only_parent_dask():
+    """Dask mode matches eager mode for case 1."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        arr = fcc_tree(f).arrays(filter_name="genParticles")
+
+    dask_arr = uproot.dask(path + ":events", filter_name="genParticles")
+    assert dask_arr.fields == ["genParticles"]
+    assert awkward.array_equal(arr, dask_arr.compute())
+
+
+# ---------------------------------------------------------------------------
+# Case 2: only a subset of children matched → returned ungrouped (flat)
+# ---------------------------------------------------------------------------
+
+
+def test_case2_only_children_eager():
+    """filter_name matching only a child branch returns it as a flat field."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        arr = fcc_tree(f).arrays(filter_name="genParticles.core.pdgId")
+
+    assert arr.fields == ["genParticles.core.pdgId"]
+    assert arr["genParticles.core.pdgId"][0][:3].tolist() == [11, -11, 11]
+
+
+def test_case2_only_children_virtual():
+    """Virtual mode matches eager mode for case 2."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        tree = fcc_tree(f)
+        arr = tree.arrays(filter_name="genParticles.core.pdgId")
+        virtual_arr = tree.arrays(virtual=True, filter_name="genParticles.core.pdgId")
+        assert awkward.array_equal(arr, awkward.materialize(virtual_arr))
+
+
+def test_case2_only_children_dask():
+    """Dask mode matches eager mode for case 2."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        arr = fcc_tree(f).arrays(filter_name="genParticles.core.pdgId")
+
+    dask_arr = uproot.dask(path + ":events", filter_name="genParticles.core.pdgId")
+    assert dask_arr.fields == ["genParticles.core.pdgId"]
+    assert awkward.array_equal(arr, dask_arr.compute())
+
+
+# ---------------------------------------------------------------------------
+# Case 3: parent AND all children matched → children returned ungrouped (flat)
+# ---------------------------------------------------------------------------
+
+
+def test_case3_parent_and_all_children_eager():
+    """filter_name matching parent AND all children drops the parent and returns children flat."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        # "genParticles*" matches both the parent and all 11 sub-branches
+        arr = fcc_tree(f).arrays(filter_name="genParticles*")
+
+    # parent should NOT appear; all 11 core sub-branches should be flat
+    assert "genParticles" not in arr.fields
+    core_fields = [f for f in arr.fields if f.startswith("genParticles.core")]
+    assert len(core_fields) == 11
+    assert arr["genParticles.core.pdgId"][0][:3].tolist() == [11, -11, 11]
+
+
+def test_case3_parent_and_all_children_virtual():
+    """Virtual mode matches eager mode for case 3."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        tree = fcc_tree(f)
+        arr = tree.arrays(filter_name="genParticles*")
+        virtual_arr = tree.arrays(virtual=True, filter_name="genParticles*")
+        # compare only the genParticles.core fields (filter also picks up #0/#1 counters)
+        core = [f for f in arr.fields if f.startswith("genParticles.core")]
+        mat = awkward.materialize(virtual_arr)
+        assert awkward.array_equal(arr[core], mat[core])
+
+
+def test_case3_parent_and_all_children_dask():
+    """Dask mode matches eager mode for case 3."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        arr = fcc_tree(f).arrays(filter_name="genParticles*")
+
+    dask_arr = uproot.dask(path + ":events", filter_name="genParticles*")
+    assert "genParticles" not in dask_arr.fields
+    core = [f for f in arr.fields if f.startswith("genParticles.core")]
+    computed = dask_arr.compute()
+    assert awkward.array_equal(arr[core], computed[core])
+
+
+# ---------------------------------------------------------------------------
+# Case 4: parent AND some children matched → ALL children returned grouped
+# ---------------------------------------------------------------------------
+
+
+def test_case4_parent_and_some_children_eager():
+    """filter_name matching parent AND some children returns ALL children grouped."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        # parent + exactly 1 of 11 children
+        arr = fcc_tree(f).arrays(
+            filter_name=["genParticles", "genParticles.core.pdgId"]
+        )
+
+    # result must be a single grouped field, not the individual child
+    assert arr.fields == ["genParticles"]
+    sub = arr["genParticles"]
+    # ALL 11 sub-branches should be present (not just the one that was in the filter)
+    assert len(sub.fields) == 11
+    assert "genParticles.core.pdgId" in sub.fields
+    assert "genParticles.core.p4.mass" in sub.fields
+    assert sub["genParticles.core.pdgId"][0][:3].tolist() == [11, -11, 11]
+
+
+def test_case4_parent_and_some_children_virtual():
+    """Virtual mode matches eager mode for case 4."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        tree = fcc_tree(f)
+        arr = tree.arrays(filter_name=["genParticles", "genParticles.core.pdgId"])
+        virtual_arr = tree.arrays(
+            virtual=True, filter_name=["genParticles", "genParticles.core.pdgId"]
+        )
+        assert awkward.array_equal(arr, awkward.materialize(virtual_arr))
+
+
+def test_case4_parent_and_some_children_dask():
+    """Dask mode matches eager mode for case 4, and does not crash."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        arr = fcc_tree(f).arrays(
+            filter_name=["genParticles", "genParticles.core.pdgId"]
+        )
+
+    dask_arr = uproot.dask(
+        path + ":events", filter_name=["genParticles", "genParticles.core.pdgId"]
+    )
+    assert dask_arr.fields == ["genParticles"]
+    computed = dask_arr.compute()
+    assert awkward.array_equal(arr, computed)
+
+
+# ---------------------------------------------------------------------------
+# Consistency: case 1 and case 4 should return the same result because both
+# include the full grouped record (case 4 merely happened to also match some
+# individual children, but they are absorbed into the group).
+# ---------------------------------------------------------------------------
+
+
+def test_case1_and_case4_return_same_grouped_record():
+    """Case 1 (parent only) and case 4 (parent + some children) yield identical arrays."""
+    path = fcc_path()
+    with uproot.open(path) as f:
+        tree = fcc_tree(f)
+        arr_case1 = tree.arrays(filter_name="genParticles")
+        arr_case4 = tree.arrays(filter_name=["genParticles", "genParticles.core.pdgId"])
+
+    assert arr_case1.fields == arr_case4.fields == ["genParticles"]
+    assert awkward.array_equal(arr_case1, arr_case4)


### PR DESCRIPTION
Seems like the filtering introduced in #1642 was a little too strong. This popped up as there was a test in Coffea that still failed, and the fix turned out to be more complicated than I thought.

In summary, what was happening is that if you did something like `tree.keys(filter_name="grouped_branch")` it would return an empty list (and similarly for `arrays`). So one needs to do some extra checks to see when they can be dropped.

@mrzimu it would be great if you can have a look at this and let me know what you think.

AI disclosure: I used assistance from Claude Code for this PR.