### PR TITLE
fix: uproot.update should accept other valid UUID versions

### DIFF
--- a/src/uproot/writing/_cascade.py
+++ b/src/uproot/writing/_cascade.py
@@ -2109,7 +2109,7 @@ class FileHeader(CascadeLeaf):
             compression_code,
             info_location,
             info_num_bytes,
-            uuid_version,
+            _uuid_version,
             uuid_bytes,
         ) = uproot.reading._file_header_fields_small.unpack(
             raw_bytes[: uproot.reading._file_header_fields_small.size]
@@ -2128,7 +2128,7 @@ class FileHeader(CascadeLeaf):
                 compression_code,
                 info_location,
                 info_num_bytes,
-                uuid_version,
+                _uuid_version,
                 uuid_bytes,
             ) = uproot.reading._file_header_fields_big.unpack(raw_bytes)
             assert units == 8
@@ -2145,8 +2145,6 @@ class FileHeader(CascadeLeaf):
         assert compression_code >= 0
         assert info_location >= 0
         assert info_num_bytes >= 0
-        assert uuid_version == 1
-
         out = FileHeader(
             end,
             free_location,

--- a/src/uproot/writing/_cascade.py
+++ b/src/uproot/writing/_cascade.py
@@ -2109,7 +2109,7 @@ class FileHeader(CascadeLeaf):
             compression_code,
             info_location,
             info_num_bytes,
-            _uuid_version,
+            uuid_version,
             uuid_bytes,
         ) = uproot.reading._file_header_fields_small.unpack(
             raw_bytes[: uproot.reading._file_header_fields_small.size]
@@ -2128,7 +2128,7 @@ class FileHeader(CascadeLeaf):
                 compression_code,
                 info_location,
                 info_num_bytes,
-                _uuid_version,
+                uuid_version,
                 uuid_bytes,
             ) = uproot.reading._file_header_fields_big.unpack(raw_bytes)
             assert units == 8
@@ -2145,6 +2145,8 @@ class FileHeader(CascadeLeaf):
         assert compression_code >= 0
         assert info_location >= 0
         assert info_num_bytes >= 0
+        assert uuid_version <= 8
+
         out = FileHeader(
             end,
             free_location,


### PR DESCRIPTION
During #1687 it was discovered that `uproot.update` didn't work on ROOT files created with new versions of ROOT. It turned out that ROOT just writes nil UUID (version 0) now, but Uproot expected the version to be 1. So that part was just fixed by removing the constraint.

~~There was another issue while reading the streamers. Claude worked on it for a long time, and the conclusion seems to be that it was a bug in ROOT 6.35. It implemented a workaround that I think is good enough. Maybe the switch to RootFileSpec can help with this.~~

Welp, I spent a lot of time on this, but it turned out there were some stale files on my laptop that were complicating things a lot.