### PR TITLE
fix: concurrency settings from build workflow

### DIFF
--- a/.github/workflows/build-distributions.yml
+++ b/.github/workflows/build-distributions.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-build-distributions
+  cancel-in-progress: true
 jobs:
   dist:
     name: Build distribution artifacts

--- a/.github/workflows/build-distributions.yml
+++ b/.github/workflows/build-distributions.yml
@@ -9,10 +9,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   dist:
     name: Build distribution artifacts


### PR DESCRIPTION
Rename concurrency settings from the build workflow.