### PR TITLE
perf: batch sink flushes and cache cluster group records when extending RNTuples

### DIFF
--- a/src/uproot/writing/_cascadentuple.py
+++ b/src/uproot/writing/_cascadentuple.py
@@ -572,13 +572,19 @@ class NTuple_ClusterGroupRecord:
         self.entry_span = entry_span
         self.num_clusters = num_clusters
         self.page_list_envlink = page_list_envlink
+        self._serialized = None
 
     def serialize(self):
-        header_bytes = _rntuple_cluster_group_format.pack(
-            self.min_entry, self.entry_span, self.num_clusters
-        )
-        page_list_link_bytes = self.page_list_envlink.serialize()
-        return header_bytes + page_list_link_bytes
+        # A record is built once, appended to the footer, and never modified
+        # again, but every extension rewrites the whole footer and so
+        # re-serializes all of the records written so far. Cache the bytes.
+        if self._serialized is None:
+            header_bytes = _rntuple_cluster_group_format.pack(
+                self.min_entry, self.entry_span, self.num_clusters
+            )
+            page_list_link_bytes = self.page_list_envlink.serialize()
+            self._serialized = header_bytes + page_list_link_bytes
+        return self._serialized
 
     def __repr__(self):
         return f"{type(self).__name__}({self.num_clusters}, {self.page_list_envlink})"
@@ -983,7 +989,9 @@ class NTuple(CascadeNode):
         key.write(sink)
         sink.write(location + key.num_bytes, raw_data)
         sink.set_file_length(self._freesegments.fileheader.end)
-        sink.flush()
+        # no flush here: callers flush once at their commit boundary, because
+        # an extension adds one blob per column plus the page list and the
+        # footer, and a flush per blob is expensive for remote sinks
         return key
 
     def write(self, sink):
@@ -1023,6 +1031,8 @@ class NTuple(CascadeNode):
         #### Anchor end ##############################
 
         self._freesegments.write(sink)
+
+        sink.flush()
 
 
 def _to_packed_form(form):

--- a/tests/test_1688_rntuple_extend_flushing.py
+++ b/tests/test_1688_rntuple_extend_flushing.py
@@ -1,0 +1,99 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot5/blob/main/LICENSE
+
+"""Regression tests for issue #1688: RNTuple extension flushing and serialization.
+
+``add_rblob`` flushed the sink for every blob it wrote, so a single ``extend``
+flushed once per column plus once for the page list and once for the footer.
+Every extension also re-serialized every cluster group record written so far.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import uproot
+import uproot.sink.file
+import uproot.writing._cascadentuple
+
+
+@pytest.fixture
+def count_flushes(monkeypatch):
+    counter = {"flushes": 0}
+    original = uproot.sink.file.FileSink.flush
+
+    def counting_flush(self):
+        counter["flushes"] += 1
+        return original(self)
+
+    monkeypatch.setattr(uproot.sink.file.FileSink, "flush", counting_flush)
+    return counter
+
+
+@pytest.mark.parametrize("num_columns", [1, 8, 32])
+def test_extend_flushes_once_regardless_of_column_count(
+    tmp_path, count_flushes, num_columns
+):
+    path = str(tmp_path / "file.root")
+    chunk = {f"c{i}": np.arange(10, dtype=np.int64) for i in range(num_columns)}
+
+    with uproot.recreate(path) as f:
+        ntuple = f.mkrntuple("nt", {k: np.dtype("int64") for k in chunk})
+        count_flushes["flushes"] = 0
+        ntuple.extend(chunk)
+        assert count_flushes["flushes"] == 1
+
+        count_flushes["flushes"] = 0
+        ntuple.extend(chunk)
+        ntuple.extend(chunk)
+        assert count_flushes["flushes"] == 2
+
+
+def test_repeated_extension_round_trips(tmp_path):
+    path = str(tmp_path / "file.root")
+    columns = {f"c{i}": np.dtype("int64") for i in range(3)}
+
+    with uproot.recreate(path) as f:
+        ntuple = f.mkrntuple("nt", columns)
+        for step in range(20):
+            ntuple.extend(
+                {name: np.arange(10 * step, 10 * (step + 1)) for name in columns}
+            )
+
+    with uproot.open(path) as f:
+        arrays = f["nt"].arrays()
+        assert len(arrays) == 200
+        for name in columns:
+            assert arrays[name].tolist() == list(range(200))
+
+
+def test_cluster_group_record_serialization_is_stable_and_cached():
+    envlink = uproot.writing._cascadentuple.NTuple_EnvLink(
+        48, uproot.writing._cascadentuple.NTuple_Locator(48, 1024)
+    )
+    record = uproot.writing._cascadentuple.NTuple_ClusterGroupRecord(0, 10, 1, envlink)
+
+    first = record.serialize()
+    second = record.serialize()
+
+    assert first == second
+    # cached, so the same object is handed back rather than rebuilt
+    assert first is second
+
+
+def test_data_is_on_disk_after_each_extend(tmp_path):
+    """The sink is flushed at the end of every extend, not only at close."""
+    path = str(tmp_path / "file.root")
+
+    with uproot.recreate(path) as f:
+        ntuple = f.mkrntuple("nt", {"x": np.dtype("int64")})
+        ntuple.extend({"x": np.arange(10)})
+
+        with uproot.open(path) as check:
+            assert check["nt"].num_entries == 10
+
+        ntuple.extend({"x": np.arange(10, 20)})
+
+        with uproot.open(path) as check:
+            assert check["nt"].num_entries == 20
+            assert check["nt"].arrays()["x"].tolist() == list(range(20))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses finding 2 of "PR 2" in #1688.

### Flush per blob → flush per commit

`add_rblob` flushed the sink for every blob it wrote, so a single `extend` flushed once per column, once for the page list envelope and once for the footer, before the explicit `sink.flush()` already at the end of `extend`. That is especially expensive for remote sinks. Flushing now happens only at the commit boundary; `write()` flushes explicitly since it relied on `add_rblob` for that.

Data is still on disk at the end of every `extend` — there is a test for that.

### Cached cluster group records

Every extension rewrites the whole footer, which re-serialized every cluster group record written so far, even though a record is never modified once appended. At 800 extends that was ~320k calls to `NTuple_ClusterGroupRecord.serialize` and roughly a third of the wall time. Caching the bytes removes the quadratic term.

### Measured

Repeated `extend` of an int64 RNTuple, local file sink:

| | before | after |
|---|---|---|
| 5 columns, 1600 extends | 2.00 s, 12803 flushes | 1.24 s, 1602 flushes |
| 50 columns, 100 extends | 0.48 s, 5303 flushes | 0.46 s, 102 flushes |

The 50-column row shows the flush reduction rather than a wall-clock win, because a local flush is cheap; that is the case remote sinks care about.

File contents are byte-for-byte unchanged.

### Not addressed

The *bytes* written for footers still grow quadratically (the footer is rewritten in full on every extension, and it grows by one cluster group record each time — ~38 kB after 800 extends). That is inherent to keeping a valid footer on disk after every extension; deferring it to `close()` would leave an unclosed file unreadable, so it seems like a design decision rather than something to slip into a perf PR.

I also left `sink.set_file_length` per blob rather than hoisting it, since skipping it mid-extend relies on writes past EOF zero-filling, which is guaranteed locally but not obviously so for every fsspec backend.

### Tests

`tests/test_1688_rntuple_extend_flushing.py`: flush count per `extend` pinned at 1 for 1, 8 and 32 columns; a 20-step round trip; the record cache; and readability of the file between extends. 4 of the 6 fail on `main`.

Full suite passes locally (1029 passed, 90 skipped).
