### PR TITLE
ci: unbreak the GPU and Pyodide jobs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -203,11 +203,24 @@ jobs:
           version: ${{ env.PYODIDE_VERSION }}
           to: pyodide-dist
 
-      - name: Install browser
+      # Installed separately from Firefox because the two take different
+      # version spellings. "latest" gets Chrome a bleeding-edge Chromium
+      # snapshot, which Selenium Manager then refuses to drive because it
+      # picks the runner image's stable Chrome instead; "stable" keeps the
+      # installed Chrome on the same channel as the image's.
+      - name: Install Chrome
         uses: pyodide/pyodide-actions/install-browser@012fa537869d343726d01863a34b773fc4d96a14 # v2
         with:
           runner: selenium
-          browser: chrome firefox
+          browser: chrome
+          browser-version: stable
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Firefox
+        uses: pyodide/pyodide-actions/install-browser@012fa537869d343726d01863a34b773fc4d96a14 # v2
+        with:
+          runner: selenium
+          browser: firefox
           browser-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -203,19 +203,12 @@ jobs:
           version: ${{ env.PYODIDE_VERSION }}
           to: pyodide-dist
 
-      # Installed separately from Firefox because the two take different
-      # version spellings. "latest" gets Chrome a bleeding-edge Chromium
-      # snapshot, which Selenium Manager then refuses to drive because it
-      # picks the runner image's stable Chrome instead; "stable" keeps the
-      # installed Chrome on the same channel as the image's.
-      - name: Install Chrome
-        uses: pyodide/pyodide-actions/install-browser@012fa537869d343726d01863a34b773fc4d96a14 # v2
-        with:
-          runner: selenium
-          browser: chrome
-          browser-version: stable
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
+      # Chrome is deliberately not installed here: the runner image already
+      # ships Chrome and a ChromeDriver built to match it. Installing another
+      # copy is what broke this job -- Selenium Manager drives the image's
+      # Chrome regardless, so any version the action fetches has to agree with
+      # it, and neither "latest" (a Chromium dev snapshot) nor "stable" (a
+      # major ahead while the image lags) does.
       - name: Install Firefox
         uses: pyodide/pyodide-actions/install-browser@012fa537869d343726d01863a34b773fc4d96a14 # v2
         with:
@@ -265,6 +258,11 @@ jobs:
         with:
           environment-name: test-env
           init-shell: bash
+          # numba-cuda 0.30.4 does not support NumPy 2.5: it calls
+          # overload(np.row_stack), removed in 2.5, while importing numba.cuda,
+          # which Awkward's CUDA backend imports. numba 0.66 used to hold NumPy
+          # back, but 0.67 relaxed its pin to <2.6. Drop this once numba-cuda
+          # releases a fix.
           create-args: >-
             -c rapidsai
             python=3.13
@@ -276,6 +274,7 @@ jobs:
             kvikio
             nvcomp
             pytest-cov
+            numpy<2.5
             ${{ matrix.cuda-version == 13 && 'root' || '' }}
 
       - name: Pip install the package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,11 +126,7 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 filterwarnings = [
   "error",
   "default:module 'sre_.*' is deprecated:DeprecationWarning",
-  "ignore:unclosed transport <asyncio.sslproto._SSLProtocolTransport",  # https://github.com/aio-libs/aiohttp/issues/1115
-  # numba-cuda hits a NumPy 2.5 deprecation while importing numba.cuda, which
-  # Awkward's CUDA backend imports; there is no released fix, so the GPU tests
-  # cannot run with this promoted to an error.
-  "ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning"
+  "ignore:unclosed transport <asyncio.sslproto._SSLProtocolTransport"  # https://github.com/aio-libs/aiohttp/issues/1115
 ]
 log_level = "INFO"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,11 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 filterwarnings = [
   "error",
   "default:module 'sre_.*' is deprecated:DeprecationWarning",
-  "ignore:unclosed transport <asyncio.sslproto._SSLProtocolTransport"  # https://github.com/aio-libs/aiohttp/issues/1115
+  "ignore:unclosed transport <asyncio.sslproto._SSLProtocolTransport",  # https://github.com/aio-libs/aiohttp/issues/1115
+  # numba-cuda hits a NumPy 2.5 deprecation while importing numba.cuda, which
+  # Awkward's CUDA backend imports; there is no released fix, so the GPU tests
+  # cannot run with this promoted to an error.
+  "ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning"
 ]
 log_level = "INFO"
 markers = [


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two independent environment regressions turned CI red. Neither is caused by a code change, and they are unrelated to each other — but both currently block every PR, since `pyodide-build` is a required check.

## GPU job — numba-cuda does not support NumPy 2.5

26 of 41 `tests-cuda` tests fail with a misleading error:

```
ImportError: cannot import name 'StreamLike' from partially initialized module
'cuda.compute.typing' (most likely due to a circular import)
```

That is a downstream symptom. The actual chain:

```
awkward/_backends/cupy.py:34
└─ awkward/_connect/cuda/_compute.py:6     from cuda.compute import ...
   └─ cuda/compute/typing.py:9             from .op import ...
      └─ cuda/compute/_jit.py:18           import numba.cuda
         └─ numba_cuda/numba/cuda/np/npdatetime_helpers.py:31
```

`numba.cuda` fails to import under NumPy 2.5, leaving `cuda.compute.typing` half-initialised; every later test then trips over the missing `StreamLike`. There are two separate NumPy 2.5 incompatibilities in `numba-cuda` 0.30.4:

- `npdatetime_helpers.py:31` — `np.timedelta64("nat")` uses the `generic` timedelta unit, deprecated in 2.5. Under `filterwarnings = error` that alone aborts the import.
- `arrayobj.py:6860` — `overload(np.row_stack)`, and `np.row_stack` was **removed** in 2.5, raising `AttributeError`.

The GPU env is solved unpinned, so what changed is a dependency release, not our code. Diffing the failing env against the last passing one (2026-08-13), the only relevant differences are:

| package | passing | failing |
| --- | --- | --- |
| numba | 0.66.0 | **0.67.0** |
| numpy | 2.4.6 | **2.5.2** |

NumPy is installed by `micromamba create`, before `pip` runs, so the conda-forge run constraints are what decided the version:

| | conda-forge run constraint |
| --- | --- |
| numba 0.66.0 | `numpy >=1.22.3,<2.5` |
| numba 0.67.0 | `numpy >=1.22.3,<2.6` |

`numba` 0.66 was the only thing holding NumPy below 2.5. When 0.67.0 (2026-08-11) lifted that ceiling, the solver took 2.5.2 for the first time. The deprecation itself landed in NumPy 2.5.0 back in June.

`numba` is not in `create-args`; it arrives transitively, via `cccl-python` -> `numba-cuda` -> `numba`. `numba-cuda` declares `numpy >=1.25,<3`, so it accepts 2.5 while being incompatible with it, which is why nothing in the solve prevented this. Awkward is not involved either way: it declares `numpy>=1.21.3` in both 2.12.0 and 2.13.0, and `pip` never touches NumPy in this job.

`numba-cuda` 0.30.4 (2026-07-03) is still its newest release and carries both problems, so there is no version to bump to. This pins the GPU environment to `numpy<2.5` until a fix ships. Only the GPU job is pinned; every other job continues to test against NumPy 2.5.

## Pyodide job — a second, mismatched Chrome

All six `tests-wasm` tests error at setup:

```
SessionNotCreatedException: This version of ChromeDriver only supports Chrome version 154
Current browser version is 151.0.7922.108 with binary path /opt/google/chrome/chrome
```

`pyodide-actions/install-browser` defaults `browser-version` to `latest`, which it forwards to `browser-actions/setup-chrome`. For that action `latest` means the latest Chromium **snapshot** — 154 — not the stable channel. The runner image ships stable Chrome 151 at `/opt/google/chrome/chrome`, and Selenium Manager sets that as `binary_location` in preference to the snapshot the action symlinks into `/usr/bin/google-chrome`, so ChromeDriver 154 refused to drive it.

This started with a runner image bump, `20260720.247.2` → `20260810.271.1`; the 2026-08-13 run used snapshot Chrome 153 with a matching driver and passed.

Since Selenium drives the image's Chrome regardless, any Chrome the action installs has to agree with it — and no channel reliably does. `latest` is a dev snapshot, and `stable` currently resolves to Chrome-for-Testing 152 while the image still ships 151, so it merely moves the skew by one major. The image already provides Chrome 151.0.7922.108 alongside ChromeDriver 151.0.7922.77, a matched pair, so this stops installing a second Chrome altogether and uses what is already there. Firefox is unchanged.

## Correction to an earlier revision of this description

An earlier version of this text claimed the `filterwarnings` list in `pyproject.toml` had a latent bug, where a missing trailing comma would let TOML implicitly concatenate two adjacent strings. That is wrong — TOML has no implicit string concatenation, and the array was valid as written. No such bug existed and `pyproject.toml` is no longer touched by this PR.

## Caveats

- The GPU fix cannot be exercised locally — `numba-cuda` publishes no macOS ARM wheels and the job needs a GPU runner. NumPy 2.4.6 is the version the job last passed on, so the pin restores a known-good combination, but `numba` 0.67 was not part of that combination.
- Relying on the runner image's Chrome means the Pyodide tests now track whatever Chrome GitHub ships. That is the same thing every other Selenium job on these runners does, and it removes a moving part rather than adding one.

## AI assistance disclosure

Per CONTRIBUTING.md: the diagnosis and the patch were produced with Claude Code. The reasoning above has been reviewed by a human, who remains the author of the change.

