### PR TITLE
docs: clarify max_num_elements behavior

### DIFF
--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -197,7 +197,10 @@ def dask(
     * handler (:doc:`uproot.source.chunk.Source` class; None)
     * timeout (float for HTTP, int for XRootD; 30)
     * max_num_elements (None or int; None)
-        The maximum number of elements to be requested in a single vector read, when using XRootD.
+        The maximum number of byte ranges requested in a single XRootD vector
+        read. This does not limit the number of TTree or RNTuple entries read;
+        pass ``entry_stop`` to ``arrays``, ``uproot.iterate``, or
+        ``uproot.concatenate`` instead.
     * num_workers (int; 1)
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True)
     * num_fallback_workers (int; 10)

--- a/src/uproot/_dask.py
+++ b/src/uproot/_dask.py
@@ -195,8 +195,9 @@ def dask(
       If None, deduced from input file type.
     * timeout (float for HTTP, int for XRootD; default defined by source implementation): The time in seconds
       to wait before giving up on the connection. Ignored for non-internet sources like local file paths.
-    * max_num_elements (None or int; None): The maximum number of elements to be requested in a single vector
-      read, when using XRootD.
+    * max_num_elements (None or int; None): The maximum number of byte ranges requested in a single XRootD
+      vector read. This does not limit the number of TTree or RNTuple entries read; pass ``entry_stop`` to
+      ``arrays``, ``uproot.iterate``, or ``uproot.concatenate`` instead.
     * num_workers (int; 1): Number of tasks to spawn for reading, only used by some source types
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True):
       Use multi-threading when spawning workers.

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -143,7 +143,10 @@ def iterate(
     * handler (:doc:`uproot.source.chunk.Source` class; None)
     * timeout (float for HTTP, int for XRootD; 30)
     * max_num_elements (None or int; None)
-        The maximum number of elements to be requested in a single vector read, when using XRootD.
+        The maximum number of byte ranges requested in a single XRootD vector
+        read. This does not limit the number of TTree or RNTuple entries read;
+        pass ``entry_stop`` to ``arrays``, ``uproot.iterate``, or
+        ``uproot.concatenate`` instead.
     * num_workers (int; 1)
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True)
     * num_fallback_workers (int; 10)
@@ -318,7 +321,10 @@ def concatenate(
     * handler (:doc:`uproot.source.chunk.Source` class; None)
     * timeout (float for HTTP, int for XRootD; 30)
     * max_num_elements (None or int; None)
-        The maximum number of elements to be requested in a single vector read, when using XRootD.
+        The maximum number of byte ranges requested in a single XRootD vector
+        read. This does not limit the number of TTree or RNTuple entries read;
+        pass ``entry_stop`` to ``arrays``, ``uproot.iterate``, or
+        ``uproot.concatenate`` instead.
     * num_workers (int; 1)
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True)
     * num_fallback_workers (int; 10)

--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -151,8 +151,9 @@ def iterate(
       If None, deduced from input file type.
     * timeout (float for HTTP, int for XRootD; default defined by source implementation): The time in seconds
       to wait before giving up on the connection. Ignored for non-internet sources like local file paths.
-    * max_num_elements (None or int; None): The maximum number of elements to be requested in a single vector
-      read, when using XRootD.
+    * max_num_elements (None or int; None): The maximum number of byte ranges requested in a single XRootD
+      vector read. This does not limit the number of TTree or RNTuple entries read; pass ``entry_stop`` to
+      ``arrays``, ``uproot.iterate``, or ``uproot.concatenate`` instead.
     * num_workers (int; 1): Number of tasks to spawn for reading, only used by some source types
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True):
       Use multi-threading when spawning workers.
@@ -355,8 +356,9 @@ def concatenate(
       If None, deduced from input file type.
     * timeout (float for HTTP, int for XRootD; default defined by source implementation): The time in seconds
       to wait before giving up on the connection. Ignored for non-internet sources like local file paths.
-    * max_num_elements (None or int; None): The maximum number of elements to be requested in a single vector
-      read, when using XRootD.
+    * max_num_elements (None or int; None): The maximum number of byte ranges requested in a single XRootD
+      vector read. This does not limit the number of TTree or RNTuple entries read; pass ``entry_stop`` to
+      ``arrays``, ``uproot.iterate``, or ``uproot.concatenate`` instead.
     * num_workers (int; 1): Number of tasks to spawn for reading, only used by some source types
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True):
       Use multi-threading when spawning workers.

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -168,7 +168,10 @@ def iterate(
     * handler (:doc:`uproot.source.chunk.Source` class; None)
     * timeout (float for HTTP, int for XRootD; 30)
     * max_num_elements (None or int; None)
-        The maximum number of elements to be requested in a single vector read, when using XRootD.
+        The maximum number of byte ranges requested in a single XRootD vector
+        read. This does not limit the number of TTree or RNTuple entries read;
+        pass ``entry_stop`` to ``arrays``, ``uproot.iterate``, or
+        ``uproot.concatenate`` instead.
     * num_workers (int; 1)
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True)
     * num_fallback_workers (int; 10)
@@ -370,7 +373,10 @@ def concatenate(
     * handler (:doc:`uproot.source.chunk.Source` class; None)
     * timeout (float for HTTP, int for XRootD; 30)
     * max_num_elements (None or int; None)
-        The maximum number of elements to be requested in a single vector read, when using XRootD.
+        The maximum number of byte ranges requested in a single XRootD vector
+        read. This does not limit the number of TTree or RNTuple entries read;
+        pass ``entry_stop`` to ``arrays``, ``uproot.iterate``, or
+        ``uproot.concatenate`` instead.
     * num_workers (int; 1)
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True)
     * num_fallback_workers (int; 10)

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -176,8 +176,9 @@ def iterate(
       If None, deduced from input file type.
     * timeout (float for HTTP, int for XRootD; default defined by source implementation): The time in seconds
       to wait before giving up on the connection. Ignored for non-internet sources like local file paths.
-    * max_num_elements (None or int; None): The maximum number of elements to be requested in a single vector
-      read, when using XRootD.
+    * max_num_elements (None or int; None): The maximum number of byte ranges requested in a single XRootD
+      vector read. This does not limit the number of TTree or RNTuple entries read; pass ``entry_stop`` to
+      ``arrays``, ``uproot.iterate``, or ``uproot.concatenate`` instead.
     * num_workers (int; 1): Number of tasks to spawn for reading, only used by some source types
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True):
       Use multi-threading when spawning workers.
@@ -391,8 +392,9 @@ def concatenate(
       If None, deduced from input file type.
     * timeout (float for HTTP, int for XRootD; default defined by source implementation): The time in seconds
       to wait before giving up on the connection. Ignored for non-internet sources like local file paths.
-    * max_num_elements (None or int; None): The maximum number of elements to be requested in a single vector
-      read, when using XRootD.
+    * max_num_elements (None or int; None): The maximum number of byte ranges requested in a single XRootD
+      vector read. This does not limit the number of TTree or RNTuple entries read; pass ``entry_stop`` to
+      ``arrays``, ``uproot.iterate``, or ``uproot.concatenate`` instead.
     * num_workers (int; 1): Number of tasks to spawn for reading, only used by some source types
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True):
       Use multi-threading when spawning workers.

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -84,7 +84,9 @@ def open(
     * handler (:doc:`uproot.source.chunk.Source` class; None)
     * timeout (float for HTTP, int for XRootD; 30)
     * max_num_elements (None or int; None)
-        The maximum number of elements to be requested in a single vector read, when using XRootD.
+        The maximum number of byte ranges requested in a single XRootD vector
+        read. This does not limit the number of TTree entries read; pass
+        ``entry_stop`` to :ref:`uproot.behaviors.TBranch.HasBranches.arrays` instead.
     * num_workers (int; 1)
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True)
     * num_fallback_workers (int; 10)

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -85,8 +85,9 @@ def open(
     * timeout (float for HTTP, int for XRootD; 30)
     * max_num_elements (None or int; None)
         The maximum number of byte ranges requested in a single XRootD vector
-        read. This does not limit the number of TTree entries read; pass
-        ``entry_stop`` to :ref:`uproot.behaviors.TBranch.HasBranches.arrays` instead.
+        read. This does not limit the number of TTree or RNTuple entries read;
+        pass ``entry_stop`` to ``arrays``, ``uproot.iterate``, or
+        ``uproot.concatenate`` instead.
     * num_workers (int; 1)
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True)
     * num_fallback_workers (int; 10)
@@ -530,7 +531,10 @@ class ReadOnlyFile(CommonFileMethods):
     * handler (:doc:`uproot.source.chunk.Source` class; None)
     * timeout (float for HTTP, int for XRootD; 30)
     * max_num_elements (None or int; None)
-       The maximum number of elements to be requested in a single vector read, when using XRootD.
+       The maximum number of byte ranges requested in a single XRootD vector
+       read. This does not limit the number of TTree or RNTuple entries read;
+       pass ``entry_stop`` to ``arrays``, ``uproot.iterate``, or
+       ``uproot.concatenate`` instead.
     * num_workers (int; 1)
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True)
     * num_fallback_workers (int; 10)

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -92,8 +92,7 @@ def open(
       to wait before giving up on the connection. Ignored for non-internet sources like local file paths.
     * max_num_elements (None or int; None): The maximum number of byte ranges requested in a single XRootD
       vector read. This does not limit the number of TTree or RNTuple entries read; pass ``entry_stop`` to
-      entry-oriented functions such as :ref:`uproot.behaviors.TBranch.HasBranches.arrays`, ``iterate``, or
-      ``concatenate`` instead.
+      ``arrays``, ``uproot.iterate``, or ``uproot.concatenate`` instead.
     * num_workers (int; 1): Number of tasks to spawn for reading, only used by some source types
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True):
       Use multi-threading when spawning workers.
@@ -547,8 +546,9 @@ class ReadOnlyFile(CommonFileMethods):
       If None, deduced from input file type.
     * timeout (float for HTTP, int for XRootD; default defined by source implementation): The time in seconds
       to wait before giving up on the connection. Ignored for non-internet sources like local file paths.
-    * max_num_elements (None or int; None): The maximum number of elements to be requested in a single vector
-      read, when using XRootD.
+    * max_num_elements (None or int; None): The maximum number of byte ranges requested in a single XRootD
+      vector read. This does not limit the number of TTree or RNTuple entries read; pass ``entry_stop`` to
+      ``arrays``, ``uproot.iterate``, or ``uproot.concatenate`` instead.
     * num_workers (int; 1): Number of tasks to spawn for reading, only used by some source types
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True):
       Use multi-threading when spawning workers.

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -90,8 +90,10 @@ def open(
       If None, deduced from input file type.
     * timeout (float for HTTP, int for XRootD; default defined by source implementation): The time in seconds
       to wait before giving up on the connection. Ignored for non-internet sources like local file paths.
-    * max_num_elements (None or int; None): The maximum number of elements to be requested in a single vector
-      read, when using XRootD.
+    * max_num_elements (None or int; None): The maximum number of byte ranges requested in a single XRootD
+      vector read. This does not limit the number of TTree or RNTuple entries read; pass ``entry_stop`` to
+      entry-oriented functions such as :ref:`uproot.behaviors.TBranch.HasBranches.arrays`, ``iterate``, or
+      ``concatenate`` instead.
     * num_workers (int; 1): Number of tasks to spawn for reading, only used by some source types
     * use_threads (bool; False on the emscripten platform (i.e. in a web browser), else True):
       Use multi-threading when spawning workers.
@@ -101,7 +103,6 @@ def open(
       to read in bytes.
     * minimal_ttree_metadata (bool; True): Skip rarely used metadata and defer reading of embedded TBaskets
     * http_max_header_bytes (int; 21784): Maximum size of HTTP packet in bytes when the source is http
-
 
     Any object derived from a ROOT file is a context manager (works in Python's
     ``with`` statement) that closes the file when exiting the ``with`` block.


### PR DESCRIPTION
## Summary

- clarify that `max_num_elements` limits byte ranges in one XRootD vector read
- point readers to `entry_stop` when they want to limit the number of TTree entries read

Closes #1429.

## Validation

- `python -m compileall -q src/uproot/reading.py`
- imported `uproot.open` and asserted that the rendered docstring contains the new clarification and cross-reference
- built a focused Sphinx autodoc page for `uproot.open`; the patched docstring produced the same 14 pre-existing warnings as the unmodified baseline and no new warning

The full repository Sphinx build was also attempted. On Windows it stops in the existing `docs-sphinx/prepare_docstrings.py` path handling because it searches for `uproot/` in a backslash-based `__file__` path; this is unrelated to the documentation change.

## AI assistance

OpenAI Codex was used to investigate the issue, draft the wording, and run local validation. The final diff and validation evidence were reviewed by the contributor before submission.
