### PR TITLE
fix: intermitten issue with fsspec on free-threaded Python

### DIFF
--- a/src/uproot/source/fsspec.py
+++ b/src/uproot/source/fsspec.py
@@ -68,7 +68,6 @@ class FSSpecSource(uproot.source.chunk.Source):
         self._open_file = fsspec.open(self._file_path_orig, **self._fsspec_options)
         self._fs = self._open_file.fs
         self._file_path = self._open_file.path
-        self._fo = self._open_file.__enter__()
         self._async_impl = self._fs.async_impl
         self._closed = False
 
@@ -82,7 +81,6 @@ class FSSpecSource(uproot.source.chunk.Source):
         state = dict(self.__dict__)
         state.pop("_executor")
         state.pop("_open_file")
-        state.pop("_fo")
         state.pop("_fs")
         return state
 

--- a/tests/test_0916_read_from_s3.py
+++ b/tests/test_0916_read_from_s3.py
@@ -16,7 +16,7 @@ def test_s3_fail():
         with uproot.source.fsspec.FSSpecSource(
             "s3://pivarski-princeton/does-not-exist", anon=True
         ) as source:
-            uproot._util.tobytes(source.chunk(0, 100).raw_data)
+            source.chunk(0, 100)
 
 
 @pytest.mark.network


### PR DESCRIPTION
There was an intermittent issue in free-threaded Python where the fsspec source would sometimes not be closed properly, which raised a warning. I had Claude debug this, and it turned out to be a surprisingly simple fix. We don't actually use the `self._fo` object, so we can just get rid of it completely.