### PR TITLE
fix: make uproot.recreate physically truncate an existing file

### DIFF
--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -113,6 +113,11 @@ def recreate(file_path: str | Path | IO, **options):
     storage_options = {
         key: value for key, value in options.items() if key not in recreate.defaults
     }
+    if isinstance(file_path, str):
+        # like ROOT's "RECREATE", physically truncate the file: otherwise a
+        # pre-existing, larger file would keep every byte beyond the new fEND.
+        # (uproot.update deliberately does not do this; it opens with "r+b".)
+        uproot.sink.file.FileSink._truncate_file(file_path, **storage_options)
     sink = uproot.sink.file.FileSink(file_path, **storage_options)
     compression = options.pop("compression", create.defaults["compression"])
 

--- a/tests/test_1688_recreate_truncates.py
+++ b/tests/test_1688_recreate_truncates.py
@@ -1,0 +1,84 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""Regression tests for issue #1688: ``uproot.recreate`` must truncate.
+
+Before the move to fsspec, ``uproot.recreate`` opened the path with mode ``"w"``,
+which truncated it. Afterwards it went through ``FileSink``, which only truncates
+when the file does *not* already exist, so recreating over a larger file left
+every byte beyond the new ``fEND`` in place.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+import uproot
+
+
+def test_recreate_truncates_existing_file(tmp_path):
+    path = str(tmp_path / "file.root")
+    with open(path, "wb") as f:
+        f.write(b"\x00" * 100_000)
+
+    with uproot.recreate(path):
+        pass
+
+    with uproot.open(path) as f:
+        end = f.file.fEND
+
+    assert os.path.getsize(path) == end
+    assert os.path.getsize(path) < 100_000
+
+
+def test_recreate_truncates_larger_root_file(tmp_path):
+    path = str(tmp_path / "file.root")
+    with uproot.recreate(path) as f:
+        f["big"] = np.histogram(np.random.normal(size=100_000), bins=5_000)
+    big_size = os.path.getsize(path)
+
+    with uproot.recreate(path) as f:
+        f["small"] = "hello"
+    small_size = os.path.getsize(path)
+
+    assert small_size < big_size
+    with uproot.open(path) as f:
+        assert f.keys() == ["small;1"]
+        assert os.path.getsize(path) == f.file.fEND
+
+
+def test_recreate_still_creates_missing_file_and_parents(tmp_path):
+    path = str(tmp_path / "subdir" / "file.root")
+    with uproot.recreate(path) as f:
+        f["h"] = np.histogram(np.random.normal(size=100))
+    with uproot.open(path) as f:
+        assert f.keys() == ["h;1"]
+
+
+def test_create_still_refuses_to_overwrite(tmp_path):
+    path = str(tmp_path / "file.root")
+    with uproot.create(path) as f:
+        f["h"] = np.histogram(np.random.normal(size=100))
+    size = os.path.getsize(path)
+
+    with pytest.raises(FileExistsError):
+        uproot.create(path)
+
+    # the failed create must not have touched the file
+    assert os.path.getsize(path) == size
+    with uproot.open(path) as f:
+        assert f.keys() == ["h;1"]
+
+
+def test_update_does_not_truncate(tmp_path):
+    path = str(tmp_path / "file.root")
+    with uproot.recreate(path) as f:
+        f["h"] = np.histogram(np.random.normal(size=100))
+
+    with uproot.update(path) as f:
+        f["h2"] = np.histogram(np.random.normal(size=100))
+
+    with uproot.open(path) as f:
+        assert f.keys() == ["h;1", "h2;1"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses finding 3 of "PR 1" in #1688. This is a regression, with a clear origin.

Before the fsspec migration, `uproot.recreate` truncated the path itself:

```python
if isinstance(file_path, str):
    with open(file_path, "w"):
        pass
    sink = uproot.sink.file.FileSink(file_path)
```

#1016 / #1034 moved that into `FileSink.__init__`, which only truncates when the file does **not** already exist:

https://github.com/scikit-hep/uproot5/blob/main/src/uproot/sink/file.py#L52-L58

so recreating over an existing file opens it `"r+b"` and leaves every byte past the new `fEND` in place. Recreating a 100 kB path as an empty ROOT file left the physical size at 100 kB with `fEND` at 1658.

Restores the truncation in `recreate`, which is also the path `create` delegates to.

* `uproot.update` is unaffected and keeps its `"r+b"` behavior.
* `uproot.create` still raises `FileExistsError` before reaching this point.
* Recreating from a file-like object is unchanged — it was not truncated before the migration either. Happy to extend it there too if you'd prefer.

### Tests

`tests/test_1688_recreate_truncates.py`: physical size after recreating over a large non-ROOT file and over a larger ROOT file, plus guards that `recreate` still creates missing files and parent directories, that `create` still refuses to overwrite without touching the file, and that `update` does not truncate. 2 of the 5 fail on `main`.

Full suite passes locally (1028 passed, 90 skipped).
