### PR TITLE
docs: remove Gitter badge and references

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,3 @@ contact_links:
   - name: 'StackOverflow: [uproot] tag'
     about: How do I…?
     url: https://stackoverflow.com/questions/tagged/uproot
-  - name: 'Gitter: Scikit-HEP/uproot room'
-    about: Getting help in real-time…
-    url: https://gitter.im/Scikit-HEP/uproot

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -13,4 +13,3 @@ Here are some links to documentation, to help you in your search.
 
    * [The tutorials site](https://uproot.readthedocs.io/)
    * [StackOverflow: [uproot] tag](https://stackoverflow.com/questions/tagged/uproot)
-   * [Gitter: Scikit-HEP/uproot room](https://gitter.im/Scikit-HEP/uproot)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)
 [![DOI 10.5281/zenodo.4340632](https://zenodo.org/badge/DOI/10.5281/zenodo.4340632.svg)](https://doi.org/10.5281/zenodo.4340632)
 [![Documentation](https://img.shields.io/badge/docs-online-success)](https://uproot.readthedocs.io/)
-[![Gitter](https://img.shields.io/badge/chat-online-success)](https://gitter.im/Scikit-HEP/uproot)
 
 [![NSF-1836650](https://img.shields.io/badge/NSF-1836650-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650)
 [![NSF-2121686](https://img.shields.io/badge/NSF-2121686-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=2121686)
@@ -49,7 +48,6 @@ conda update --all
    * Report bugs, request features, and ask for additional documentation on [GitHub Issues](https://github.com/scikit-hep/uproot5/issues).
    * If you have a "How do I...?" question, start a [GitHub Discussion](https://github.com/scikit-hep/uproot5/discussions) with category "Q&A".
    * Alternatively, ask about it on [StackOverflow with the [uproot] tag](https://stackoverflow.com/questions/tagged/uproot). Be sure to include tags for any other libraries that you use, such as Pandas or PyTorch.
-   * To ask questions in real time, try the Gitter [Scikit-HEP/uproot](https://gitter.im/Scikit-HEP/uproot) chat room.
 
 ## Installation for developers
 

--- a/docs-sphinx/index.rst
+++ b/docs-sphinx/index.rst
@@ -108,10 +108,6 @@
    :alt: Documentation
    :target: https://uproot.readthedocs.io/
 
-.. image:: https://img.shields.io/badge/chat-online-success
-   :alt: Gitter
-   :target: https://gitter.im/Scikit-HEP/uproot
-
 :raw-html:`</p>`
 
 |br| Uproot is a library for reading and writing ROOT files in pure Python and NumPy.
@@ -160,4 +156,3 @@ Getting help
 - Report bugs, request features, and ask for additional documentation on `GitHub Issues <https://github.com/scikit-hep/uproot5/issues>`__.
 - If you have a "How do I...?" question, start a `GitHub Discussion <https://github.com/scikit-hep/uproot5/discussions>`__ with category "Q&A".
 - Alternatively, ask about it on `StackOverflow with the [uproot] tag <https://stackoverflow.com/questions/tagged/uproot>`__. Be sure to include tags for any other libraries that you use, such as Pandas or PyTorch.
-- To ask questions in real time, try the Gitter `Scikit-HEP/uproot <https://gitter.im/Scikit-HEP/uproot>`__ chat room.


### PR DESCRIPTION
This is following a discussion to archive all Gitter channels for Scikit-HEP. (see https://github.com/scikit-hep/scikit-hep.github.io/pull/471)

:robot: _AI text below_ :robot:

The Gitter room is no longer used, so this removes all references to it:

- `README.md`: the chat badge and the "ask questions in real time" bullet under Getting help
- `docs-sphinx/index.rst`: the same badge and bullet on the docs landing page
- `.github/ISSUE_TEMPLATE/config.yml`: the Gitter contact link
- `.github/ISSUE_TEMPLATE/feature-request.md`: the Gitter link in the list of documentation pointers